### PR TITLE
lease: catch up new observers with maxVersionNotified state

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -2175,8 +2175,9 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Set verbose log to confirm whether or not we hit the same nil row issue as in #140669
-	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
+	// Set verbose log to confirm whether or not we hit the same nil row issue
+	// as in #140669 (and schema_feed=2 helps #169505 if it comes up again).
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2,schema_feed=2")
 
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3171,6 +3171,7 @@ WITH resolved='50ms', min_checkpoint_frequency='50ms', no_initial_scan, cursor=$
 func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	testutils.SetVModule(t, "schema_feed=2") // might help #170357 if it comes up again
 
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -26,6 +26,7 @@ func TestChangefeedNemeses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1 min under race")
+	testutils.SetVModule(t, "schema_feed=2") // helps #169820 if it comes up again
 
 	testutils.RunValues(t, "nemeses_options=", cdctest.NemesesOptions, func(t *testing.T, nop cdctest.NemesesOption) {
 		testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -64,7 +64,7 @@ type leaseAcquirer interface {
 	AcquireFreshestFromStore(ctx context.Context, id descpb.ID) error
 	// TODO(yang): Investigate whether the codec can be stored in the schema feed itself.
 	Codec() keys.SQLCodec
-	RegisterLeaseObserver(observer lease.Observer) (unregisterFn func())
+	RegisterLeaseObserver(ctx context.Context, observer lease.Observer) (unregisterFn func())
 }
 
 // SchemaFeed is a stream of events corresponding the relevant set of
@@ -282,7 +282,7 @@ func (tf *schemaFeed) Run(ctx context.Context) error {
 		return err
 	}
 
-	unregisterFn := tf.leaseMgr.RegisterLeaseObserver(tf)
+	unregisterFn := tf.leaseMgr.RegisterLeaseObserver(ctx, tf)
 	// Make sure the observer unregisters before trying to release leases.
 	defer func() {
 		tf.mu.Lock()
@@ -557,6 +557,7 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 			// version could not have changed.
 			heldLease := tf.mu.heldLeases[id]
 			if heldLease.leasedDescriptor == nil {
+				prevLatest := heldLease.latestVersion // captured before mutation below for V(2) log
 				// Otherwise, a new version was detected, so acquire it at advanceTo.
 				newLease, err := tf.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(advanceTo), id)
 				if err != nil {
@@ -566,8 +567,12 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 				if newLease.Underlying().GetVersion() >= heldLease.latestVersion {
 					heldLease.latestVersion = newLease.Underlying().GetVersion()
 					tf.mu.heldLeases[id].leasedDescriptor = newLease
+					log.VEventf(ctx, 2, "schemafeed pauseOrResumePolling id=%d: acquired and stored lease version=%d (prevLatest=%d)",
+						id, newLease.Underlying().GetVersion(), prevLatest)
 				} else {
 					// The latest observed version was not picked up yet.
+					log.VEventf(ctx, 2, "schemafeed pauseOrResumePolling id=%d: acquired version=%d but latestVersion=%d is newer; releasing",
+						id, newLease.Underlying().GetVersion(), heldLease.latestVersion)
 					newLease.Release(ctx)
 				}
 				// This new version could be schema_locked, but we don't know if multiple versions
@@ -1009,10 +1014,16 @@ func (tf *schemaFeed) OnNewVersion(
 		return
 	}
 	// Check if the new version is greater than the latest version we know
-	// about.
+	// about. If we've already seen this version (e.g. because we acquired it
+	// via pauseOrResumePolling before the observer event arrived) there is
+	// nothing to release here.
 	if ld.latestVersion >= version {
+		log.VEventf(ctx, 2, "schemafeed OnNewVersion id=%d version=%d: already at latestVersion=%d, no-op",
+			id, version, ld.latestVersion)
 		return
 	}
+	prevVersion := ld.latestVersion
+	hadLease := ld.leasedDescriptor != nil
 	ld.latestVersion = version
 	tf.mu.staleLeases = true
 	tf.mu.pollingPaused = false
@@ -1021,6 +1032,8 @@ func (tf *schemaFeed) OnNewVersion(
 		ld.leasedDescriptor.Release(ctx)
 		ld.leasedDescriptor = nil
 	}
+	log.VEventf(ctx, 2, "schemafeed OnNewVersion id=%d version=%d: advanced latestVersion %d->%d, releasedLease=%v",
+		id, version, prevVersion, version, hadLease)
 }
 
 type doNothingSchemaFeed struct{}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -375,7 +375,9 @@ func (t *testLeaseAcquirer) Codec() keys.SQLCodec {
 	panic("should not be called")
 }
 
-func (t *testLeaseAcquirer) RegisterLeaseObserver(observer lease.Observer) (unregisterFn func()) {
+func (t *testLeaseAcquirer) RegisterLeaseObserver(
+	_ context.Context, observer lease.Observer,
+) (unregisterFn func()) {
 	t.observers = append(t.observers, observer)
 	return func() {
 		t.unregisterLeaseObserver(observer)
@@ -498,7 +500,7 @@ func TestPauseOrResumePolling(t *testing.T) {
 		targets:  CreateChangefeedTargets(tableID),
 	}
 	sf.testingInitSchemaFeed()
-	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	unregisterFn := lm.RegisterLeaseObserver(ctx, &sf)
 	defer unregisterFn()
 
 	getFrontier := func() hlc.Timestamp {
@@ -612,7 +614,7 @@ func TestPauseOrResumePollingAdvancesToNow(t *testing.T) {
 		targets:  CreateChangefeedTargets(tableID),
 	}
 	sf.testingInitSchemaFeed()
-	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	unregisterFn := lm.RegisterLeaseObserver(ctx, &sf)
 	defer unregisterFn()
 
 	getFrontier := func() hlc.Timestamp {
@@ -680,7 +682,7 @@ func BenchmarkPauseOrResumePolling(b *testing.B) {
 		targets:  CreateChangefeedTargets(tableID),
 	}
 	sf.testingInitSchemaFeed()
-	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	unregisterFn := lm.RegisterLeaseObserver(ctx, &sf)
 	defer unregisterFn()
 
 	setFrontier := func(ts hlc.Timestamp) error {

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -55,9 +55,17 @@ type descriptorState struct {
 		// of a descriptor.
 		maxVersionSeen descpb.DescriptorVersion
 
-		// maxVersionNotified is the maximum version of the descriptor for
-		// which observers have been notified.
-		maxVersionNotified descpb.DescriptorVersion
+		// notifiedVersion records the most recent descriptor version
+		// broadcast to observers and that version's modificationTime.
+		// Both fields are zero before the first broadcast. After that,
+		// they are updated together under t.mu in maybeAddObserverEvent
+		// and read under t.mu by Manager.RegisterLeaseObserver to replay
+		// the most recently broadcast version to a freshly registered
+		// Observer with its original timestamp.
+		notifiedVersion struct {
+			version descpb.DescriptorVersion
+			modTime hlc.Timestamp
+		}
 
 		// acquisitionsInProgress indicates that at least one caller is currently
 		// in the process of performing an acquisition. This tracking is critical

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -2294,11 +2294,12 @@ func (m *Manager) maybeAddObserverEvent(
 		defer t.mu.Unlock()
 		// If the version hasn't changed, then nothing needs to be emitted, unless
 		// it's a drop event.
-		if !dropped && version <= t.mu.maxVersionNotified {
+		if !dropped && version <= t.mu.notifiedVersion.version {
 			return false
 		}
 		if !dropped {
-			t.mu.maxVersionNotified = version
+			t.mu.notifiedVersion.version = version
+			t.mu.notifiedVersion.modTime = modificationTime
 		}
 		return true
 	}()

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -4634,7 +4634,7 @@ func TestObserverNotificationFromRangefeed(t *testing.T) {
 		lease:     ld,
 		startTime: nodes.Server(1).Clock().Now(),
 	}
-	_ = lm1.RegisterLeaseObserver(obs)
+	_ = lm1.RegisterLeaseObserver(ctx, obs)
 	// Run schema change on Node 0 in a goroutine because it will block
 	// on the two-version invariant waiting for Node 1 to release version 1.
 	errCh := make(chan error, 1)

--- a/pkg/sql/catalog/lease/observer.go
+++ b/pkg/sql/catalog/lease/observer.go
@@ -12,8 +12,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-// Observer is an interface that allows observers to be notified of new
-// versions of descriptors.
+// Observer is notified of new descriptor versions. Implementations must be
+// idempotent: the same (id, version) may be delivered more than once, and
+// versions may be delivered out of order on registration (see
+// Manager.RegisterLeaseObserver, which replays the most recently broadcast
+// version of every known descriptor to a freshly registered Observer).
 type Observer interface {
 	// OnNewVersion Invoked when a new version of a descriptor becomes available.
 	OnNewVersion(ctx context.Context, descID descpb.ID, newVersion descpb.DescriptorVersion, modificationTime hlc.Timestamp)
@@ -22,20 +25,54 @@ type Observer interface {
 // RegisterLeaseObserver registers an observer. An unregisterFn is returned
 // to remove this observer. Note: Observers are buffered, pending events may
 // still fire after unregistering.
-func (m *Manager) RegisterLeaseObserver(observer Observer) (unregisterFn func()) {
-	// Writers will need mutual exclusion to avoid clobbering.
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	// We will always allocate a new array, so readers can keep
-	// using existing pointers.
-	oldObservers := m.mu.observers.Load()
-	var newObservers []Observer
-	if oldObservers != nil {
-		newObservers = make([]Observer, len(*oldObservers), len(*oldObservers)+1)
-		copy(newObservers, *oldObservers)
+//
+// After registration, the observer is delivered a synthetic OnNewVersion
+// for the latest known version of each descriptor. Without this, an
+// observer registered after a broadcast permanently misses it, because
+// maybeAddObserverEvent's per-descriptor dedup suppresses replays. See
+// #169820 for the lease-hang this caused in CDC.
+func (m *Manager) RegisterLeaseObserver(
+	ctx context.Context, observer Observer,
+) (unregisterFn func()) {
+	type observedDescriptorVersion struct {
+		id      descpb.ID
+		version descpb.DescriptorVersion
+		modTime hlc.Timestamp
 	}
-	newObservers = append(newObservers, observer)
-	m.mu.observers.Store(&newObservers)
+	// Collected under m.mu and replayed outside it: OnNewVersion may take
+	// the observer's own locks, so we don't want to hold m.mu across it.
+	var observedVersions []observedDescriptorVersion
+	func() {
+		// Writers will need mutual exclusion to avoid clobbering.
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		// We will always allocate a new array, so readers can keep
+		// using existing pointers.
+		oldObservers := m.mu.observers.Load()
+		var newObservers []Observer
+		if oldObservers != nil {
+			newObservers = make([]Observer, len(*oldObservers), len(*oldObservers)+1)
+			copy(newObservers, *oldObservers)
+		}
+		newObservers = append(newObservers, observer)
+		m.mu.observers.Store(&newObservers)
+		for id, t := range m.mu.descriptors {
+			t.mu.Lock()
+			nv := t.mu.notifiedVersion
+			t.mu.Unlock()
+			if nv.version > 0 {
+				observedVersions = append(observedVersions, observedDescriptorVersion{
+					id: id, version: nv.version, modTime: nv.modTime,
+				})
+			}
+		}
+	}()
+	for _, ov := range observedVersions {
+		if ctx.Err() != nil {
+			break
+		}
+		observer.OnNewVersion(ctx, ov.id, ov.version, ov.modTime)
+	}
 	return func() {
 		m.unregisterLeaseObserver(observer)
 	}

--- a/pkg/sql/catalog/lease/observer_test.go
+++ b/pkg/sql/catalog/lease/observer_test.go
@@ -19,23 +19,40 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
+
+type capturedEvent struct {
+	version descpb.DescriptorVersion
+	modTime hlc.Timestamp
+}
 
 type testObserver struct {
 	notified  chan descpb.DescriptorVersion
 	targetID  descpb.ID
 	numEvents atomic.Int64
+
+	// targetCaptures holds the (version, modTime) of every OnNewVersion
+	// call where id == targetID. Used by tests that want to assert on
+	// modTime or exact event count for the target descriptor.
+	targetCaptures struct {
+		syncutil.Mutex
+		events []capturedEvent
+	}
 }
 
 func (o *testObserver) OnNewVersion(
-	ctx context.Context, id descpb.ID, version descpb.DescriptorVersion, timestamp hlc.Timestamp,
+	_ context.Context, id descpb.ID, version descpb.DescriptorVersion, modTime hlc.Timestamp,
 ) {
 	o.numEvents.Add(1)
 	if id != o.targetID {
 		return
 	}
+	o.targetCaptures.Lock()
+	o.targetCaptures.events = append(o.targetCaptures.events, capturedEvent{version, modTime})
+	o.targetCaptures.Unlock()
 	o.notified <- version
 }
 
@@ -57,7 +74,7 @@ func TestLeaseObserver(t *testing.T) {
 		targetID: tableID,
 	}
 	lm := server.LeaseManager().(*lease.Manager)
-	unregisterFn := lm.RegisterLeaseObserver(obs)
+	unregisterFn := lm.RegisterLeaseObserver(context.Background(), obs)
 
 	// Trigger initial acquisition on node 0.
 	sqlRunner.Exec(t, "SELECT * FROM t")
@@ -147,4 +164,86 @@ func TestLeaseObserver(t *testing.T) {
 	// No new events should be see.
 	require.Equal(t, numEvents, obs.numEvents.Load())
 	require.NoError(t, grp.Wait())
+}
+
+// TestRegisterLeaseObserverCatchesUpToLatestNotifiedVersion verifies that an
+// observer registered after a descriptor version has already been broadcast
+// still receives that version on registration. Regression test for #169820.
+func TestRegisterLeaseObserverCatchesUpToLatestNotifiedVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	server, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	sqlRunner := sqlutils.MakeSQLRunner(db)
+	sqlRunner.Exec(t, "CREATE TABLE t (k INT PRIMARY KEY)")
+	var tableID descpb.ID
+	sqlRunner.QueryRow(t, "SELECT 't'::regclass::int").Scan(&tableID)
+
+	lm := server.LeaseManager().(*lease.Manager)
+
+	// Register a first observer and use it as a synchronization point: it
+	// lets us wait until the lease manager has actually broadcast new
+	// versions of the table descriptor (via maybeAddObserverEvent), so that
+	// maxVersionNotified is non-trivial when we register the second
+	// observer below.
+	firstObserver := &testObserver{
+		notified: make(chan descpb.DescriptorVersion, 100),
+		targetID: tableID,
+	}
+	firstObserverUnreg := lm.RegisterLeaseObserver(ctx, firstObserver)
+
+	// Trigger acquisition (so the descriptor is known to the lease
+	// manager) and then run schema changes so the broadcast version is
+	// strictly greater than 1.
+	sqlRunner.Exec(t, "SELECT * FROM t")
+	sqlRunner.Exec(t, "ALTER TABLE t ADD COLUMN v INT")
+	sqlRunner.Exec(t, "ALTER TABLE t ADD COLUMN w INT")
+
+	var maxSeen descpb.DescriptorVersion
+	testutils.SucceedsSoon(t, func() error {
+		for {
+			select {
+			case v := <-firstObserver.notified:
+				if v > maxSeen {
+					maxSeen = v
+				}
+			default:
+				if maxSeen >= 2 {
+					return nil
+				}
+				return errors.Newf("first observer has only seen version %d so far", maxSeen)
+			}
+		}
+	})
+	// Done with the first observer; unregister so its presence cannot
+	// affect the observer-list state we exercise below.
+	firstObserverUnreg()
+
+	// Register a second observer. With the catch-up behavior, it must
+	// receive an OnNewVersion for the table immediately, for the most
+	// recently broadcast version.
+	lateObserver := &testObserver{
+		notified: make(chan descpb.DescriptorVersion, 100),
+		targetID: tableID,
+	}
+	lateObserverUnreg := lm.RegisterLeaseObserver(ctx, lateObserver)
+	defer lateObserverUnreg()
+
+	// Catch-up runs synchronously inside RegisterLeaseObserver, so by the
+	// time it returns the late observer should have received exactly one
+	// event for our target descriptor, with a version at least as high as
+	// what the first observer saw and a non-zero modTime. (Version is a
+	// lower bound rather than equality because additional broadcasts may
+	// have raced with the first observer's drain.)
+	lateObserver.targetCaptures.Lock()
+	captured := append([]capturedEvent(nil), lateObserver.targetCaptures.events...)
+	lateObserver.targetCaptures.Unlock()
+	require.Len(t, captured, 1,
+		"expected exactly one catch-up event for descriptor %d, got %d", tableID, len(captured))
+	require.GreaterOrEqual(t, captured[0].version, maxSeen,
+		"catch-up version %d, expected >= %d", captured[0].version, maxSeen)
+	require.False(t, captured[0].modTime.IsEmpty(),
+		"catch-up modTime should be non-zero")
 }


### PR DESCRIPTION
A lease.Observer registered with Manager.RegisterLeaseObserver only received notifications for descriptor versions broadcast after it registered. The per-descriptor maxVersionNotified dedup in maybeAddObserverEvent suppresses re-broadcasts, so an observer that registered after a broadcast permanently missed that version.

In the changefeed schemafeed, this caused TestChangefeedNemeses (#169820) and TestAlterChangefeedAddTargetsDuringSchemaChangeBackfill (#169505) to hang: on schemafeed restart the new instance held an old descriptor lease forever, blocking subsequent schema changes in CheckTwoVersionInvariant.

RegisterLeaseObserver now accepts a context.Context and replays an OnNewVersion for the latest known version of each descriptor on registration. descriptorState tracks maxVersionNotifiedModTime so the replay carries the original timestamp.

Also adds V(2) logging in the schemafeed's OnNewVersion and pauseOrResumePolling, and turns it on (via testutils.SetVModule) in the tests that reproduce these failures - including TestChangefeedSchemaChangeBackfillCheckpoint (#170357), which is unaffected by this fix but in scope for the same diagnostic path.

Note: #170357 was observed on the fix branch and is being investigated separately.

Fixes #169820
Fixes #169505

Release note (bug fix): Fixed a bug where a changefeed could permanently hold a stale descriptor lease across an internal restart, causing subsequent schema changes on the watched table to hang indefinitely.

Epic: none