### PR TITLE
roachtest/decommission: retry through transient snapshot-throttle errors

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -39,6 +39,13 @@ import (
 // will wait for a graceful shutdown.
 const shutdownGracePeriod = 300
 
+// throttledStoresMsg is the substring emitted by the allocator when every
+// candidate target store is within its server.failed_reservation.timeout
+// window (default 5s) after a snapshot reservation failure. See the comment
+// in runDecommissionRandomized for why this surfaces transiently during
+// decommission.
+const throttledStoresMsg = "matching stores are currently throttled"
+
 func registerDecommission(r registry.Registry) {
 	{
 		numNodes := 4
@@ -635,10 +642,55 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 		}
 
 		// Decommission two nodes.
+		//
+		// DUCT TAPE: the substring match below is a targeted retry, not a
+		// fix. The right fix lives elsewhere and is non-trivial — see below.
+		//
+		// The CLI exits non-zero ("Cannot decommission nodes.") when the
+		// server-side pre-check (DecommissionPreCheck → AllocatorCheckRange →
+		// AllocateTarget) cannot find a target for any range on the
+		// decommissioning node. One common transient cause:
+		//
+		//   1. A replication change tries to send a snapshot to s_X.
+		//   2. s_X already holds a placeholder for that range (its prior
+		//      snapshot is still applying), so canAcceptSnapshotLocked rejects
+		//      the new one within milliseconds.
+		//   3. The sender calls StorePool.Throttle(ThrottleFailed, ...), which
+		//      marks s_X throttled for server.failed_reservation.timeout
+		//      (default 5s) and stores the rejection text in
+		//      detail.throttledBecause.
+		//   4. If the pre-check runs in that 5s window and s_X is the only
+		//      viable target, the allocator returns "N matching stores are
+		//      currently throttled: [<throttledBecause>...]", which surfaces
+		//      verbatim as the per-range blocker text — even though the
+		//      placeholder is long gone.
+		//
+		// A proper fix would have to address one of:
+		//   - the pre-check treating a transient throttle as a hard blocker
+		//     (it should distinguish "no viable target ever" from "back off
+		//     and retry"),
+		//   - the allocator's throttle reason string being stale/misleading
+		//     after the underlying snapshot has succeeded, or
+		//   - canAcceptSnapshotLocked engaging the failed-reservation throttle
+		//     for a benign "already in progress" rejection.
+		// Each of these threads through allocator/storepool/snapshot code,
+		// touches mixed-version and CLI UX, and has already burned at least
+		// one revert (#159165, fix attempt for #157973). Not something to do
+		// drive-by from a roachtest flake.
+		//
+		// With --wait=none the CLI is one-shot, so the retry has to live
+		// here. Keep it tight: substring-match only this transient and let
+		// every other CLI failure fatal as before.
 		if err := retry.WithMaxAttempts(ctx, retryOpts, maxAttempts, func() error {
-			o, err := h.decommission(ctx, c.Nodes(targetNodeA, targetNodeB), runNode,
+			o, e, err := h.decommissionExt(ctx, c.Nodes(targetNodeA, targetNodeB), runNode,
 				fmt.Sprintf("--wait=%s", waitStrategy), "--format=csv")
 			if err != nil {
+				// The blocking-range summary goes to stderr; roachprod also folds
+				// stderr into err.Error(), so check both.
+				if strings.Contains(e, throttledStoresMsg) || strings.Contains(err.Error(), throttledStoresMsg) {
+					t.L().Printf("decommission hit transient throttle, retrying: %v", err)
+					return err
+				}
 				t.Fatalf("decommission failed: %v", err)
 			}
 


### PR DESCRIPTION
## Summary

**This is duct tape.** `runDecommissionRandomized` wraps the
decommission CLI in a `retry.WithMaxAttempts` loop, but the helper
fatals on any non-zero CLI exit, so the retry never fires for the very
class of transient error it was meant to absorb. This PR substring-
matches the throttle error, returns it to the retry loop, and lets the
existing 1s→5s backoff cover the `server.failed_reservation.timeout`
window. Every other CLI failure still fatals.

## Why this is transient (from #170166)

The CLI reported

> n2 has 4 replicas blocked with error: \"2 matching stores are currently throttled: [[n6,s6]: canAcceptSnapshotLocked: cannot add placeholder, have an existing placeholder range=47 ...\"

This is a 5s window, not a real blocker:

1. A replication change sends a snapshot to s_X.
2. s_X already holds a placeholder for the range (the prior snapshot is still applying), so `canAcceptSnapshotLocked` rejects the new one within milliseconds.
3. The sender calls `StorePool.Throttle(ThrottleFailed, ...)`, which marks s_X throttled for `server.failed_reservation.timeout` (default 5s) and stashes the rejection text in `detail.throttledBecause`.
4. If `DecommissionPreCheck` → `AllocatorCheckRange` → `AllocateTarget` runs in that window, the allocator returns `\"N matching stores are currently throttled: [<throttledBecause>...]\"`. The text is the stale reason string — the placeholder is long gone — and the CLI exits 1.

In the captured failure (#170166), each placeholder cited in the error
existed for ~3ms; the throttled store list was the actual cause.

## Why not fix it properly here

A proper fix would have to touch one of:

- the pre-check treating a transient throttle as a hard blocker (it should distinguish \"no viable target ever\" from \"back off and retry\"),
- the allocator's throttle reason string being stale/misleading after the underlying snapshot has succeeded, or
- `canAcceptSnapshotLocked` engaging the failed-reservation throttle for a benign \"already in progress\" rejection.

Each threads through allocator/storepool/snapshot code, touches
mixed-version and CLI UX, and has already burned at least one revert:
#159165 reverted a server-side retry around `AllocatorCheckRange`
because the broad retry caused `decommission/randomized` timeouts (see
#157973). Not something to land drive-by from a roachtest flake — this
PR keeps the workaround test-local and narrow so the real fix can be
sequenced separately.

Fixes: #170166
Epic: none
Release note: None