### PR TITLE
logical,txnmode: allow replicating stored computed columns

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -3266,50 +3266,7 @@ func TestSchemaValidation(t *testing.T) {
 				"ALTER TABLE tab ADD COLUMN virtual_col INT AS (pk + 1) VIRTUAL",
 				"CREATE UNIQUE INDEX virtual_idx ON tab(virtual_col)",
 			},
-			expectedErr: "cannot create logical replication stream: table tab has a computed column virtual_col that is a key of unique index virtual_idx",
-		},
-		{
-			name: "txn_mode_stored_computed_in_unique_index",
-			mode: "transactional",
-			destSetup: []string{
-				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
-				"CREATE UNIQUE INDEX stored_idx ON tab(stored_col)",
-			},
-			sourceSetup: []string{
-				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
-				"CREATE UNIQUE INDEX stored_idx ON tab(stored_col)",
-			},
-			expectedErr: "cannot create logical replication stream: table tab has a computed column stored_col that is a key of unique index stored_idx",
-		},
-		{
-			name: "txn_mode_stored_computed_in_outbound_fk",
-			mode: "transactional",
-			destSetup: []string{
-				"CREATE TABLE parent (id INT PRIMARY KEY)",
-				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
-				"ALTER TABLE tab ADD CONSTRAINT fk_stored FOREIGN KEY (stored_col) REFERENCES parent(id)",
-			},
-			sourceSetup: []string{
-				"CREATE TABLE parent (id INT PRIMARY KEY)",
-				"ALTER TABLE tab ADD COLUMN stored_col INT AS (pk + 1) STORED",
-				"ALTER TABLE tab ADD CONSTRAINT fk_stored FOREIGN KEY (stored_col) REFERENCES parent(id)",
-			},
-			expectedErr: "cannot create logical replication stream: table tab has a computed column stored_col that is part of foreign key fk_stored",
-		},
-		{
-			name: "txn_mode_stored_computed_in_inbound_fk",
-			mode: "transactional",
-			destSetup: []string{
-				"DROP TABLE tab",
-				"CREATE TABLE tab (pk INT, stored_col INT AS (pk + 1) STORED, PRIMARY KEY (stored_col), payload STRING)",
-				"CREATE TABLE child (id INT PRIMARY KEY, ref INT REFERENCES tab(stored_col))",
-			},
-			sourceSetup: []string{
-				"DROP TABLE tab",
-				"CREATE TABLE tab (pk INT, stored_col INT AS (pk + 1) STORED, PRIMARY KEY (stored_col), payload STRING)",
-				"CREATE TABLE child (id INT PRIMARY KEY, ref INT REFERENCES tab(stored_col))",
-			},
-			expectedErr: "cannot create logical replication stream: table tab has a computed column stored_col that is referenced by foreign key",
+			expectedErr: "cannot create logical replication stream: table tab has a virtual computed column virtual_col that is a key of unique index virtual_idx",
 		},
 	}
 

--- a/pkg/crosscluster/logical/sqlwriter/replication_statements.go
+++ b/pkg/crosscluster/logical/sqlwriter/replication_statements.go
@@ -29,16 +29,17 @@ type ColumnSchema struct {
 // around a tree.Datums for each row where column[i] is the column definition
 // for datums[i].
 //
-// A column is decoded by crud LDR writer if either are true:
+// A column is decoded by the crud LDR writer if any are true:
 //  1. The column is part of the primary key. Every primary key column is needed
 //     to perform read refreshes.
-//  2. The column is not a computed column. If a column is not computed, it must
-//     be included in update and insert statements.
+//  2. The column is not computed. If a column is not computed,
+//     it must be included in update and insert statements
+//  3. The column is a stored computed column. These can participate in a unique
+//     or foreign key constraint, so lock synthesis may need to hash its value.
 //
-// Notably, this excludes computed columns that are not part of the primary key
+// Notably, this excludes virtual columns that are not part of the primary key
 // and system columns like crdb_internal_mvcc_timestamp.
 func GetColumnSchema(table catalog.TableDescriptor) []ColumnSchema {
-	// Create a map of column ID to column for fast lookup
 	primaryIdx := table.GetPrimaryIndex()
 	isPrimaryKey := make(map[catid.ColumnID]bool)
 	for _, col := range primaryIdx.IndexDesc().KeyColumnIDs {
@@ -51,9 +52,7 @@ func GetColumnSchema(table catalog.TableDescriptor) []ColumnSchema {
 		if col.IsSystemColumn() {
 			continue
 		}
-
-		isComputed := col.IsComputed()
-		if isComputed && !isPrimaryKey[col.GetID()] {
+		if col.IsVirtual() && !isPrimaryKey[col.GetID()] {
 			continue
 		}
 
@@ -61,7 +60,7 @@ func GetColumnSchema(table catalog.TableDescriptor) []ColumnSchema {
 			Column:       col,
 			ColumnType:   col.GetType().Canonical(),
 			IsPrimaryKey: isPrimaryKey[col.GetID()],
-			IsComputed:   isComputed,
+			IsComputed:   col.IsComputed(),
 		})
 	}
 

--- a/pkg/crosscluster/logical/sqlwriter/testdata/ldr_statements
+++ b/pkg/crosscluster/logical/sqlwriter/testdata/ldr_statements
@@ -202,3 +202,33 @@ DELETE FROM [113 AS replication_target] WHERE ((arr_col = $1::INT8[]) AND (name 
 show-point-select table=array_pk_table
 ----
 SELECT replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.arr_col, replication_target.name, replication_target.value FROM [113 AS replication_target] WHERE replication_target.arr_col = $1::INT8[]
+
+# Test a table with a stored computed column in a unique constraint but not
+# in the primary key. The column is read back via SELECT but skipped in
+# INSERT/UPDATE/WHERE since the database computes it.
+exec
+CREATE TABLE stored_uc (
+  id INT PRIMARY KEY,
+  sum_ab INT AS (a + b) STORED,
+  a INT NOT NULL,
+  b INT NOT NULL,
+  UNIQUE (sum_ab)
+);
+----
+ok
+
+show-insert table=stored_uc
+----
+INSERT INTO [114 AS replication_target](id, a, b) VALUES ($1::INT8, $3::INT8, $4::INT8)
+
+show-update table=stored_uc
+----
+UPDATE [114 AS replication_target] SET id = $5::INT8, a = $7::INT8, b = $8::INT8 WHERE ((id = $1::INT8) AND (a IS NOT DISTINCT FROM $3::INT8)) AND (b IS NOT DISTINCT FROM $4::INT8)
+
+show-delete table=stored_uc
+----
+DELETE FROM [114 AS replication_target] WHERE ((id = $1::INT8) AND (a IS NOT DISTINCT FROM $3::INT8)) AND (b IS NOT DISTINCT FROM $4::INT8) RETURNING *
+
+show-select table=stored_uc
+----
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.sum_ab, replication_target.a, replication_target.b FROM ROWS FROM (unnest($1::INT8[])) WITH ORDINALITY AS key_list (key1, "index") INNER LOOKUP JOIN [114 AS replication_target] ON replication_target.id = key_list.key1

--- a/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
+++ b/pkg/crosscluster/logical/txnlock/lock_synthesis_test.go
@@ -160,11 +160,12 @@ func ucRow(id int, email string) tree.Datums {
 
 // compositeRow builds datums for schema:
 //
-//	(pk1 INT, pk2 INT, a INT, b INT, PRIMARY KEY (pk1, pk2), UNIQUE (a, b))
+//	(pk1 INT, pk2 INT, a INT, b INT, c INT AS (a + b) STORED,
+//	 PRIMARY KEY (pk1, pk2), UNIQUE (a, c))
 //
 // Negative values for a or b map to DNull.
 func compositeRow(pk1, pk2, a, b int) tree.Datums {
-	var aDatum, bDatum tree.Datum
+	var aDatum, bDatum, cDatum tree.Datum
 	if a < 0 {
 		aDatum = tree.DNull
 	} else {
@@ -175,11 +176,17 @@ func compositeRow(pk1, pk2, a, b int) tree.Datums {
 	} else {
 		bDatum = tree.NewDInt(tree.DInt(b))
 	}
+	if a < 0 || b < 0 {
+		cDatum = tree.DNull
+	} else {
+		cDatum = tree.NewDInt(tree.DInt(a + b))
+	}
 	return tree.Datums{
 		tree.NewDInt(tree.DInt(pk1)),
 		tree.NewDInt(tree.DInt(pk2)),
 		aDatum,
 		bDatum,
+		cDatum,
 	}
 }
 
@@ -245,7 +252,11 @@ func pkFKRow(id int) tree.Datums {
 }
 
 // compositeFKParentRow builds datums for schema
-// (a INT, b INT, c INT, d INT, val INT, PRIMARY KEY (a, b), UNIQUE (c, d)).
+// (a INT, b INT, c INT, d INT, val INT,
+//
+//	e INT AS (val + 1) STORED UNIQUE, PRIMARY KEY (a, b), UNIQUE (c, d)).
+//
+// e is computed from val to match the stored computed column.
 func compositeFKParentRow(a, b, c, d, val int) tree.Datums {
 	return tree.Datums{
 		tree.NewDInt(tree.DInt(a)),
@@ -253,17 +264,20 @@ func compositeFKParentRow(a, b, c, d, val int) tree.Datums {
 		tree.NewDInt(tree.DInt(c)),
 		tree.NewDInt(tree.DInt(d)),
 		tree.NewDInt(tree.DInt(val)),
+		tree.NewDInt(tree.DInt(val + 1)),
 	}
 }
 
 // compositeFKChildRow builds datums for schema
 //
 //	(id INT PRIMARY KEY, b_pk_ref INT, a_pk_ref INT, d_uc_ref INT, c_uc_ref INT,
+//	 e_ref INT REFERENCES composite_fk_parent(e),
 //	 FOREIGN KEY (a_pk_ref, b_pk_ref) REFERENCES composite_fk_parent(a, b),
 //	 FOREIGN KEY (c_uc_ref, d_uc_ref) REFERENCES composite_fk_parent(c, d))
 //
 // Note the column order in the table is inverted relative to the FK
-// column order for both constraints.
+// column order for both constraints. e_ref defaults to NULL; the inbound
+// FK on the parent's e column still exercises the schema path.
 func compositeFKChildRow(id, bPKRef, aPKRef, dUCRef, cUCRef int) tree.Datums {
 	return tree.Datums{
 		tree.NewDInt(tree.DInt(id)),
@@ -271,6 +285,7 @@ func compositeFKChildRow(id, bPKRef, aPKRef, dUCRef, cUCRef int) tree.Datums {
 		tree.NewDInt(tree.DInt(aPKRef)),
 		tree.NewDInt(tree.DInt(dUCRef)),
 		tree.NewDInt(tree.DInt(cUCRef)),
+		tree.DNull,
 	}
 }
 
@@ -286,8 +301,13 @@ func TestDeriveLocks(t *testing.T) {
 	runner := sqlutils.MakeSQLRunner(conn)
 	runner.Exec(t, `CREATE TABLE plain_table (id INT PRIMARY KEY, data STRING)`)
 	runner.Exec(t, `CREATE TABLE uc_table (id INT PRIMARY KEY, email STRING UNIQUE)`)
-	// TODO(164507): make one of these columns a stored computed column.
-	runner.Exec(t, `CREATE TABLE composite_table (pk1 INT, pk2 INT, a INT, b INT, PRIMARY KEY (pk1, pk2), UNIQUE (a, b))`)
+	runner.Exec(t, `
+		CREATE TABLE composite_table (
+			pk1 INT, pk2 INT, a INT, b INT,
+			c INT AS (a + b) STORED,
+			PRIMARY KEY (pk1, pk2),
+			UNIQUE (a, c)
+		)`)
 	runner.Exec(t, `CREATE TABLE fk_parent (id INT PRIMARY KEY, ref_col INT UNIQUE, val INT)`)
 	runner.Exec(t, `
 		CREATE TABLE fk_child (
@@ -310,12 +330,14 @@ func TestDeriveLocks(t *testing.T) {
 	runner.Exec(t, `
 		CREATE TABLE composite_fk_parent (
 			a INT, b INT, c INT, d INT, val INT,
+			e INT AS (val + 1) STORED UNIQUE,
 			PRIMARY KEY (a, b),
 			UNIQUE (c, d)
 		)`)
 	runner.Exec(t, `
 		CREATE TABLE composite_fk_child (
 			id INT PRIMARY KEY, b_pk_ref INT, a_pk_ref INT, d_uc_ref INT, c_uc_ref INT,
+			e_ref INT REFERENCES composite_fk_parent(e),
 			FOREIGN KEY (a_pk_ref, b_pk_ref) REFERENCES composite_fk_parent(a, b),
 			FOREIGN KEY (c_uc_ref, d_uc_ref) REFERENCES composite_fk_parent(c, d)
 		)`)
@@ -602,7 +624,7 @@ func TestDeriveLocks(t *testing.T) {
 					compositeEB.InsertEvent(txnTime,
 						compositeRow(1, 2, 10, 20)),
 				},
-				writeLockCount: 2, // PK + UC(new: 10,20)
+				writeLockCount: 2, // PK + UC(new: a=10, c=30)
 				order:          []int{0},
 			},
 			txn2: txnCase{
@@ -618,7 +640,9 @@ func TestDeriveLocks(t *testing.T) {
 		},
 		{
 			// One txn updates a row's unique columns, the other deletes the
-			// same composite PK. PK and UC(30,40) locks overlap.
+			// same composite PK. PK and UC(a=30, c=70) locks overlap. The UC
+			// covers the stored computed column c, so updating b changes c
+			// and produces a new UC lock.
 			name: "composite_pk_update_and_delete",
 			txn1: txnCase{
 				events: []streampb.StreamEvent_KV{
@@ -626,7 +650,7 @@ func TestDeriveLocks(t *testing.T) {
 						compositeRow(1, 2, 30, 40),
 						compositeRow(1, 2, 10, 20)),
 				},
-				// PK + UC(old: 10,20) + UC(new: 30,40) = 3 write.
+				// PK + UC(old: a=10, c=30) + UC(new: a=30, c=70) = 3 write.
 				writeLockCount: 3,
 				order:          []int{0},
 			},
@@ -635,15 +659,15 @@ func TestDeriveLocks(t *testing.T) {
 					compositeEB.DeleteEvent(txnTime,
 						compositeRow(1, 2, 30, 40)),
 				},
-				writeLockCount: 2, // PK + UC(prev: 30,40)
+				writeLockCount: 2, // PK + UC(prev: a=30, c=70)
 				order:          []int{0},
 			},
-			writeOverlapCount: 2, // PK(1,2) + UC(30,40)
+			writeOverlapCount: 2, // PK(1,2) + UC(a=30, c=70)
 		},
 		{
 			// Unique key transfer on composite table: row 0 takes the unique
-			// value (10,20) freed by row 1's update. The sort must place
-			// row 1 before row 0. UC(10,20) is deduplicated across rows:
+			// value (a=10, c=30) freed by row 1's update. The sort must place
+			// row 1 before row 0. UC(a=10, c=30) is deduplicated across rows:
 			// read(row0) && write(row1) → write.
 			name: "composite_unique_key_transfer",
 			txn1: txnCase{
@@ -655,7 +679,7 @@ func TestDeriveLocks(t *testing.T) {
 						compositeRow(2, 2, 30, 40),
 						compositeRow(2, 2, 10, 20)),
 				},
-				// 2 PK + UC(10,20) + UC(30,40) = 4 write.
+				// 2 PK + UC(a=10, c=30) + UC(a=30, c=70) = 4 write.
 				writeLockCount: 4,
 				order:          []int{1, 0},
 			},
@@ -1214,8 +1238,8 @@ func TestDeriveLocks(t *testing.T) {
 				events: []streampb.StreamEvent_KV{
 					compositeFKParentEB.DeleteEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
 				},
-				// PK + UC + 2 inbound FK = 4.
-				writeLockCount: 4,
+				// PK + UC(c,d) + UC(e) + 3 inbound FK = 6.
+				writeLockCount: 6,
 				order:          []int{0},
 			},
 			writeOverlapCount: 2,
@@ -1228,8 +1252,11 @@ func TestDeriveLocks(t *testing.T) {
 					compositeChildEB.InsertEvent(txnTime, compositeFKChildRow(1, 2, 1, 4, 3)),
 					compositeFKParentEB.InsertEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
 				},
-				// 2 PKs + UC + 2 FK (read→write via collision) = 5.
-				writeLockCount: 5,
+				// Parent: PK + UC(c,d) + UC(e) + 3 inbound FK = 6.
+				// Child: PK + 2 outbound FK (read→write via collision with
+				// parent inbound on (a,b) and (c,d)). e_ref is NULL so it
+				// produces no outbound lock. Net: 6 + 1 = 7.
+				writeLockCount: 7,
 				order:          []int{1, 0},
 			},
 		},
@@ -1248,7 +1275,8 @@ func TestDeriveLocks(t *testing.T) {
 				events: []streampb.StreamEvent_KV{
 					compositeFKParentEB.DeleteEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
 				},
-				writeLockCount: 4,
+				// PK + UC(c,d) + UC(e) + 3 inbound FK = 6.
+				writeLockCount: 6,
 				order:          []int{0},
 			},
 		},
@@ -1262,7 +1290,8 @@ func TestDeriveLocks(t *testing.T) {
 						compositeFKChildRow(1, 20, 10, 40, 30),
 						compositeFKChildRow(1, 2, 1, 4, 3)),
 				},
-				// PK + 2 old FK + 2 new FK = 1 write, 4 read.
+				// PK + 2 old FK + 2 new FK = 1 write, 4 read. e_ref is NULL
+				// in both rows so it produces no outbound lock.
 				writeLockCount: 1,
 				readLockCount:  4,
 				order:          []int{0},
@@ -1272,7 +1301,8 @@ func TestDeriveLocks(t *testing.T) {
 					// Parent that the child is moving away from.
 					compositeFKParentEB.DeleteEvent(txnTime, compositeFKParentRow(1, 2, 3, 4, 0)),
 				},
-				writeLockCount: 4,
+				// PK + UC(c,d) + UC(e) + 3 inbound FK = 6.
+				writeLockCount: 6,
 				order:          []int{0},
 			},
 			// Child's old FK read locks on (a=1,b=2) and (c=3,d=4) overlap

--- a/pkg/sql/catalog/tabledesc/logical_replication_helpers.go
+++ b/pkg/sql/catalog/tabledesc/logical_replication_helpers.go
@@ -179,20 +179,18 @@ func checkExpressionEvaluation(
 	return nil
 }
 
-// checkComputedColumnsInConstraints rejects computed columns that are
+// checkComputedColumnsInConstraints rejects virtual computed columns that are
 // in a unique or a foreign key constraint. Lock derivation hashes column datums
-// from the decoded row, which does not contain computed columns.
-//
-// TODO(#164507): support stored computed columns.
+// from the decoded row, which does not contain virtual computed columns.
 func checkComputedColumnsInConstraints(
 	dst *descpb.TableDescriptor, columns []catalog.Column, colOrd catalog.TableColMap,
 ) error {
-	getComputedCol := func(colID descpb.ColumnID) (catalog.Column, bool) {
+	getVirtualCol := func(colID descpb.ColumnID) (catalog.Column, bool) {
 		ord, ok := colOrd.Get(colID)
-		if !ok || !columns[ord].IsComputed() {
-			return nil, false
+		if ok && columns[ord].IsVirtual() {
+			return columns[ord], true
 		}
-		return columns[ord], true
+		return nil, false
 	}
 
 	for _, idx := range dst.Indexes {
@@ -200,9 +198,9 @@ func checkComputedColumnsInConstraints(
 			continue
 		}
 		for _, colID := range idx.KeyColumnIDs {
-			if col, ok := getComputedCol(colID); ok {
+			if col, ok := getVirtualCol(colID); ok {
 				return errors.Newf(
-					"table %s has a computed column %s that is a key of unique index %s",
+					"table %s has a virtual computed column %s that is a key of unique index %s",
 					dst.Name, col.GetName(), idx.Name,
 				)
 			}
@@ -213,9 +211,9 @@ func checkComputedColumnsInConstraints(
 	// but the check should be harmless in case we add support.
 	for _, fk := range dst.OutboundFKs {
 		for _, colID := range fk.OriginColumnIDs {
-			if col, ok := getComputedCol(colID); ok {
+			if col, ok := getVirtualCol(colID); ok {
 				return errors.Newf(
-					"table %s has a computed column %s that is part of foreign key %s",
+					"table %s has a virtual computed column %s that is part of foreign key %s",
 					dst.Name, col.GetName(), fk.Name,
 				)
 			}
@@ -224,9 +222,9 @@ func checkComputedColumnsInConstraints(
 
 	for _, fk := range dst.InboundFKs {
 		for _, colID := range fk.ReferencedColumnIDs {
-			if col, ok := getComputedCol(colID); ok {
+			if col, ok := getVirtualCol(colID); ok {
 				return errors.Newf(
-					"table %s has a computed column %s that is referenced by foreign key %s",
+					"table %s has a virtual computed column %s that is referenced by foreign key %s",
 					dst.Name, col.GetName(), fk.Name,
 				)
 			}


### PR DESCRIPTION
Previously, stored computed columns were not supported in txn mode as we need to decode their values for lock synthesis but not for the actual SQL writer. This change now checks if the computed column is part of a constraint, and decodes it if so.

Fixes: https://github.com/cockroachdb/cockroach/issues/164507
Release note: none