### PR TITLE
changefeedccl: return all rows from batched webhook test feed POSTs

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11802,6 +11802,38 @@ func TestChangefeedCSVHeaderRowWebhook(t *testing.T) {
 	cdcTest(t, testFn, feedTestForceSink("webhook"))
 }
 
+// TestChangefeedMultiRowWebhookBatch verifies that the webhook test feed
+// returns every row when the webhook sink batches multiple rows into a
+// single POST. Real webhook sinks wrap batches as
+// {"payload":[r1,r2,...],"length":N}; the test feed must surface all N
+// rows when consumed via Next.
+func TestChangefeedMultiRowWebhookBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+
+		// Frequency=1h keeps the batcher's timer from flushing partial
+		// batches before Messages is reached.
+		wf := feed(t, f,
+			`CREATE CHANGEFEED FOR foo `+
+				`WITH webhook_sink_config='{"Flush":{"Messages":4,"Frequency":"1h"}}'`)
+		defer closeFeed(t, wf)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')`)
+		assertPayloads(t, wf, []string{
+			`foo: [1]->{"after": {"a": 1, "b": "a"}}`,
+			`foo: [2]->{"after": {"a": 2, "b": "b"}}`,
+			`foo: [3]->{"after": {"a": 3, "b": "c"}}`,
+			`foo: [4]->{"after": {"a": 4, "b": "d"}}`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestForceSink("webhook"))
+}
+
 // TestCloudstorageBufferedBytesMetric tests the metric which tracks the number
 // of buffered bytes in the cloudstorage sink.
 func TestCloudstorageBufferedBytesMetric(t *testing.T) {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -2380,6 +2380,9 @@ type webhookFeed struct {
 	ss           *sinkSynchronizer
 	envelopeType changefeedbase.EnvelopeType
 	mockSink     *cdctest.MockWebhookSink
+	// pending holds row messages extracted from a single batched POST that
+	// have not yet been returned by Next.
+	pending []*cdctest.TestFeedMessage
 }
 
 var _ cdctest.TestFeed = (*webhookFeed)(nil)
@@ -2437,9 +2440,10 @@ type webhookSinkTestfeedPayload struct {
 	Length  int                 `json:"length"`
 }
 
-// extractValueFromJSONMessage extracts the value of the first element of
-// the payload array from an webhook sink JSON message.
-func extractValueFromJSONMessage(message []byte) (val []byte, err error) {
+// extractValuesFromJSONMessage extracts every value from the payload array
+// of a webhook sink JSON message. A single POST may carry multiple batched
+// rows (the webhook sink wraps batches as {"payload":[r1,r2,...],"length":N}).
+func extractValuesFromJSONMessage(message []byte) (vals [][]byte, err error) {
 	defer func() {
 		if err != nil {
 			err = errors.Wrapf(err, "message was '%s'", message)
@@ -2449,16 +2453,16 @@ func extractValueFromJSONMessage(message []byte) (val []byte, err error) {
 	if err := gojson.Unmarshal(message, &parsed); err != nil {
 		return nil, err
 	}
-	keyParsed := parsed.Payload
-	if len(keyParsed) <= 0 {
+	if len(parsed.Payload) == 0 {
 		return nil, fmt.Errorf("payload value in json message contains no elements")
 	}
-
-	var value []byte
-	if value, err = reformatJSON(keyParsed[0]); err != nil {
-		return nil, err
+	vals = make([][]byte, len(parsed.Payload))
+	for i, raw := range parsed.Payload {
+		if vals[i], err = reformatJSON(raw); err != nil {
+			return nil, err
+		}
 	}
-	return value, nil
+	return vals, nil
 }
 
 // Ignore these headers from the webhook sink, since they're always included and not interesting.
@@ -2472,72 +2476,83 @@ var ignoreHeaders = []string{
 // Next implements TestFeed
 func (f *webhookFeed) Next() (*cdctest.TestFeedMessage, error) {
 	for {
-		msgWithHeaders := f.mockSink.PopWithHeaders()
-		msg := msgWithHeaders.Row
-		if msg != "" {
-			m := &cdctest.TestFeedMessage{}
-			for k, v := range msgWithHeaders.Headers {
-				if slices.Contains(ignoreHeaders, k) {
-					continue
-				}
-				m.Headers = append(m.Headers, cdctest.Header{K: k, V: []byte(v[0])})
-			}
-			if msg != "" {
-				details, err := f.Details()
-				if err != nil {
-					return nil, err
-				}
-				switch v := changefeedbase.FormatType(details.Opts[changefeedbase.OptFormat]); v {
-				case ``, changefeedbase.OptFormatJSON:
-					resolved, err := isResolvedTimestamp([]byte(msg))
-					if err != nil {
-						return nil, err
-					}
-					if resolved {
-						m.Resolved = []byte(msg)
-					} else {
-						wrappedValue, err := extractValueFromJSONMessage([]byte(msg))
-						if err != nil {
-							return nil, err
-						}
-						if m.Key, m.Value, err = extractKeyFromJSONValue(f.envelopeType, wrappedValue); err != nil {
-							return nil, err
-						}
-						if m.Topic, m.Value, err = extractTopicFromJSONValue(f.envelopeType, m.Value); err != nil {
-							return nil, err
-						}
-						if isNew := f.markSeen(m); !isNew {
-							continue
-						}
-					}
-				case changefeedbase.OptFormatCSV:
-					m.Value = []byte(msg)
-					return m, nil
-				default:
-					return nil, errors.Errorf(`unknown %s: %s`, changefeedbase.OptFormat, v)
-				}
-				return m, nil
-			}
-			m.Key, m.Value = nil, nil
+		// A single POST can carry multiple messages, but Next returns one at
+		// a time. Serve any rows queued from a previous POST before fetching
+		// a new one.
+		if len(f.pending) > 0 {
+			m := f.pending[0]
+			f.pending = f.pending[1:]
 			return m, nil
 		}
 
-		if err := timeutil.RunWithTimeout(
-			context.Background(), timeoutOp("webhook.Next", f.jobID), timeout(),
-			func(ctx context.Context) error {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case <-f.ss.eventReady():
-					return nil
-				case <-f.mockSink.NotifyMessage():
-					return nil
-				case <-f.shutdown:
-					return f.terminalJobError()
-				}
-			},
-		); err != nil {
+		msgWithHeaders := f.mockSink.PopWithHeaders()
+		msg := msgWithHeaders.Row
+		if msg == "" {
+			if err := timeutil.RunWithTimeout(
+				context.Background(), timeoutOp("webhook.Next", f.jobID), timeout(),
+				func(ctx context.Context) error {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-f.ss.eventReady():
+						return nil
+					case <-f.mockSink.NotifyMessage():
+						return nil
+					case <-f.shutdown:
+						return f.terminalJobError()
+					}
+				},
+			); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		var headers []cdctest.Header
+		for k, v := range msgWithHeaders.Headers {
+			if slices.Contains(ignoreHeaders, k) {
+				continue
+			}
+			headers = append(headers, cdctest.Header{K: k, V: []byte(v[0])})
+		}
+		details, err := f.Details()
+		if err != nil {
 			return nil, err
+		}
+		switch v := changefeedbase.FormatType(details.Opts[changefeedbase.OptFormat]); v {
+		case ``, changefeedbase.OptFormatJSON:
+			resolved, err := isResolvedTimestamp([]byte(msg))
+			if err != nil {
+				return nil, err
+			}
+			if resolved {
+				return &cdctest.TestFeedMessage{Headers: headers, Resolved: []byte(msg)}, nil
+			}
+			values, err := extractValuesFromJSONMessage([]byte(msg))
+			if err != nil {
+				return nil, err
+			}
+			for _, value := range values {
+				m := &cdctest.TestFeedMessage{Headers: headers}
+				if m.Key, m.Value, err = extractKeyFromJSONValue(f.envelopeType, value); err != nil {
+					return nil, err
+				}
+				if m.Topic, m.Value, err = extractTopicFromJSONValue(f.envelopeType, m.Value); err != nil {
+					return nil, err
+				}
+				if isNew := f.markSeen(m); !isNew {
+					continue
+				}
+				f.pending = append(f.pending, m)
+			}
+			// Loop back so the drain block at the top returns f.pending[0].
+		case changefeedbase.OptFormatCSV:
+			// The CSV format webhook sink concatenates a batch's rows into
+			// a single CSV document. To avoid implementing CSV parsing, we
+			// return a CSV batch as a single message.
+			return &cdctest.TestFeedMessage{Headers: headers, Value: []byte(msg)}, nil
+		default:
+			return nil, errors.Errorf(`unknown %s: %s`, changefeedbase.OptFormat, v)
 		}
 	}
 }


### PR DESCRIPTION
Previously, changefeed unit tests that produced batched webhook POSTs
would fail: the test feed only inspected the first message in each
POST and silently dropped the rest. The test feed now queues the rows
from a batched POST and serves them across subsequent `Next` calls.

This unblocks upcoming tests under the no-linger changefeed batching
epic that exercise webhook with real batching (see #169760 for the
prototype that originally surfaced the gap).

Resolves: #170201
Epic: CRDB-62737

Release note: None