### PR TITLE
sql: deflake TestExecBuild_distsql_plan_locality_filter

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_plan_locality_filter
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_plan_locality_filter
@@ -56,24 +56,22 @@ EXPLAIN (VEC) SELECT * FROM lf_distributed
 
 # With the filter set to us-east-1, scan flows should move off non-matching
 # nodes (1-6) onto us-east-1 nodes (7-9). The gateway (node 1) still
-# coordinates.
+# coordinates the result via Inboxes but does not run a local scan.
+#
+# We don't pin the EXPLAIN (VEC) output here because makeInstanceResolver
+# picks randomly among matching instances when the lease holder's locality
+# has no shared prefix with the eligible set (see distsql_physical_planner.go,
+# the SpanPartitionReason_LOCALITY_FILTERED_RANDOM branch). Instead, we
+# assert the deterministic invariant: nodes outside us-east-1 (specifically
+# nodes 2-6) must not appear anywhere in the plan.
 statement ok
 SET distsql_plan_locality_filter = 'region=us-east-1'
 
-query T
-EXPLAIN (VEC) SELECT * FROM lf_distributed
+query I
+SELECT count(*) FROM [EXPLAIN (VEC) SELECT * FROM lf_distributed]
+WHERE info ~ ' Node [2-6]$'
 ----
-│
-├ Node 1
-│ └ *colexec.ParallelUnorderedSynchronizer
-│   ├ *colrpc.Inbox
-│   └ *colrpc.Inbox
-├ Node 7
-│ └ *colrpc.Outbox
-│   └ *colfetcher.ColBatchScan
-└ Node 8
-  └ *colrpc.Outbox
-    └ *colfetcher.ColBatchScan
+0
 
 # Narrowing further to a specific AZ restricts to node 7 plus the gateway
 # (node 1) which coordinates the result.


### PR DESCRIPTION
The `distributed_flow_placement` subtest in
`pkg/sql/opt/exec/execbuilder/testdata/distsql_plan_locality_filter`
sets up three ranges with leases on nodes 1, 4, and 7 (one per region)
and then asserts the exact `EXPLAIN (VEC)` tree under a
`region=us-east-1` filter. For the ranges whose lease sits outside
us-east-1, `makeInstanceResolver` has no instance with a shared
locality prefix in the eligible set and falls through to
`randutil.FastUint32n` to pick from `{7, 8, 9}` (the
`SpanPartitionReason_LOCALITY_FILTERED_RANDOM` branch). The pinned
expected output happened to match one possible random outcome;
observed failures showed all-on-7, 7+9, and 7+8+9. Local stress
reproduces in roughly 8 of 10 runs.

Replace the rigid plan match with a SQL assertion that no node outside
us-east-1 (i.e. nodes 2-6) appears in the plan. This keeps the
meaningful invariant the subtest is verifying — the lease on node 4
in the unfiltered case earlier in the file demonstrates that node 4
would otherwise appear — while being deterministic regardless of which
us-east-1 nodes the planner picks. The AZ-narrowing subtest below is
already deterministic (only one instance matches) and is left as-is.

Stressed locally with `--count=20` after the change (20/20 pass).

Resolves: #170347
Epic: none