### PR TITLE
backup: disable dRPC package-wide for backup tests

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1091,15 +1091,7 @@ func TestBackupRestoreSystemTables(t *testing.T) {
 
 	const numAccounts = 0
 	ctx := context.Background()
-	// Note (kev-cao): DRPC is currently flaky on this test, disabling while it is
-	// investigated.
-	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
-		t, multiNode, numAccounts, InitManualReplication, base.TestClusterArgs{
-			ServerArgs: base.TestServerArgs{
-				DefaultDRPCOption: base.TestDRPCDisabled,
-			},
-		},
-	)
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, InitManualReplication)
 	conn := sqlDB.DB.(*gosql.DB)
 	defer cleanupFn()
 
@@ -2360,12 +2352,7 @@ func TestBackupRestoreUserDefinedTypes(t *testing.T) {
 	// ts4: no farewell type exists
 	// ts5: farewell type exists as (third)
 	t.Run("revision-history", func(t *testing.T) {
-		// Note (kev-cao): DRPC is currently flaky on this test, disabling while it
-		// is investigated.
-		_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode,
-			0, InitManualReplication, base.TestClusterArgs{
-				ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
-			})
+		_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
 		defer cleanupFn()
 
 		var ts1, ts2, ts3, ts4, ts5 string
@@ -2492,10 +2479,7 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/rev-history-backup'
 
 	// Test backup/restore of a single table.
 	t.Run("table", func(t *testing.T) {
-		_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode,
-			0, InitManualReplication, base.TestClusterArgs{
-				ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
-			})
+		_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
 		defer cleanupFn()
 		sqlDB.Exec(t, `
 CREATE DATABASE d;
@@ -3980,12 +3964,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 
 	const numAccounts = 10
 	ctx := context.Background()
-	args := base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			DefaultDRPCOption: base.TestDRPCDisabled,
-		},
-	}
-	tc, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, args)
+	tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 	const dir = "nodelocal://1/"
 	s := tc.SystemLayer(0)
@@ -4021,7 +4000,7 @@ func TestRestoreAsOfSystemTimeGCBounds(t *testing.T) {
 
 	t.Run("restore-pre-gc-aost", func(t *testing.T) {
 		backupPath := dir + "/tbl-before-gc"
-		_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, 0, InitManualReplication, args)
+		_, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
 		defer cleanupFn()
 
 		sqlDB.Exec(t, "CREATE DATABASE db")
@@ -10887,12 +10866,8 @@ func TestBackupRestoreForeignKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	params := base.TestServerArgs{
-		DefaultDRPCOption: base.TestDRPCDisabled,
-	}
 	const numAccounts = 1000
-	_, sqlDB, _, cleanup := backupRestoreTestSetupWithParams(t, singleNode, numAccounts,
-		InitManualReplication, base.TestClusterArgs{ServerArgs: params})
+	_, sqlDB, _, cleanup := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanup()
 	sqlDB.Exec(t, `SET use_backups_with_ids = true`)
 

--- a/pkg/backup/backupdest/main_test.go
+++ b/pkg/backup/backupdest/main_test.go
@@ -23,8 +23,10 @@ func TestMain(m *testing.M) {
 	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
+	// TODO(kev-cao): DRPC is currently flaky in backup tests; disable it
+	// package-wide while it is investigated. See #170394.
 	serverutils.InitTestServerFactory(server.TestServerFactory,
-		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
+		serverutils.WithDRPCOption(base.TestDRPCDisabled))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/backup/backupinfo/main_test.go
+++ b/pkg/backup/backupinfo/main_test.go
@@ -24,8 +24,10 @@ func TestMain(m *testing.M) {
 	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
+	// TODO(kev-cao): DRPC is currently flaky in backup tests; disable it
+	// package-wide while it is investigated. See #170394.
 	serverutils.InitTestServerFactory(server.TestServerFactory,
-		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
+		serverutils.WithDRPCOption(base.TestDRPCDisabled))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/backup/backuprand/main_test.go
+++ b/pkg/backup/backuprand/main_test.go
@@ -23,8 +23,10 @@ func TestMain(m *testing.M) {
 	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
+	// TODO(kev-cao): DRPC is currently flaky in backup tests; disable it
+	// package-wide while it is investigated. See #170394.
 	serverutils.InitTestServerFactory(server.TestServerFactory,
-		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
+		serverutils.WithDRPCOption(base.TestDRPCDisabled))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/backup/backupresolver/main_test.go
+++ b/pkg/backup/backupresolver/main_test.go
@@ -21,8 +21,10 @@ import (
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
+	// TODO(kev-cao): DRPC is currently flaky in backup tests; disable it
+	// package-wide while it is investigated. See #170394.
 	serverutils.InitTestServerFactory(server.TestServerFactory,
-		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
+		serverutils.WithDRPCOption(base.TestDRPCDisabled))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -684,7 +684,6 @@ func TestBackupCompactionExecLocality(t *testing.T) {
 	args := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			DefaultTestTenant: base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(142798),
-			DefaultDRPCOption: base.TestDRPCDisabled,
 		},
 		ServerArgsPerNode: map[int]base.TestServerArgs{
 			0: {

--- a/pkg/backup/datadriven_test.go
+++ b/pkg/backup/datadriven_test.go
@@ -160,10 +160,6 @@ type clusterCfg struct {
 func (d *datadrivenTestState) addCluster(t *testing.T, cfg clusterCfg) error {
 	params := base.TestClusterArgs{}
 	params.ServerArgs.ExternalIODirConfig = cfg.ioConf
-	// Note (kev-cao): DRPC is currently flaky on this test, disabling while it
-	// is investigated.
-	params.ServerArgs.DefaultDRPCOption = base.TestDRPCDisabled
-
 	params.ServerArgs.DefaultTestTenant = cfg.defaultTestTenant
 	var transactionRetryFilter func(roachpb.Transaction) bool
 	if cfg.randomTxnRetries {

--- a/pkg/backup/main_test.go
+++ b/pkg/backup/main_test.go
@@ -23,8 +23,10 @@ func TestMain(m *testing.M) {
 	start := timeutil.Now()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
+	// TODO(kev-cao): DRPC is currently flaky in backup tests; disable it
+	// package-wide while it is investigated. See #170394.
 	serverutils.InitTestServerFactory(server.TestServerFactory,
-		serverutils.WithDRPCOption(base.TestDRPCEnabledRandomly))
+		serverutils.WithDRPCOption(base.TestDRPCDisabled))
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	exit := m.Run()
 	testcluster.PrintTimings(timeutil.Since(start))

--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -635,11 +635,7 @@ func TestRestoreWithBackupIDs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	_, sqlDB, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
-		t, singleNode, backuptestutils.WithInitFunc(InitManualReplication),
-		backuptestutils.WithParams(base.
-			TestClusterArgs{
-			ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
-		}))
+		t, singleNode, backuptestutils.WithInitFunc(InitManualReplication))
 	defer cleanupFn()
 
 	const classicColl = "nodelocal://1/classic"

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -44,14 +44,9 @@ func TestShowBackup(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	const numAccounts = 11
-	// Note (kev-cao): DRPC is currently flaky on this test, disabling while it
-	// is investigated.
-	args := base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{DefaultDRPCOption: base.TestDRPCDisabled},
-	}
-	tc, sqlDB, tempDir, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, args)
+	tc, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	kvDB := tc.Server(0).ApplicationLayer().DB()
-	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, args)
+	_, sqlDBRestore, cleanupEmptyCluster := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
 	defer cleanupFn()
 	defer cleanupEmptyCluster()
 	sqlDB.ExecMultiple(t, strings.Split(`


### PR DESCRIPTION
Disable metamorphic dRPC enabling in the backup test packages by flipping the factory default to `TestDRPCDisabled`, and drop the per-test workarounds that were previously needed.

Informs: #170394

Release note: None