### PR TITLE
sql/opt: implement PlanGram field matching for Table and Index

### DIFF
--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "logical_props_builder.go",
         "memo.go",
         "multiplicity_builder.go",
+        "plangram.go",
         "statistics_builder.go",
         "typing.go",
         ":gen-expr",  # keep

--- a/pkg/sql/opt/memo/plangram.go
+++ b/pkg/sql/opt/memo/plangram.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package memo
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+)
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *ScanExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *PlaceholderScanExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *IndexJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(0).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *LookupJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *InvertedJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *ZigzagJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	leftTab := md.Table(e.LeftTable)
+	rightTab := md.Table(e.RightTable)
+	return []physical.PlanGramField{
+		{Key: "LeftTable", Val: string(leftTab.Name())},
+		{Key: "RightTable", Val: string(rightTab.Name())},
+		{Key: "LeftIndex", Val: string(leftTab.Index(e.LeftIndex).Name())},
+		{Key: "RightIndex", Val: string(rightTab.Index(e.RightIndex).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *VectorSearchExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *VectorMutationSearchExpr) PlanGramMatchableFields(
+	md *opt.Metadata,
+) []physical.PlanGramField {
+	tab := md.Table(e.Table)
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(tab.Name())},
+		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *InsertExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(md.Table(e.Table).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *UpdateExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(md.Table(e.Table).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *UpsertExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(md.Table(e.Table).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *DeleteExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(md.Table(e.Table).Name())},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *LockExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "Table", Val: string(md.Table(e.Table).Name())},
+	}
+}

--- a/pkg/sql/opt/plangram/BUILD.bazel
+++ b/pkg/sql/opt/plangram/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/plangram",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/opt",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/props/physical",
     ],

--- a/pkg/sql/opt/plangram/plangram.go
+++ b/pkg/sql/opt/plangram/plangram.go
@@ -6,6 +6,7 @@
 package plangram
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 )
@@ -28,14 +29,14 @@ func VisibleToPlanGram(expr memo.RelExpr) bool {
 // BuildChildRequired returns the PlanGram term for the nth child of
 // the parent expression.
 func BuildChildRequired(
-	parent memo.RelExpr, required physical.PlanGram, childIdx int,
+	parent memo.RelExpr, required physical.PlanGram, childIdx int, md *opt.Metadata,
 ) physical.PlanGram {
 	if !VisibleToPlanGram(parent) {
 		// For expressions not visible to PlanGrams, the current term is simply
 		// passed down.
 		return required
 	}
-	if !required.Matches(parent) {
+	if !required.Matches(parent, md) {
 		// Once we hit a mismatch, NonePlanGram is passed downward to reduce the
 		// number of optimization calls for lower groups.
 		return physical.NonePlanGram

--- a/pkg/sql/opt/plangram/plangram_test.go
+++ b/pkg/sql/opt/plangram/plangram_test.go
@@ -60,29 +60,29 @@ func TestBuildChildRequired(t *testing.T) {
 
 	t.Run("invisible parent passes through", func(t *testing.T) {
 		pg := parsePG(t, "root: (Scan);")
-		result := plangram.BuildChildRequired(&memo.DistributeExpr{}, pg, 0)
+		result := plangram.BuildChildRequired(&memo.DistributeExpr{}, pg, 0, nil)
 		require.True(t, result.Equals(pg))
 	})
 
 	t.Run("visible parent matching descends to child", func(t *testing.T) {
 		pg := parsePG(t, "root: (Select (Scan));")
-		result := plangram.BuildChildRequired(&memo.SelectExpr{}, pg, 0)
-		require.True(t, result.Matches(&memo.ScanExpr{}))
+		result := plangram.BuildChildRequired(&memo.SelectExpr{}, pg, 0, nil)
+		require.True(t, result.Matches(&memo.ScanExpr{}, nil))
 	})
 
 	t.Run("visible parent mismatching returns none", func(t *testing.T) {
 		pg := parsePG(t, "root: (Select);")
-		result := plangram.BuildChildRequired(&memo.ScanExpr{}, pg, 0)
+		result := plangram.BuildChildRequired(&memo.ScanExpr{}, pg, 0, nil)
 		require.True(t, result.Equals(physical.NonePlanGram))
 	})
 
 	t.Run("any always matches and returns any for child", func(t *testing.T) {
-		result := plangram.BuildChildRequired(&memo.SelectExpr{}, physical.AnyPlanGram, 0)
+		result := plangram.BuildChildRequired(&memo.SelectExpr{}, physical.AnyPlanGram, 0, nil)
 		require.True(t, result.Any())
 	})
 
 	t.Run("none never matches visible parent", func(t *testing.T) {
-		result := plangram.BuildChildRequired(&memo.SelectExpr{}, physical.NonePlanGram, 0)
+		result := plangram.BuildChildRequired(&memo.SelectExpr{}, physical.NonePlanGram, 0, nil)
 		require.True(t, result.Equals(physical.NonePlanGram))
 	})
 }

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -126,15 +126,24 @@ type planGramProduction struct {
 // If the op is UnknownOp this is a wildcard expr.
 type planGramExpr struct {
 	op       opt.Operator
-	fields   []planGramExprField
+	fields   []PlanGramField
 	children []planGramTerm
 }
 
-// planGramExprField represents a single field of an optimizer expression. How
-// this matches the corresponding optgen field depends on the specific
-// expression and field.
-type planGramExprField struct {
-	key, val string
+// PlanGramField represents a single field of an optimizer expression. How this
+// matches the corresponding optgen field depends on the specific expression and
+// field.
+type PlanGramField struct {
+	Key, Val string
+}
+
+// PlanGramFieldMatchableExpr is an optional interface that optimizer expression
+// types can implement to support field-based matching in PlanGrams. Expressions
+// that implement this interface report their matchable fields (e.g. Table,
+// Index) so that PlanGram field constraints like (Scan Table="abc") can be
+// checked during matching.
+type PlanGramFieldMatchableExpr interface {
+	PlanGramMatchableFields(md *opt.Metadata) []PlanGramField
 }
 
 var _ planGramTerm = &planGramProduction{}
@@ -232,9 +241,9 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 			for _, field := range t.fields {
 				b.WriteRune(' ')
 				// Assume field names don't need to be quoted.
-				b.WriteString(field.key)
+				b.WriteString(field.Key)
 				b.WriteRune('=')
-				b.WriteString(strconv.Quote(field.val))
+				b.WriteString(strconv.Quote(field.Val))
 			}
 			for _, child := range t.children {
 				b.WriteRune(' ')
@@ -553,7 +562,7 @@ func (p *planGramParser) parseExpr() (planGramTerm, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "invalid field value %s", val)
 		}
-		expr.fields = append(expr.fields, planGramExprField{key: name, val: unquoted})
+		expr.fields = append(expr.fields, PlanGramField{Key: name, Val: unquoted})
 	}
 	// TODO(michae2): check for correct number of children.
 	return expr, nil
@@ -642,11 +651,11 @@ func (p PlanGram) RootHash() uint64 {
 
 // Matches reports whether this PlanGram term matches the given optimizer
 // expression. Any matches everything, None matches nothing. A concrete PlanGram
-// expression matches if the operator matches (or is a wildcard) and the child
-// count matches. This should only be called after alternates have been
-// expanded, so the root is always a planGramExpr or Any or None. It panics if
-// called on a production.
-func (p PlanGram) Matches(e opt.Expr) bool {
+// expression matches if the operator matches (or is a wildcard), the child
+// count matches, and all specified fields match. This should only be called
+// after alternates have been expanded, so the root is always a planGramExpr or
+// Any or None. It panics if called on a production.
+func (p PlanGram) Matches(e opt.Expr, md *opt.Metadata) bool {
 	if p.Any() {
 		return true
 	}
@@ -655,11 +664,34 @@ func (p PlanGram) Matches(e opt.Expr) bool {
 	}
 	switch t := p.root.(type) {
 	case *planGramExpr:
-		// TODO(michae2): check fields
-		return (t.op == opt.UnknownOp || t.op == e.Op()) && len(t.children) <= e.ChildCount()
+		if (t.op != opt.UnknownOp && t.op != e.Op()) || len(t.children) > e.ChildCount() {
+			return false
+		}
+		if len(t.fields) > 0 {
+			fm, ok := e.(PlanGramFieldMatchableExpr)
+			if !ok {
+				return false
+			}
+			exprFields := fm.PlanGramMatchableFields(md)
+			for _, f := range t.fields {
+				if !containsPlanGramField(exprFields, f) {
+					return false
+				}
+			}
+		}
+		return true
 	default:
 		panic(errors.AssertionFailedf("called Matches(%v) on non-expression PlanGram term %v", e, t))
 	}
+}
+
+func containsPlanGramField(fields []PlanGramField, f PlanGramField) bool {
+	for _, ef := range fields {
+		if ef.Key == f.Key && ef.Val == f.Val {
+			return true
+		}
+	}
+	return false
 }
 
 // Child returns the PlanGram for the nth child of this term. If this PlanGram

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -91,14 +91,14 @@ func TestPlanGramFormatPretty(t *testing.T) {
 		rules: []planGramTerm{
 			&planGramExpr{
 				op: opt.ScanOp,
-				fields: []planGramExprField{
-					{key: "Index", val: "abc_b_idx"},
+				fields: []PlanGramField{
+					{Key: "Index", Val: "abc_b_idx"},
 				},
 			},
 			&planGramExpr{
 				op: opt.ScanOp,
-				fields: []planGramExprField{
-					{key: "Index", val: "abc_c_idx"},
+				fields: []PlanGramField{
+					{Key: "Index", Val: "abc_c_idx"},
 				},
 			},
 		},
@@ -144,8 +144,8 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			name: "simple terminal",
 			plangram: PlanGram{root: &planGramExpr{
 				op: opt.ScanOp,
-				fields: []planGramExprField{
-					{key: "Index", val: "abc_a_idx"},
+				fields: []PlanGramField{
+					{Key: "Index", Val: "abc_a_idx"},
 				},
 			}},
 			expectedOneLine:  "root: (Scan Index=\"abc_a_idx\");",
@@ -208,9 +208,9 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			name: "multiple fields",
 			plangram: PlanGram{root: &planGramExpr{
 				op: opt.ScanOp,
-				fields: []planGramExprField{
-					{key: "Table", val: "abc"},
-					{key: "Index", val: "abc_b_idx"},
+				fields: []PlanGramField{
+					{Key: "Table", Val: "abc"},
+					{Key: "Index", Val: "abc_b_idx"},
 				},
 			}},
 			expectedOneLine:  "root: (Scan Table=\"abc\" Index=\"abc_b_idx\");",
@@ -220,8 +220,8 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			name: "field value with special characters",
 			plangram: PlanGram{root: &planGramExpr{
 				op: opt.ScanOp,
-				fields: []planGramExprField{
-					{key: "Index", val: `has "quotes" and spaces`},
+				fields: []PlanGramField{
+					{Key: "Index", Val: `has "quotes" and spaces`},
 				},
 			}},
 			expectedOneLine:  `root: (Scan Index="has \"quotes\" and spaces");`,
@@ -257,6 +257,15 @@ func (m *mockExpr) ChildCount() int        { return len(m.children) }
 func (m *mockExpr) Child(nth int) opt.Expr { return m.children[nth] }
 func (m *mockExpr) Private() interface{}   { return nil }
 
+type mockFieldExpr struct {
+	mockExpr
+	fields []PlanGramField
+}
+
+func (m *mockFieldExpr) PlanGramMatchableFields(*opt.Metadata) []PlanGramField {
+	return m.fields
+}
+
 func TestPlanGramMatches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -266,6 +275,13 @@ func TestPlanGramMatches(t *testing.T) {
 	twoChildExpr := &mockExpr{
 		op:       opt.InnerJoinOp,
 		children: []opt.Expr{scanExpr, scanExpr},
+	}
+	scanWithFields := &mockFieldExpr{
+		mockExpr: mockExpr{op: opt.ScanOp},
+		fields: []PlanGramField{
+			{Key: "Table", Val: "abc"},
+			{Key: "Index", Val: "abc_b_idx"},
+		},
 	}
 
 	tests := []struct {
@@ -338,11 +354,53 @@ func TestPlanGramMatches(t *testing.T) {
 			expr:     twoChildExpr,
 			expected: true,
 		},
+		{
+			name: "field match",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "Index", Val: "abc_b_idx"}},
+			}},
+			expr:     scanWithFields,
+			expected: true,
+		},
+		{
+			name: "field mismatch",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "Index", Val: "abc_c_idx"}},
+			}},
+			expr:     scanWithFields,
+			expected: false,
+		},
+		{
+			name: "field on non-matchable expr",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "Index", Val: "abc_b_idx"}},
+			}},
+			expr:     scanExpr,
+			expected: false,
+		},
+		{
+			name: "subset of fields matches",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "Table", Val: "abc"}},
+			}},
+			expr:     scanWithFields,
+			expected: true,
+		},
+		{
+			name:     "no fields with matchable expr still matches",
+			pg:       PlanGram{root: &planGramExpr{op: opt.ScanOp}},
+			expr:     scanWithFields,
+			expected: true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, tc.pg.Matches(tc.expr))
+			require.Equal(t, tc.expected, tc.pg.Matches(tc.expr, nil))
 		})
 	}
 }

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -639,7 +639,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	}
 
 	// Penalize expressions that don't match the PlanGram.
-	if plangram.VisibleToPlanGram(candidate) && !required.PlanGram.Matches(candidate) {
+	if plangram.VisibleToPlanGram(candidate) && !required.PlanGram.Matches(candidate, c.mem.Metadata()) {
 		cost.Penalties |= memo.PlanGramMismatchPenalty
 	}
 

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -92,7 +92,7 @@ func BuildChildPhysicalProps(
 	childProps.Ordering = ordering.BuildChildRequired(mem, parent, &parentProps.Ordering, nth)
 	childProps.Distribution = distribution.BuildChildRequired(parent, &parentProps.Distribution, nth)
 	childProps.RemoteBranch = parentProps.RemoteBranch
-	childProps.PlanGram = plangram.BuildChildRequired(parent, parentProps.PlanGram, nth)
+	childProps.PlanGram = plangram.BuildChildRequired(parent, parentProps.PlanGram, nth, mem.Metadata())
 
 	switch parent.Op() {
 	case opt.LimitOp:

--- a/pkg/sql/opt/xform/testdata/physprops/plangram
+++ b/pkg/sql/opt/xform/testdata/physprops/plangram
@@ -10,6 +10,10 @@ exec-ddl
 CREATE TABLE pqr (p INT PRIMARY KEY, q INT, r INT)
 ----
 
+exec-ddl
+CREATE TABLE vec_tab (id INT PRIMARY KEY, v VECTOR(3), VECTOR INDEX v_idx (v))
+----
+
 # Matching Fundamentals
 
 # Basic match.
@@ -1058,3 +1062,829 @@ limit
  │         └── filters
  │              └── c:3 > 0 [outer=(3)]
  └── 5
+
+# Field Matching
+
+# Table field match — Scan on abc matches Table="abc".
+
+opt format=show-cost plangram=(root: (Scan Table="abc");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# Table field mismatch — Scan on abc does not match Table="xy".
+
+opt format=show-cost plangram=(root: (Scan Table="xy");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# Index field match — steer to a specific index using Index=.
+
+opt format=show-cost plangram=(root: (Select (IndexJoin (Scan Index="abc_c_idx")));)
+SELECT * FROM abc WHERE b = 1 AND c > 0
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cost: 2384.73667
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 2381.37333
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan abc@abc_c_idx
+ │         ├── columns: a:1!null c:3!null
+ │         ├── constraint: /3/1: [/1 - ]
+ │         ├── cost: 364.686667
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── b:2 = 1 [outer=(2), fd=()-->(2)]
+
+# Index field mismatch — specifying a non-matching index causes penalty.
+
+opt format=show-cost plangram=(root: (Scan Index="abc_b_idx");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# Table and Index fields together — both must match. Query only indexed columns
+# so the plan is a bare Scan (no IndexJoin).
+
+opt format=show-cost plangram=(root: (Scan Table="abc" Index="abc_b_idx");)
+SELECT a, b FROM abc@abc_b_idx
+----
+scan abc@abc_b_idx
+ ├── columns: a:1!null b:2
+ ├── flags: force-index=abc_b_idx
+ ├── cost: 1068.42
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2)
+
+# Table match + Index mismatch — both fields must match for the expression to
+# match. Query only indexed columns so the plan is a bare Scan.
+
+opt format=show-cost plangram=(root: (Scan Table="abc" Index="abc_c_idx");)
+SELECT a, b FROM abc@abc_b_idx
+----
+scan abc@abc_b_idx
+ ├── columns: a:1!null b:2
+ ├── flags: force-index=abc_b_idx
+ ├── cost: 1068.42
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2)
+
+# Index field steering with alternates — both alternates specify valid indexes.
+# The scan with abc_b_idx matches because the query forces that index.
+
+opt format=show-cost plangram=(root: scan; scan: (Scan Index="abc_c_idx") | (Scan Index="abc_b_idx");)
+SELECT a, b FROM abc@abc_b_idx
+----
+scan abc@abc_b_idx
+ ├── columns: a:1!null b:2
+ ├── flags: force-index=abc_b_idx
+ ├── cost: 1068.42
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2)
+
+# Field match on non-matchable expression — field matching on operators that
+# don't implement PlanGramFieldMatchableExpr always mismatches.
+
+opt format=show-cost plangram=(root: (Select Table="abc");)
+SELECT * FROM abc WHERE a = 1
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── cost: 9.07
+ ├── cost-flags: plangram-mismatch
+ ├── key: ()
+ └── fd: ()-->(1-3)
+
+# IndexJoin — Table field match.
+
+opt format=show-cost plangram=(root: (Select (IndexJoin Table="abc" (Scan)));)
+SELECT * FROM abc WHERE b = 1 AND c > 0
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cost: 89.0700007
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 88.9400007
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    └── scan abc@abc_b_idx
+ │         ├── columns: a:1!null b:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── cost: 28.4200001
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── c:3 > 0 [outer=(3)]
+
+# IndexJoin — Table field mismatch.
+
+opt format=show-cost plangram=(root: (Select (IndexJoin Table="xy" (Scan)));)
+SELECT * FROM abc WHERE b = 1 AND c > 0
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cost: 89.0700007
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 88.9400007
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    └── scan abc@abc_b_idx
+ │         ├── columns: a:1!null b:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── cost: 28.4200001
+ │         ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── c:3 > 0 [outer=(3)]
+
+# LookupJoin — Table field match.
+
+opt format=show-cost plangram=(root: (LookupJoin Table="abc" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (lookup abc)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── key columns: [6] = [1]
+ ├── lookup columns are key
+ ├── cost: 7142.44
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+# LookupJoin — Table field steering. The PlanGram asks for a lookup into xy, so
+# the optimizer steers to scan abc and look up into xy (instead of the default
+# direction). No mismatch.
+
+opt format=show-cost plangram=(root: (LookupJoin Table="xy" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (lookup xy)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── key columns: [1] = [6]
+ ├── lookup columns are key
+ ├── cost: 7142.64
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters (true)
+
+# Insert — Table field match.
+
+opt format=show-cost plangram=(root: (Insert Table="xy");)
+INSERT INTO xy SELECT a, b FROM abc WHERE a > 10
+----
+insert xy
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:5 => x:1
+ │    └── b:6 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 368.03
+ ├── cost-flags: unbounded-cardinality
+ └── scan abc
+      ├── columns: a:5!null b:6
+      ├── constraint: /5: [/11 - ]
+      ├── cost: 368.02
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (5)
+      └── fd: (5)-->(6)
+
+# Insert — Table field mismatch.
+
+opt format=show-cost plangram=(root: (Insert Table="abc");)
+INSERT INTO xy SELECT a, b FROM abc WHERE a > 10
+----
+insert xy
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:5 => x:1
+ │    └── b:6 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 368.03
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ └── scan abc
+      ├── columns: a:5!null b:6
+      ├── constraint: /5: [/11 - ]
+      ├── cost: 368.02
+      ├── cost-flags: plangram-mismatch unbounded-cardinality
+      ├── key: (5)
+      └── fd: (5)-->(6)
+
+# Delete — Table field match.
+
+opt format=show-cost plangram=(root: (Delete Table="xy");)
+DELETE FROM xy WHERE x > 0
+----
+delete xy
+ ├── columns: <none>
+ ├── fetch columns: x:5 y:6
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 364.696667
+ ├── cost-flags: unbounded-cardinality
+ └── scan xy
+      ├── columns: x:5!null y:6
+      ├── constraint: /5: [/1 - ]
+      ├── flags: avoid-full-scan
+      ├── cost: 364.686667
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (5)
+      └── fd: (5)-->(6)
+
+# ZigzagJoin — LeftIndex and RightIndex field match.
+
+opt format=show-cost plangram=(root: (ZigzagJoin LeftIndex="abc_b_idx" RightIndex="abc_c_idx");)
+SELECT * FROM abc WHERE b = 1 AND c = 1
+----
+inner-join (zigzag abc@abc_b_idx abc@abc_c_idx)
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [1]
+ ├── cost: 30.14
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── b:2 = 1 [outer=(2), fd=()-->(2)]
+      └── c:3 = 1 [outer=(3), fd=()-->(3)]
+
+# ZigzagJoin — RightIndex field mismatch.
+
+opt format=show-cost plangram=(root: (ZigzagJoin LeftIndex="abc_b_idx" RightIndex="abc_b_idx");)
+SELECT * FROM abc WHERE b = 1 AND c = 1
+----
+inner-join (zigzag abc@abc_b_idx abc@abc_c_idx)
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [1]
+ ├── cost: 30.14
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── b:2 = 1 [outer=(2), fd=()-->(2)]
+      └── c:3 = 1 [outer=(3), fd=()-->(3)]
+
+# Field on nested (non-root) child expression.
+
+opt format=show-cost plangram=(root: (Insert Table="xy" (Select (Scan Table="abc")));)
+INSERT INTO xy SELECT a, b FROM abc WHERE a > 10
+----
+insert xy
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a:5 => x:1
+ │    └── b:6 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 1078.46
+ ├── cost-flags: unbounded-cardinality
+ └── select
+      ├── columns: a:5!null b:6
+      ├── cost: 1078.45
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (5)
+      ├── fd: (5)-->(6)
+      ├── scan abc@abc_b_idx
+      │    ├── columns: a:5!null b:6
+      │    ├── cost: 1068.42
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      └── filters
+           └── a:5 > 10 [outer=(5)]
+
+# Unknown field key — should mismatch since Scan doesn't report "Foo".
+
+opt format=show-cost plangram=(root: (Scan Foo="bar");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# Update — Table field match.
+
+opt format=show-cost plangram=(root: (Update Table="xy");)
+UPDATE xy SET y = 1 WHERE x > 0
+----
+update xy
+ ├── columns: <none>
+ ├── fetch columns: x:5 y:6
+ ├── update-mapping:
+ │    └── y_new:9 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 371.383333
+ ├── cost-flags: unbounded-cardinality
+ └── project
+      ├── columns: y_new:9!null x:5!null y:6
+      ├── cost: 371.373333
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (5)
+      ├── fd: ()-->(9), (5)-->(6)
+      ├── scan xy
+      │    ├── columns: x:5!null y:6
+      │    ├── constraint: /5: [/1 - ]
+      │    ├── flags: avoid-full-scan
+      │    ├── cost: 364.686667
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      └── projections
+           └── 1 [as=y_new:9]
+
+# Update — Table field mismatch.
+
+opt format=show-cost plangram=(root: (Update Table="abc");)
+UPDATE xy SET y = 1 WHERE x > 0
+----
+update xy
+ ├── columns: <none>
+ ├── fetch columns: x:5 y:6
+ ├── update-mapping:
+ │    └── y_new:9 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 371.383333
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ └── project
+      ├── columns: y_new:9!null x:5!null y:6
+      ├── cost: 371.373333
+      ├── cost-flags: plangram-mismatch unbounded-cardinality
+      ├── key: (5)
+      ├── fd: ()-->(9), (5)-->(6)
+      ├── scan xy
+      │    ├── columns: x:5!null y:6
+      │    ├── constraint: /5: [/1 - ]
+      │    ├── flags: avoid-full-scan
+      │    ├── cost: 364.686667
+      │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      └── projections
+           └── 1 [as=y_new:9]
+
+# IndexJoin — Index field match. IndexJoin always uses the primary index.
+
+opt format=show-cost plangram=(root: (Select (IndexJoin Index="abc_pkey" (Scan)));)
+SELECT * FROM abc WHERE b = 1 AND c > 0
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cost: 89.0700007
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 88.9400007
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    └── scan abc@abc_b_idx
+ │         ├── columns: a:1!null b:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── cost: 28.4200001
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── c:3 > 0 [outer=(3)]
+
+# IndexJoin — Index field mismatch.
+
+opt format=show-cost plangram=(root: (Select (IndexJoin Index="abc_b_idx" (Scan)));)
+SELECT * FROM abc WHERE b = 1 AND c > 0
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cost: 89.0700007
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 88.9400007
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    └── scan abc@abc_b_idx
+ │         ├── columns: a:1!null b:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── cost: 28.4200001
+ │         ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── c:3 > 0 [outer=(3)]
+
+# LookupJoin — Index field match. Lookup into abc uses primary key index.
+
+opt format=show-cost plangram=(root: (LookupJoin Index="abc_pkey" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (lookup abc)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── key columns: [6] = [1]
+ ├── lookup columns are key
+ ├── cost: 7142.44
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+# LookupJoin — Index field mismatch.
+
+opt format=show-cost plangram=(root: (LookupJoin Index="abc_b_idx" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (merge)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── left ordering: +1
+ ├── right ordering: +6
+ ├── cost: 2187.06
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── filters (true)
+
+# ZigzagJoin — LeftTable and RightTable field match.
+
+opt format=show-cost plangram=(root: (ZigzagJoin LeftTable="abc" RightTable="abc");)
+SELECT * FROM abc WHERE b = 1 AND c = 1
+----
+inner-join (zigzag abc@abc_b_idx abc@abc_c_idx)
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [1]
+ ├── cost: 30.14
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── b:2 = 1 [outer=(2), fd=()-->(2)]
+      └── c:3 = 1 [outer=(3), fd=()-->(3)]
+
+# ZigzagJoin — LeftTable field mismatch.
+
+opt format=show-cost plangram=(root: (ZigzagJoin LeftTable="xy");)
+SELECT * FROM abc WHERE b = 1 AND c = 1
+----
+inner-join (zigzag abc@abc_b_idx abc@abc_c_idx)
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [1]
+ ├── cost: 30.14
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── b:2 = 1 [outer=(2), fd=()-->(2)]
+      └── c:3 = 1 [outer=(3), fd=()-->(3)]
+
+# Upsert — Table field match.
+
+opt format=show-cost plangram=(root: (Upsert Table="xy");)
+UPSERT INTO xy VALUES (1, 2)
+----
+upsert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── canary column: x:7
+ ├── fetch columns: x:7 y:8
+ ├── insert-mapping:
+ │    ├── column1:5 => x:1
+ │    └── column2:6 => y:2
+ ├── update-mapping:
+ │    └── column2:6 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 9.13
+ └── left-join (cross)
+      ├── columns: column1:5!null column2:6!null x:7 y:8
+      ├── cardinality: [1 - 1]
+      ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+      ├── cost: 9.12
+      ├── key: ()
+      ├── fd: ()-->(5-8)
+      ├── values
+      │    ├── columns: column1:5!null column2:6!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── cost: 0.02
+      │    ├── key: ()
+      │    ├── fd: ()-->(5,6)
+      │    └── (1, 2)
+      ├── scan xy
+      │    ├── columns: x:7!null y:8
+      │    ├── constraint: /7: [/1 - /1]
+      │    ├── flags: avoid-full-scan
+      │    ├── cardinality: [0 - 1]
+      │    ├── cost: 9.05
+      │    ├── key: ()
+      │    └── fd: ()-->(7,8)
+      └── filters (true)
+
+# Upsert — Table field mismatch.
+
+opt format=show-cost plangram=(root: (Upsert Table="abc");)
+UPSERT INTO xy VALUES (1, 2)
+----
+upsert xy
+ ├── arbiter indexes: xy_pkey
+ ├── columns: <none>
+ ├── canary column: x:7
+ ├── fetch columns: x:7 y:8
+ ├── insert-mapping:
+ │    ├── column1:5 => x:1
+ │    └── column2:6 => y:2
+ ├── update-mapping:
+ │    └── column2:6 => y:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── cost: 9.13
+ ├── cost-flags: plangram-mismatch
+ └── left-join (cross)
+      ├── columns: column1:5!null column2:6!null x:7 y:8
+      ├── cardinality: [1 - 1]
+      ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+      ├── cost: 9.12
+      ├── cost-flags: plangram-mismatch
+      ├── key: ()
+      ├── fd: ()-->(5-8)
+      ├── values
+      │    ├── columns: column1:5!null column2:6!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── cost: 0.02
+      │    ├── cost-flags: plangram-mismatch
+      │    ├── key: ()
+      │    ├── fd: ()-->(5,6)
+      │    └── (1, 2)
+      ├── scan xy
+      │    ├── columns: x:7!null y:8
+      │    ├── constraint: /7: [/1 - /1]
+      │    ├── flags: avoid-full-scan
+      │    ├── cardinality: [0 - 1]
+      │    ├── cost: 9.05
+      │    ├── cost-flags: plangram-mismatch
+      │    ├── key: ()
+      │    └── fd: ()-->(7,8)
+      └── filters (true)
+
+# Lock — Table field match.
+
+opt format=show-cost set=(optimizer_use_lock_op_for_serializable=true) plangram=(root: (Lock Table="xy");)
+SELECT * FROM xy WHERE x = 1 FOR UPDATE
+----
+lock xy
+ ├── columns: x:1!null y:2
+ ├── key columns: x:1
+ ├── lock columns: (5,6)
+ ├── locking: for-update
+ ├── cardinality: [0 - 1]
+ ├── volatile
+ ├── cost: 9.06
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ └── scan xy
+      ├── columns: x:1!null y:2
+      ├── constraint: /1: [/1 - /1]
+      ├── cardinality: [0 - 1]
+      ├── cost: 9.05
+      ├── key: ()
+      └── fd: ()-->(1,2)
+
+# Lock — Table field mismatch.
+
+opt format=show-cost set=(optimizer_use_lock_op_for_serializable=true) plangram=(root: (Lock Table="abc");)
+SELECT * FROM xy WHERE x = 1 FOR UPDATE
+----
+lock xy
+ ├── columns: x:1!null y:2
+ ├── key columns: x:1
+ ├── lock columns: (5,6)
+ ├── locking: for-update
+ ├── cardinality: [0 - 1]
+ ├── volatile
+ ├── cost: 9.06
+ ├── cost-flags: plangram-mismatch
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ └── scan xy
+      ├── columns: x:1!null y:2
+      ├── constraint: /1: [/1 - /1]
+      ├── cardinality: [0 - 1]
+      ├── cost: 9.05
+      ├── cost-flags: plangram-mismatch
+      ├── key: ()
+      └── fd: ()-->(1,2)
+
+# VectorSearch — Table field match.
+
+opt format=show-cost plangram=(root: (TopK (Project (LookupJoin (VectorSearch Table="vec_tab"))));)
+SELECT * FROM vec_tab ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+top-k
+ ├── columns: id:1!null v:2  [hidden: column5:5]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.5843856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5 id:1!null v:2
+      ├── immutable
+      ├── cost: 64.76
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── inner-join (lookup vec_tab)
+      │    ├── columns: id:1!null v:2
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.54
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── vector-search vec_tab@v_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+
+# VectorSearch — Table field mismatch.
+
+opt format=show-cost plangram=(root: (TopK (Project (LookupJoin (VectorSearch Table="abc"))));)
+SELECT * FROM vec_tab ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+top-k
+ ├── columns: id:1!null v:2  [hidden: column5:5]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.5843856
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5 id:1!null v:2
+      ├── immutable
+      ├── cost: 64.76
+      ├── cost-flags: plangram-mismatch unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── inner-join (lookup vec_tab)
+      │    ├── columns: id:1!null v:2
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.54
+      │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── vector-search vec_tab@v_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+
+# VectorSearch — Index field match.
+
+opt format=show-cost plangram=(root: (TopK (Project (LookupJoin (VectorSearch Index="v_idx"))));)
+SELECT * FROM vec_tab ORDER BY v <-> '[1,2,3]' LIMIT 5
+----
+top-k
+ ├── columns: id:1!null v:2  [hidden: column5:5]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── cost: 65.5843856
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5 id:1!null v:2
+      ├── immutable
+      ├── cost: 64.76
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── inner-join (lookup vec_tab)
+      │    ├── columns: id:1!null v:2
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── cost: 64.54
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── vector-search vec_tab@v_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── cost: 0.12
+      │    │    ├── cost-flags: unbounded-cardinality
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]'
+      │    └── filters (true)
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, outer=(2), immutable]


### PR DESCRIPTION
PlanGram expressions can specify fields like Table="abc" and Index="abc_b_idx", but the Matches method previously ignored them. This change implements field matching so that PlanGrams can constrain which table/index an expression operates on.

The approach adds a PlanGramFieldMatchableExpr interface. Expressions that have matchable fields implement this interface, reporting their Table and/or Index names.

This change only adds Table and Index fields. A future PR will need to add the following fields for better plan gist matching:

- HasConstraint
- HasLimit
- AutoCommit
- JoinType
- All (for set ops)

Plus we'll need to think about whether we want to match column sets.

Informs: #152053

Release note: None