### PR TITLE
roachtest: treat "already exists" as success on disk create retry

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_snapshot.go
@@ -134,6 +134,16 @@ func copySnapshotDataToNode(
 		if err == nil {
 			return nil
 		}
+		// A prior attempt may have created the disk on the server but
+		// failed on the response path (e.g. an HTTP 502 returned after
+		// the create succeeded). In that case, the retry sees an
+		// "already exists" error for our uniquely-named disk; treat it
+		// as success.
+		if isGCEAlreadyExistsError(result.Stderr) {
+			l.Printf("n%d: disk %s already exists (created by prior attempt), treating as success",
+				nodeID, tempDiskName)
+			return nil
+		}
 		if isGCETransientError(result.Stderr) {
 			l.Printf("n%d: transient GCE error creating disk, retrying: %v", nodeID, err)
 			return err
@@ -209,6 +219,14 @@ func copySnapshotDataToNode(
 	l.Printf("n%d: data copy complete", nodeID)
 
 	return nil
+}
+
+// isGCEAlreadyExistsError checks whether stderr from a gcloud command
+// indicates the resource already exists. This can happen on a retry
+// after a prior attempt's response was lost (e.g. HTTP 502): the server
+// created the resource but the client never got the success response.
+func isGCEAlreadyExistsError(stderr string) bool {
+	return strings.Contains(stderr, "already exists")
 }
 
 // isGCETransientError checks whether stderr from a gcloud command


### PR DESCRIPTION
## Summary
GCE disk create can succeed on the server but fail on the response path (e.g. an HTTP 502 returned after the disk was actually created). `isGCETransientError` recognizes the 502 and triggers a retry, but the retried `gcloud compute disks create` then fails with "already exists" — the prior attempt did create the disk on the server. That error was not matched by the transient-error check, so the retry loop treated it as a permanent failure and aborted the test. Because the per-node disk creates run in an `errgroup`, the failure also cancelled all other nodes' first-attempt creates.

Since the temp disk name is unique per test run (it embeds the cluster name), an "already exists" result on retry must come from a prior attempt by the same test, and is safe to treat as success.

Fixes #170375.
Touches #170324 (same root cause, different variant).

Epic: none
Release note: None