### PR TITLE
logstore: one-shot clear overwrites in logAppend

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -262,7 +262,7 @@ func (s *LogStore) storeEntriesAndCommitBatch(
 		stats.EntryStats.Add(entryStats) // TODO(pav-kv): just return the stats.
 		state.ByteSize += entryStats.SideloadedBytes
 		if state, err = logAppend(
-			ctx, s.StateLoader.RaftLogPrefix(), batch, state, thinEntries,
+			ctx, s.StateLoader.RangeIDPrefixBuf, batch, state, thinEntries,
 			UseRaftLogSingleDelete(s.Separated),
 		); err != nil {
 			const expl = "during append"
@@ -456,7 +456,7 @@ func storeHardState(
 // on-disk payloads in case the log tail is replaced.
 func logAppend(
 	ctx context.Context,
-	raftLogPrefix roachpb.Key,
+	prefixBuf keys.RangeIDPrefixBuf,
 	rw storage.ReadWriter,
 	prev RaftState,
 	entries []raftpb.Entry,
@@ -481,6 +481,7 @@ func logAppend(
 
 	useSingleDelete := UseRaftLogSingleDelete(enginesSeparated)
 	opts := storage.MVCCWriteOptions{Stats: diff, Category: fs.ReplicationReadCategory}
+	raftLogPrefix := prefixBuf.RaftLogPrefix()
 	for i := range entries {
 		ent := &entries[i]
 		key := keys.RaftLogKeyFromPrefix(raftLogPrefix, kvpb.RaftIndex(ent.Index))

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
@@ -262,7 +261,7 @@ func (s *LogStore) storeEntriesAndCommitBatch(
 		stats.EntryStats.Add(entryStats) // TODO(pav-kv): just return the stats.
 		state.ByteSize += entryStats.SideloadedBytes
 		if state, err = logAppend(
-			ctx, s.StateLoader.RangeIDPrefixBuf, batch, state, thinEntries,
+			ctx, s.StateLoader.RangeIDPrefixBuf, s.Engine, batch, state, thinEntries,
 			UseRaftLogSingleDelete(s.Separated),
 		); err != nil {
 			const expl = "during append"
@@ -457,7 +456,8 @@ func storeHardState(
 func logAppend(
 	ctx context.Context,
 	prefixBuf keys.RangeIDPrefixBuf,
-	rw storage.ReadWriter,
+	eng storage.Engine, // only used to create a read-only batch if needed
+	w storage.Writer,
 	prev RaftState,
 	entries []raftpb.Entry,
 	enginesSeparated bool,
@@ -479,96 +479,81 @@ func logAppend(
 	value.RawBytes = value.RawBytes[:0]
 	diff.Reset()
 
+	newFirst := kvpb.RaftIndex(entries[0].Index)
+	if newFirst == 0 {
+		// No raft entry should have index 0.
+		return RaftState{}, errors.AssertionFailedf("raft entry index must be >= 1")
+	}
+	newLast := kvpb.RaftIndex(entries[len(entries)-1].Index)
 	useSingleDelete := UseRaftLogSingleDelete(enginesSeparated)
+	overlapping := newFirst <= prev.LastIndex
+	// In the common case, the new entries don't overlap the existing log and are
+	// appended to its end. If there is an overlap, the [newFirst, prev.LastIndex]
+	// span is overwritten by the [newFirst, newLast] suffix.
+	//
+	// TODO(ibrahim): both ClearRangeSizeKnown calls below pass MaxInt to force
+	// point deletes (no Pebble range tombstones). Worth investigating whether a
+	// lower threshold is appropriate for large overwrites/tail-drops.
+	if overlapping {
+		// Subtract [newFirst, prev.LastIndex] from the log size stats.
+		startKey, endKey := raftLogBounds(prefixBuf, newFirst-1, prev.LastIndex)
+		reader := eng.NewReader(storage.StandardDurability)
+		defer reader.Close()
+		ms, err := storage.ComputeStats(
+			ctx, reader, fs.ReplicationReadCategory, startKey, endKey, 0, /* nowNanos */
+		)
+		if err != nil {
+			return RaftState{}, err
+		}
+		// Inline raft log entries only contribute to Sys{Bytes,Count}.
+		diff.SysBytes -= ms.SysBytes
+		diff.SysCount -= ms.SysCount
+
+		// When using SingleDelete, explicitly delete the old suffix, because
+		// SingleDelete requires there to be no double PUT of the same key. If not
+		// using SingleDelete, the MVCCBlindPut below will overwrite those entries,
+		// and another ClearRangeSizeKnown will remove the (newLast, prev.LastIndex]
+		// remainder, if any.
+		if useSingleDelete {
+			if err := ClearRangeSizeKnown(
+				w, prefixBuf, newFirst-1, prev.LastIndex, math.MaxInt, true, /* maybeUseSingleDel */
+			); err != nil {
+				return RaftState{}, err
+			}
+		}
+	}
+
 	opts := storage.MVCCWriteOptions{Stats: diff, Category: fs.ReplicationReadCategory}
+	// NB: each iteration consumes its key before the next RaftLogKeyFromPrefix
+	// call rewrites the bytes after raftLogPrefix.
 	raftLogPrefix := prefixBuf.RaftLogPrefix()
 	for i := range entries {
 		ent := &entries[i]
 		key := keys.RaftLogKeyFromPrefix(raftLogPrefix, kvpb.RaftIndex(ent.Index))
-
 		if err := value.SetProto(ent); err != nil {
 			return RaftState{}, err
 		}
 		value.InitChecksum(key)
-		var err error
-		if kvpb.RaftIndex(ent.Index) > prev.LastIndex {
-			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
-		} else if useSingleDelete {
-			// Overwriting an existing log entry. To make SingleDelete here and in
-			// other places safe, maintain the invariant that there is always a
-			// deletion between two puts.
-			if err := singleClearInline(ctx, rw, key, diff); err != nil {
-				return RaftState{}, err
-			}
-			_, err = storage.MVCCBlindPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
-		} else {
-			_, err = storage.MVCCPut(ctx, rw, key, hlc.Timestamp{}, *value, opts)
-		}
-		if err != nil {
+		if _, err := storage.MVCCBlindPut(ctx, w, key, hlc.Timestamp{}, *value, opts); err != nil {
 			return RaftState{}, err
 		}
 	}
 
-	newLastIndex := kvpb.RaftIndex(entries[len(entries)-1].Index)
-	// Delete any previously appended log entries which never committed.
-	if prev.LastIndex > 0 {
-		for i := newLastIndex + 1; i <= prev.LastIndex; i++ {
-			// Note that the caller is in charge of deleting any sideloaded payloads
-			// (which they must only do *after* the batch has committed).
-			key := keys.RaftLogKeyFromPrefix(raftLogPrefix, i)
-			var err error
-			if useSingleDelete {
-				// SingleDelete is safe since there is always a deletion between two
-				// puts.
-				err = singleClearInline(ctx, rw, key, diff)
-			} else {
-				_, _, err = storage.MVCCDelete(ctx, rw, key, hlc.Timestamp{}, opts)
-			}
-			if err != nil {
-				return RaftState{}, err
-			}
+	if overlapping && !useSingleDelete {
+		// Truncate the log suffix not covered by the new entries.
+		// No-op if newLast >= prev.LastIndex.
+		if err := ClearRangeSizeKnown(
+			w, prefixBuf, newLast, prev.LastIndex, math.MaxInt, false, /* maybeUseSingleDel */
+		); err != nil {
+			return RaftState{}, err
 		}
 	}
 
 	return RaftState{
-		LastIndex: newLastIndex,
+		LastIndex: newLast,
 		LastTerm:  kvpb.RaftTerm(entries[len(entries)-1].Term),
 		ByteSize:  prev.ByteSize + diff.SysBytes,
 	}, nil
-}
-
-// singleClearInline issues a Pebble SingleDelete for the inline entry at key
-// and subtracts its byte/count contribution from ms. This restores the
-// MVCCStats accounting that SingleClearUnversioned skips, mirroring what
-// MVCCDelete's inline path computes via updateStatsForInline.
-// TODO(ibrahim): Replace this with a new MVCCSingleDelete function that does
-// something similar to MVCCDelete but using SingleDelete.
-func singleClearInline(
-	ctx context.Context, rw storage.ReadWriter, key roachpb.Key, ms *enginepb.MVCCStats,
-) error {
-	// TODO(ibrahim): Instead of creating an iterator for every deleted entry,
-	// create just one iterator and use it to delete the entries.
-	iter, err := rw.NewMVCCIterator(ctx, storage.MVCCKeyIterKind, storage.IterOptions{
-		Prefix: true, ReadCategory: fs.ReplicationReadCategory,
-	})
-	if err != nil {
-		return err
-	}
-	defer iter.Close()
-	iter.SeekGE(storage.MakeMVCCMetadataKey(key))
-	if ok, err := iter.Valid(); err != nil {
-		return err
-	} else if ok && iter.UnsafeKey().Key.Equal(key) {
-		keyBytes := int64(iter.UnsafeKey().EncodedSize())
-		valBytes := int64(iter.ValueLen())
-		ms.SysBytes -= keyBytes + valBytes
-		ms.SysCount--
-		return rw.SingleClearUnversioned(key)
-	}
-	// We don't expect to hit this. However, we can fail-open here because
-	// the entry is already deleted, and there is nothing to do.
-	log.KvExec.Errorf(ctx, "attempted to delete a non-existent raft log entry: %s", key)
-	return nil
 }
 
 // Compact prepares a write that removes entries (prev.Index, next.Index] from

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -82,7 +82,7 @@ func TestRaftStorageWrites(t *testing.T) {
 			batch := writeBatch(func(rw storage.ReadWriter) {
 				require.NoError(t, storeHardState(ctx, rw, sl, hs))
 				var err error
-				newState, err = logAppend(ctx, sl.RangeIDPrefixBuf, rw, state, entries, false /* enginesSeparated */)
+				newState, err = logAppend(ctx, sl.RangeIDPrefixBuf, eng, rw, state, entries, false /* enginesSeparated */)
 				require.NoError(t, err)
 			})
 			state = newState
@@ -168,7 +168,7 @@ func (h *clearRangeHelper) populate(ctx context.Context, firstIndex uint64, last
 	b := h.eng.NewBatch()
 	defer b.Close()
 	_, err := logAppend(
-		ctx, h.prefixBuf, b, RaftState{}, entries, false, /* enginesSeparated */
+		ctx, h.prefixBuf, h.eng, b, RaftState{}, entries, false, /* enginesSeparated */
 	)
 	require.NoError(h.t, err)
 	require.NoError(h.t, b.Commit(false /* sync */))

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -118,8 +118,14 @@ func TestRaftStorageWrites(t *testing.T) {
 			{Index: 104, Term: 22},
 			{Index: 105, Term: 22},
 		})
+		write("append (103,107] with overlap extending past tail", raftpb.HardState{}, []raftpb.Entry{
+			{Index: 104, Term: 22},
+			{Index: 105, Term: 22},
+			{Index: 106, Term: 22},
+			{Index: 107, Term: 22},
+		})
 		truncate("truncate at 103", kvserverpb.RaftTruncatedState{Index: 103, Term: 22})
-		truncate("truncate all", kvserverpb.RaftTruncatedState{Index: 105, Term: 22})
+		truncate("truncate all", kvserverpb.RaftTruncatedState{Index: 107, Term: 22})
 
 		// TODO(pav-kv): print the engine content as well.
 

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -82,7 +82,7 @@ func TestRaftStorageWrites(t *testing.T) {
 			batch := writeBatch(func(rw storage.ReadWriter) {
 				require.NoError(t, storeHardState(ctx, rw, sl, hs))
 				var err error
-				newState, err = logAppend(ctx, sl.RaftLogPrefix(), rw, state, entries, false /* enginesSeparated */)
+				newState, err = logAppend(ctx, sl.RangeIDPrefixBuf, rw, state, entries, false /* enginesSeparated */)
 				require.NoError(t, err)
 			})
 			state = newState
@@ -168,7 +168,7 @@ func (h *clearRangeHelper) populate(ctx context.Context, firstIndex uint64, last
 	b := h.eng.NewBatch()
 	defer b.Close()
 	_, err := logAppend(
-		ctx, h.prefixBuf.RaftLogPrefix(), b, RaftState{}, entries, false, /* enginesSeparated */
+		ctx, h.prefixBuf, b, RaftState{}, entries, false, /* enginesSeparated */
 	)
 	require.NoError(h.t, err)
 	require.NoError(h.t, b.Commit(false /* sync */))

--- a/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=false
+++ b/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=false
@@ -11,7 +11,7 @@ State:{LastIndex:103 LastTerm:21 ByteSize:129} RaftTruncatedState:{Index:100 Ter
 >> append (101,102] with overlap
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:22 vote:0 commit:100 lead:0 lead_epoch:0 
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:102 (0x0169f67b757266746c000000000000006600): Term:22 Index:102 Type:EntryNormal : EMPTY
-Delete (Sized at 43): 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): 
+Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): 
 State:{LastIndex:102 LastTerm:22 ByteSize:86} RaftTruncatedState:{Index:100 Term:20}
 >> append (102,105]
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): Term:22 Index:103 Type:EntryNormal : EMPTY

--- a/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=false
+++ b/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=false
@@ -18,14 +18,22 @@ Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c00000000
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): Term:22 Index:104 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): Term:22 Index:105 Type:EntryNormal : EMPTY
 State:{LastIndex:105 LastTerm:22 ByteSize:215} RaftTruncatedState:{Index:100 Term:20}
+>> append (103,107] with overlap extending past tail
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): Term:22 Index:104 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): Term:22 Index:105 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:106 (0x0169f67b757266746c000000000000006a00): Term:22 Index:106 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:107 (0x0169f67b757266746c000000000000006b00): Term:22 Index:107 Type:EntryNormal : EMPTY
+State:{LastIndex:107 LastTerm:22 ByteSize:301} RaftTruncatedState:{Index:100 Term:20}
 >> truncate at 103
 Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:101 (0x0169f67b757266746c000000000000006500): 
 Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:102 (0x0169f67b757266746c000000000000006600): 
 Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): 
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:103 term:22 
-State:{LastIndex:105 LastTerm:22 ByteSize:86} RaftTruncatedState:{Index:103 Term:22}
+State:{LastIndex:107 LastTerm:22 ByteSize:172} RaftTruncatedState:{Index:103 Term:22}
 >> truncate all
 Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): 
 Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): 
-Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:105 term:22 
-State:{LastIndex:105 LastTerm:22 ByteSize:0} RaftTruncatedState:{Index:105 Term:22}
+Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:106 (0x0169f67b757266746c000000000000006a00): 
+Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:107 (0x0169f67b757266746c000000000000006b00): 
+Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:107 term:22 
+State:{LastIndex:107 LastTerm:22 ByteSize:0} RaftTruncatedState:{Index:107 Term:22}

--- a/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=true
+++ b/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=true
@@ -19,14 +19,24 @@ Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c00000000
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): Term:22 Index:104 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): Term:22 Index:105 Type:EntryNormal : EMPTY
 State:{LastIndex:105 LastTerm:22 ByteSize:215} RaftTruncatedState:{Index:100 Term:20}
+>> append (103,107] with overlap extending past tail
+Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): 
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): Term:22 Index:104 Type:EntryNormal : EMPTY
+Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): 
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): Term:22 Index:105 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:106 (0x0169f67b757266746c000000000000006a00): Term:22 Index:106 Type:EntryNormal : EMPTY
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:107 (0x0169f67b757266746c000000000000006b00): Term:22 Index:107 Type:EntryNormal : EMPTY
+State:{LastIndex:107 LastTerm:22 ByteSize:301} RaftTruncatedState:{Index:100 Term:20}
 >> truncate at 103
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:101 (0x0169f67b757266746c000000000000006500): 
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:102 (0x0169f67b757266746c000000000000006600): 
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): 
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:103 term:22 
-State:{LastIndex:105 LastTerm:22 ByteSize:86} RaftTruncatedState:{Index:103 Term:22}
+State:{LastIndex:107 LastTerm:22 ByteSize:172} RaftTruncatedState:{Index:103 Term:22}
 >> truncate all
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): 
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): 
-Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:105 term:22 
-State:{LastIndex:105 LastTerm:22 ByteSize:0} RaftTruncatedState:{Index:105 Term:22}
+Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:106 (0x0169f67b757266746c000000000000006a00): 
+Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:107 (0x0169f67b757266746c000000000000006b00): 
+Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:107 term:22 
+State:{LastIndex:107 LastTerm:22 ByteSize:0} RaftTruncatedState:{Index:107 Term:22}

--- a/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=true
+++ b/pkg/kv/kvserver/logstore/testdata/TestRaftStorageWrites/single_delete=true
@@ -11,8 +11,8 @@ State:{LastIndex:103 LastTerm:21 ByteSize:129} RaftTruncatedState:{Index:100 Ter
 >> append (101,102] with overlap
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:22 vote:0 commit:100 lead:0 lead_epoch:0 
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:102 (0x0169f67b757266746c000000000000006600): 
-Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:102 (0x0169f67b757266746c000000000000006600): Term:22 Index:102 Type:EntryNormal : EMPTY
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): 
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:102 (0x0169f67b757266746c000000000000006600): Term:22 Index:102 Type:EntryNormal : EMPTY
 State:{LastIndex:102 LastTerm:22 ByteSize:86} RaftTruncatedState:{Index:100 Term:20}
 >> append (102,105]
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:103 (0x0169f67b757266746c000000000000006700): Term:22 Index:103 Type:EntryNormal : EMPTY
@@ -21,8 +21,8 @@ Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c00000000
 State:{LastIndex:105 LastTerm:22 ByteSize:215} RaftTruncatedState:{Index:100 Term:20}
 >> append (103,107] with overlap extending past tail
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): 
-Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): Term:22 Index:104 Type:EntryNormal : EMPTY
 Single Delete: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): 
+Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:104 (0x0169f67b757266746c000000000000006800): Term:22 Index:104 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:105 (0x0169f67b757266746c000000000000006900): Term:22 Index:105 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:106 (0x0169f67b757266746c000000000000006a00): Term:22 Index:106 Type:EntryNormal : EMPTY
 Put: 0,0 /Local/RangeID/123/u/RaftLog/logIndex:107 (0x0169f67b757266746c000000000000006b00): Term:22 Index:107 Type:EntryNormal : EMPTY


### PR DESCRIPTION
Replace logAppend's per-entry overwrite handling with a single ComputeStats + ClearRangeSizeKnown pair. When the new entries overlap the existing log.

After the clear, the entry loop is unconditional MVCCBlindPut. This replaces the prior code path that opened a new MVCC iterator per overwritten entry.

References: https://github.com/cockroachdb/cockroach/issues/8979

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>