### PR TITLE
schemachanger: implement `SET SCHEMA` for domains

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2624,7 +2624,7 @@ An event of type `set_schema` is recorded when a table, view, sequence or type's
 |--|--|--|
 | `DescriptorName` | The old name of the affected descriptor. | no |
 | `NewDescriptorName` | The new name of the affected descriptor. | no |
-| `DescriptorType` | The descriptor type being changed (table, view, sequence, type). | no |
+| `DescriptorType` | The descriptor type being changed (table, view, sequence, type, domain). | no |
 
 
 #### Common fields

--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -148,6 +148,13 @@ func TestBackupRollbacks_base_alter_database_configure_zone_multiple(t *testing.
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_index_configure_zone_discard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1055,6 +1062,13 @@ func TestBackupRollbacksMixedVersion_base_alter_database_configure_zone_multiple
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1968,6 +1982,13 @@ func TestBackupSuccess_base_alter_database_configure_zone_multiple(t *testing.T)
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_index_configure_zone_discard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2875,6 +2896,13 @@ func TestBackupSuccessMixedVersion_base_alter_database_configure_zone_multiple(t
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_domain
+++ b/pkg/sql/logictest/testdata/logic_test/alter_domain
@@ -224,8 +224,77 @@ subtest end
 
 subtest set_schema
 
-statement error pgcode 0A000 ALTER DOMAIN SET SCHEMA is not supported
-ALTER DOMAIN d SET SCHEMA public
+statement ok
+CREATE SCHEMA s_sc1;
+CREATE SCHEMA s_sc2;
+CREATE DOMAIN d_sc AS INT DEFAULT 0
+
+statement ok
+ALTER DOMAIN d_sc SET SCHEMA public
+
+statement ok
+ALTER DOMAIN d_sc SET SCHEMA s_sc1
+
+# The domain should be usable in the new schema.
+query T
+SELECT 1::s_sc1.d_sc
+----
+1
+
+# The array type should have moved too.
+query T
+SELECT ARRAY[1]::s_sc1._d_sc
+----
+{1}
+
+statement ok
+ALTER DOMAIN s_sc1.d_sc SET SCHEMA s_sc2
+
+query T
+SELECT 1::s_sc2.d_sc
+----
+1
+
+# The domain should no longer exist in s_sc1.
+query error pq: type "s_sc1.d_sc" does not exist
+SELECT 1::s_sc1.d_sc
+
+# Nor does the implicit array.
+query error pq: type "s_sc1._d_sc" does not exist
+SELECT '{}'::s_sc1._d_sc
+
+statement error pq: unknown schema "does_not_exist"
+ALTER DOMAIN s_sc2.d_sc SET SCHEMA does_not_exist
+
+# Error when there's a name conflict in the target schema.
+statement ok
+CREATE DOMAIN s_sc1.d_sc AS TEXT
+
+statement error pq: type "test.s_sc1.d_sc" already exists
+ALTER DOMAIN s_sc2.d_sc SET SCHEMA s_sc1
+
+# Moving a domain referenced by a table column should succeed
+# because types are referenced by ID.
+statement ok
+CREATE DOMAIN d_ref AS INT DEFAULT 42;
+CREATE TABLE t_dref (c d_ref);
+INSERT INTO t_dref VALUES (1);
+
+statement ok
+ALTER DOMAIN d_ref SET SCHEMA s_sc2
+
+query T
+SELECT c FROM t_dref
+----
+1
+
+statement ok
+DROP TABLE t_dref;
+DROP DOMAIN s_sc1.d_sc;
+DROP DOMAIN s_sc2.d_sc;
+DROP DOMAIN s_sc2.d_ref;
+DROP SCHEMA s_sc1;
+DROP SCHEMA s_sc2
 
 subtest end
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
@@ -182,5 +182,5 @@ func alterDomainRename(
 func alterDomainSetSchema(
 	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainSetSchema,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN SET SCHEMA is not supported"))
+	setSchemaForTypeDesc(b, domainType, domainType.TypeID, domainType.ArrayTypeID, t.Schema, "domain")
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -280,40 +280,7 @@ func alterTypeRenameValue(
 func alterTypeSetSchema(
 	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeSetSchema,
 ) {
-	typeID := enumType.TypeID
-
-	currNamespace := mustRetrieveNamespaceElem(b, typeID)
-	currSchemaID := currNamespace.SchemaID
-	panicIfSchemaIsTemporaryOrVirtual(t.Schema)
-	newSchema := resolveSchemaByName(b, t.Schema, currNamespace.DatabaseID)
-	newSchemaID := newSchema.SchemaID
-
-	if currSchemaID == newSchemaID {
-		return
-	}
-
-	currName := tree.MakeTableNameFromPrefix(b.NamePrefix(enumType), tree.Name(currNamespace.Name))
-	newName := currName
-	newName.SchemaName = t.Schema
-
-	checkTableNameConflicts(b, currName, newName, currNamespace)
-
-	arrayNamespace := mustRetrieveNamespaceElem(b, enumType.ArrayTypeID)
-	arrayName := tree.MakeTableNameFromPrefix(
-		b.NamePrefix(enumType), tree.Name(arrayNamespace.Name),
-	)
-	newArrayName := arrayName
-	newArrayName.SchemaName = t.Schema
-	checkTableNameConflicts(b, arrayName, newArrayName, arrayNamespace)
-
-	newNS, _ := moveDescriptorToSchema(b, typeID, currNamespace, newSchemaID)
-	moveDescriptorToSchema(b, enumType.ArrayTypeID, arrayNamespace, newSchemaID)
-
-	b.LogEventForExistingPayload(newNS, &eventpb.SetSchema{
-		DescriptorName:    currName.FQString(),
-		NewDescriptorName: newName.FQString(),
-		DescriptorType:    "type",
-	})
+	setSchemaForTypeDesc(b, enumType, enumType.TypeID, enumType.ArrayTypeID, t.Schema, "type")
 }
 
 func alterTypeOwner(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/type_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/type_helpers.go
@@ -121,6 +121,50 @@ func setOwnerForTypeDesc(
 	})
 }
 
+// setSchemaForTypeDesc implements SET SCHEMA for user-defined types that have
+// an associated array type (enums, composites, domains).
+func setSchemaForTypeDesc(
+	b BuildCtx,
+	typeElem scpb.Element,
+	typeID catid.DescID,
+	arrayTypeID catid.DescID,
+	newSchemaName tree.Name,
+	descriptorType string,
+) {
+	currNamespace := mustRetrieveNamespaceElem(b, typeID)
+	currSchemaID := currNamespace.SchemaID
+	panicIfSchemaIsTemporaryOrVirtual(newSchemaName)
+	newSchema := resolveSchemaByName(b, newSchemaName, currNamespace.DatabaseID)
+	newSchemaID := newSchema.SchemaID
+
+	if currSchemaID == newSchemaID {
+		return
+	}
+
+	currName := tree.MakeTableNameFromPrefix(b.NamePrefix(typeElem), tree.Name(currNamespace.Name))
+	newName := currName
+	newName.SchemaName = newSchemaName
+
+	checkTableNameConflicts(b, currName, newName, currNamespace)
+
+	arrayNamespace := mustRetrieveNamespaceElem(b, arrayTypeID)
+	arrayName := tree.MakeTableNameFromPrefix(
+		b.NamePrefix(typeElem), tree.Name(arrayNamespace.Name),
+	)
+	newArrayName := arrayName
+	newArrayName.SchemaName = newSchemaName
+	checkTableNameConflicts(b, arrayName, newArrayName, arrayNamespace)
+
+	newNS, _ := moveDescriptorToSchema(b, typeID, currNamespace, newSchemaID)
+	moveDescriptorToSchema(b, arrayTypeID, arrayNamespace, newSchemaID)
+
+	b.LogEventForExistingPayload(newNS, &eventpb.SetSchema{
+		DescriptorName:    currName.FQString(),
+		NewDescriptorName: newName.FQString(),
+		DescriptorType:    descriptorType,
+	})
+}
+
 // moveDescriptorToSchema drops the old Namespace and SchemaChild elements for
 // the given descriptor and adds new ones with the updated schema ID. It returns
 // the new Namespace and SchemaChild elements.

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_domain
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_domain
@@ -13,3 +13,31 @@ ALTER DOMAIN defaultdb.d OWNER TO testuser
   {descriptorId: 104, owner: testuser}
 - [[Owner:{DescID: 105}, PUBLIC], ABSENT]
   {descriptorId: 105, owner: testuser}
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d SET SCHEMA public
+----
+
+setup
+CREATE SCHEMA s;
+----
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d SET SCHEMA s
+----
+- [[Namespace:{DescID: 104, Name: d, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 104, name: d, schemaId: 101}
+- [[SchemaChild:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {childObjectId: 104, schemaId: 101}
+- [[Namespace:{DescID: 105, Name: _d, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 105, name: _d, schemaId: 101}
+- [[SchemaChild:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC]
+  {childObjectId: 105, schemaId: 101}
+- [[Namespace:{DescID: 104, Name: d, ReferencedDescID: 100, IntValue: 106}, PUBLIC], ABSENT]
+  {databaseId: 100, descriptorId: 104, name: d, schemaId: 106}
+- [[SchemaChild:{DescID: 104, ReferencedDescID: 106}, PUBLIC], ABSENT]
+  {childObjectId: 104, schemaId: 106}
+- [[Namespace:{DescID: 105, Name: _d, ReferencedDescID: 100, IntValue: 106}, PUBLIC], ABSENT]
+  {databaseId: 100, descriptorId: 105, name: _d, schemaId: 106}
+- [[SchemaChild:{DescID: 105, ReferencedDescID: 106}, PUBLIC], ABSENT]
+  {childObjectId: 105, schemaId: 106}

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -148,6 +148,13 @@ func TestEndToEndSideEffects_alter_database_configure_zone_multiple(t *testing.T
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_index_configure_zone_discard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1055,6 +1062,13 @@ func TestExecuteWithDMLInjection_alter_database_configure_zone_multiple(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1968,6 +1982,13 @@ func TestGenerateSchemaChangeCorpus_alter_database_configure_zone_multiple(t *te
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_index_configure_zone_discard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2875,6 +2896,13 @@ func TestPause_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3788,6 +3816,13 @@ func TestPauseMixedVersion_alter_database_configure_zone_multiple(t *testing.T) 
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_index_configure_zone_discard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4695,6 +4730,13 @@ func TestRollback_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_domain_set_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE SCHEMA fish;
+----
+
+test
+ALTER DOMAIN salmon SET SCHEMA fish;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.explain
@@ -1,0 +1,69 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE SCHEMA fish;
+
+/* test */
+EXPLAIN (DDL) ALTER DOMAIN salmon SET SCHEMA fish;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET SCHEMA ‹fish›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 4 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-salmon+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 106}
+ │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (salmon-salmon+), ReferencedDescID: 106 (fish)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_salmon+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 106}
+ │         │    └── ABSENT → PUBLIC SchemaChild:{DescID: 105 (_salmon-_salmon+), ReferencedDescID: 106 (fish)}
+ │         ├── 4 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-salmon+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (salmon-salmon+), ReferencedDescID: 101 (public)}
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_salmon+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── PUBLIC → ABSENT SchemaChild:{DescID: 105 (_salmon-_salmon+), ReferencedDescID: 101 (public)}
+ │         └── 10 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+ │              ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+ │              ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+ │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"salmon"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":106}}
+ │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":106}}
+ │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"_salmon"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":106}}
+ │              └── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":106}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-salmon+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 106}
+      │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (salmon-salmon+), ReferencedDescID: 106 (fish)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_salmon+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 106}
+      │    │    └── PUBLIC → ABSENT SchemaChild:{DescID: 105 (_salmon-_salmon+), ReferencedDescID: 106 (fish)}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-salmon+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (salmon-salmon+), ReferencedDescID: 101 (public)}
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_salmon+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── ABSENT → PUBLIC SchemaChild:{DescID: 105 (_salmon-_salmon+), ReferencedDescID: 101 (public)}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 4 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-salmon+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 106}
+           │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 104 (salmon-salmon+), ReferencedDescID: 106 (fish)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_salmon+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 106}
+           │    └── ABSENT → PUBLIC SchemaChild:{DescID: 105 (_salmon-_salmon+), ReferencedDescID: 106 (fish)}
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-salmon+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 104 (salmon-salmon+), ReferencedDescID: 101 (public)}
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_salmon+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── PUBLIC → ABSENT SchemaChild:{DescID: 105 (_salmon-_salmon+), ReferencedDescID: 101 (public)}
+           └── 12 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+                ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+                ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+                ├── SetNameInDescriptor {"DescriptorID":104,"Name":"salmon"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":106}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"salmon","TableID":104}
+                ├── SetObjectParentID {"ObjParent":{"ChildObjectID":104,"SchemaID":106}}
+                ├── SetNameInDescriptor {"DescriptorID":105,"Name":"_salmon"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":106}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"_salmon","TableID":105}
+                └── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":106}}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE SCHEMA fish;
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER DOMAIN salmon SET SCHEMA fish;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET SCHEMA ‹fish›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_schema/alter_domain_set_schema.side_effects
@@ -1,0 +1,107 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE SCHEMA fish;
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
++schema {100 0 fish} -> 106
+
+/* test */
+ALTER DOMAIN salmon SET SCHEMA fish;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER DOMAIN
+increment telemetry for sql.schema.alter_domain.set_schema
+write *eventpb.SetSchema to event log:
+  descriptorName: defaultdb.public.salmon
+  descriptorType: domain
+  newDescriptorName: defaultdb.fish.salmon
+  sql:
+    descriptorId: 104
+    statement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET SCHEMA ‹fish›
+    tag: ALTER DOMAIN
+    user: root
+## StatementPhase stage 1 of 1 with 10 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 106 salmon} -> 104
+add object namespace entry {100 106 _salmon} -> 105
+upsert descriptor #104
+  ...
+     name: salmon
+     parentId: 100
+  -  parentSchemaId: 101
+  +  parentSchemaId: 106
+     privileges:
+       ownerProto: root
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     name: _salmon
+     parentId: 100
+  -  parentSchemaId: 101
+  +  parentSchemaId: 106
+     privileges:
+       ownerProto: root
+  ...
+     referencingDescriptorIds:
+     - 104
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #106
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 12 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 106 salmon} -> 104
+add object namespace entry {100 106 _salmon} -> 105
+upsert descriptor #104
+  ...
+     name: salmon
+     parentId: 100
+  -  parentSchemaId: 101
+  +  parentSchemaId: 106
+     privileges:
+       ownerProto: root
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     name: _salmon
+     parentId: 100
+  -  parentSchemaId: 101
+  +  parentSchemaId: 106
+     privileges:
+       ownerProto: root
+  ...
+     referencingDescriptorIds:
+     - 104
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #106
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -143,7 +143,7 @@ message SetSchema {
   string descriptor_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
   // The new name of the affected descriptor.
   string new_descriptor_name = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-  // The descriptor type being changed (table, view, sequence, type).
+  // The descriptor type being changed (table, view, sequence, type, domain).
   string descriptor_type = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 


### PR DESCRIPTION
This change implements the `ALTER DOMAIN ... SET
SCHEMA` statement which was previously
unsupported. The legacy schemachanger did not
support domain types so logic tests are added to
cover the feature.

The `ALTER TYPE` implementation is refactored so
the `ALTER DOMAIN` implementation can use its
logic.

Closes: #166943
Epic: CRDB-62146

Release note (sql change): The `ALTER DOMAIN ...
SET SCHEMA` statement is supported.
