### PR TITLE
release-25.4: s390x-unit-tests: `bazel clean --expunge` after the build

### DIFF
--- a/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
@@ -24,3 +24,5 @@ $(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --extralabels=s390x-test-fail
 		       test --config=ci --config=dev \
 		       $TESTS \
 		       --profile=/artifacts/profile.gz
+
+bazel clean --expunge


### PR DESCRIPTION
Backport 1/1 commits from #170402 on behalf of @rickystewart.

----

The build agent is prone to running out of disk. Hoping this helps.

This will theoretically slow down builds since less will be cached from build-to-build, but we're going to have to eat the cost.

Release note: none
Epic: none

----

Release justification: