### PR TITLE
catalog/lease: respect stopper quiesce in DeleteOrphanedLeases

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -3613,7 +3613,14 @@ func (m *Manager) DeleteOrphanedLeases(
 	// AddTags and not WithTags, so that we combine the tags with those
 	// filled by AnnotateCtx.
 	newCtx = logtags.AddTags(newCtx, logtags.FromContext(ctx))
-	_ = m.stopper.RunAsyncTask(newCtx, "del-orphaned-leases", func(ctx context.Context) {
+	// Derive the task ctx from the stopper so that the inner retry loops and
+	// any blocking KV/SQL work terminate promptly when the stopper begins to
+	// quiesce. Without this, the task is rooted at context.Background() and
+	// can keep retrying indefinitely while Stopper.Quiesce is waiting for it,
+	// blocking shutdown (see #170331).
+	newCtx, cancel := m.stopper.WithCancelOnQuiesce(newCtx)
+	if err := m.stopper.RunAsyncTask(newCtx, "del-orphaned-leases", func(ctx context.Context) {
+		defer cancel()
 		retryOpts := base.DefaultRetryOptions()
 		retryOpts.MaxRetries = 10
 		m.deleteOrphanedLeasesFromStaleSession(ctx, retryOpts, timeThreshold, locality)
@@ -3621,7 +3628,12 @@ func (m *Manager) DeleteOrphanedLeases(
 		if err := m.cleanupUpdateKeys(ctx, true /* force */); err != nil {
 			log.Dev.Warningf(ctx, "error cleaning up update keys: %v", err)
 		}
-	})
+	}); err != nil {
+		// RunAsyncTask only fails if the stopper is already quiescing, in which
+		// case there is nothing for us to do. Release the cancel registration
+		// to avoid leaking it.
+		cancel()
+	}
 }
 
 // Codec returns the Manager's SQLCodec.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -3613,16 +3613,18 @@ func (m *Manager) DeleteOrphanedLeases(
 	// AddTags and not WithTags, so that we combine the tags with those
 	// filled by AnnotateCtx.
 	newCtx = logtags.AddTags(newCtx, logtags.FromContext(ctx))
-	// Derive the task ctx from the stopper so that the inner retry loops and
-	// any blocking KV/SQL work terminate promptly when the stopper begins to
-	// quiesce. Without this, the task is rooted at context.Background() and
-	// can keep retrying indefinitely while Stopper.Quiesce is waiting for it,
-	// blocking shutdown (see #170331).
+	// Cancel on quiesce so the retry loops and blocking KV/SQL work below
+	// don't outlive the stopper.
 	newCtx, cancel := m.stopper.WithCancelOnQuiesce(newCtx)
 	if err := m.stopper.RunAsyncTask(newCtx, "del-orphaned-leases", func(ctx context.Context) {
 		defer cancel()
 		retryOpts := base.DefaultRetryOptions()
 		retryOpts.MaxRetries = 10
+		// Plumb ctx cancellation through Closer too. retry.StartWithCtx already
+		// observes ctx.Done() from Next, but Closer also makes the inner ExecEx
+		// retry paths short-circuit even if an intermediate error is wrapped in
+		// a form that IsRetryableReplicaError happens to accept.
+		retryOpts.Closer = ctx.Done()
 		m.deleteOrphanedLeasesFromStaleSession(ctx, retryOpts, timeThreshold, locality)
 		m.deleteOrphanedLeasesWithSameInstanceID(ctx, retryOpts, timeThreshold, instanceID)
 		if err := m.cleanupUpdateKeys(ctx, true /* force */); err != nil {


### PR DESCRIPTION
## Summary

The async task launched by `Manager.DeleteOrphanedLeases` ran with a context rooted at `context.Background()`, so its inner retry loops over internal SQL queries against `system.lease` did not observe the stopper beginning to quiesce. If KV was unavailable (e.g. during shutdown of a test cluster) the task could retry indefinitely, holding `Stopper.NumTasks` above zero and blocking `Stopper.Quiesce` — and through it the process — until the test deadline fired. This was the root cause of the 40-minute shutdown hang observed in #170331.

Wrap the task context with `Stopper.WithCancelOnQuiesce` so the context is canceled when quiesce starts, mirroring the pattern already used by `acquireNodeLease` in the same file. The retry loops at `deleteOrphanedLeasesFromStaleSession` and `deleteLeaseWithSessionIDWithBatch` then return promptly on shutdown.

The use of `context.Background()` here is a legacy artifact of the original `RunWorker`-based implementation (in which workers had no parent context and explicitly outlived their callers). When `RunWorker` was removed in favor of `RunAsyncTask` in 8c5253bbcc, sibling call sites in this file were updated to either thread the caller context through or select on `ShouldQuiesce`; this site was missed. A subsequent change (e8061cbd6f) retrofitted `acquireNodeLease` with `WithCancelOnQuiesce` but did not extend the same treatment to `DeleteOrphanedLeases`.

Fixes: #170331

Epic: none

Release note: None