### PR TITLE
ts: filter out merges in TestServerQueryCombinedBatchReducesKVRPCs

### DIFF
--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -265,6 +265,17 @@ func TestServerQueryCombinedBatchReducesKVRPCs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	var tsBatchCount atomic.Int64
+	// isTSRead reports whether the request reads from the timeseries keyspace.
+	// The background ts poller writes metrics via Merge requests on the same
+	// keyspace; filtering by request type prevents a poll inflating the count.
+	isTSRead := func(ru kvpb.RequestUnion) bool {
+		inner := ru.GetInner()
+		switch inner.(type) {
+		case *kvpb.GetRequest, *kvpb.ScanRequest:
+			return bytes.HasPrefix(inner.Header().Key, keys.TimeseriesPrefix)
+		}
+		return false
+	}
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		Knobs: base.TestingKnobs{
@@ -274,10 +285,7 @@ func TestServerQueryCombinedBatchReducesKVRPCs(t *testing.T) {
 					_ context.Context, req *kvpb.BatchRequest,
 				) *kvpb.Error {
 					for _, ru := range req.Requests {
-						if bytes.HasPrefix(
-							ru.GetInner().Header().Key,
-							keys.TimeseriesPrefix,
-						) {
+						if isTSRead(ru) {
 							tsBatchCount.Add(1)
 							break
 						}


### PR DESCRIPTION
TestServerQueryCombinedBatchReducesKVRPCs uses a TestingRequestFilter to count KV BatchRequests touching the timeseries keyspace, then asserts that 5 individual queries produce exactly 5 batches and a combined query produces exactly 1. The filter previously matched every request whose key had the timeseries prefix, regardless of request type.

That filter made the count likely to race with the background timeseries poller, which writes metrics via Merge requests on the same keyspace every DefaultMetricsSampleInterval (10s). When a poll fired inside the post-reset measurement window, the Merge batch was counted alongside the query reads, producing 6 instead of 5.

This change narrows the filter to only count batches containing a Get or Scan into the timeseries keyspace. Merge writes from the poller are now ignored, eliminating the race without changing what the test asserts.

Resolves: #169740
Epic: none
Release note: None