### PR TITLE
logical: block DROP DATABASE CASCADE schema change

### DIFF
--- a/pkg/crosscluster/logical/ldrdecoder/row_decoder.go
+++ b/pkg/crosscluster/logical/ldrdecoder/row_decoder.go
@@ -47,6 +47,9 @@ func newTableDecoder(
 			if err != nil {
 				return err
 			}
+			if descriptor == nil {
+				return catalog.NewDescriptorNotFoundError(table.DestID)
+			}
 
 			columns := sqlwriter.GetColumnSchema(descriptor)
 			columnNames := make([]string, 0, len(columns))

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2531,6 +2531,8 @@ func TestLogicalReplicationSchemaChanges(t *testing.T) {
 
 		// Drop table is blocked
 		{"drop table", "DROP TABLE tab", false},
+		// Drop database cascade is blocked.
+		{"drop database cascade", "DROP DATABASE a CASCADE", false},
 
 		// Dissalow storage param updates if is not the only change.
 		{"disable schema locked", "ALTER TABLE tab SET (schema_locked = false)", true},

--- a/pkg/crosscluster/logical/table_batch_handler.go
+++ b/pkg/crosscluster/logical/table_batch_handler.go
@@ -106,7 +106,13 @@ func newTableHandler(
 	err = db.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
 		var err error
 		table, err = txn.Descriptors().GetLeasedImmutableTableByID(ctx, txn.KV(), tableID)
-		return err
+		if err != nil {
+			return err
+		}
+		if table == nil {
+			return catalog.NewDescriptorNotFoundError(tableID)
+		}
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_logical_replication
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_logical_replication
@@ -45,3 +45,23 @@ CREATE INDEX idx ON t(y)
 
 statement ok
 DROP INDEX idx
+
+# Clean up the job; test harness uses DROP CASCADE which is not allowed.
+statement ok
+SELECT
+	crdb_internal.unsafe_upsert_descriptor(
+		d.id,
+		crdb_internal.json_to_pb(
+			'cockroach.sql.sqlbase.Descriptor',
+			json_set(
+				crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', d.descriptor),
+				ARRAY['table', 'ldrJobIds'],
+				'[]'::JSONB
+			)
+		),
+		true
+	)
+FROM
+	system.descriptor AS d INNER JOIN system.namespace AS ns ON d.id = ns.id
+WHERE
+	name = 't'

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -181,6 +181,10 @@ func dropCascadeDescriptor(b BuildCtx, id catid.DescID) {
 			if t.IsTemporary {
 				panic(scerrors.NotImplementedErrorf(nil, "dropping a temporary table"))
 			}
+			if ldrJobIDs := undropped.FilterLDRJobIDs().MustGetZeroOrOneElement(); ldrJobIDs != nil && len(ldrJobIDs.JobIDs) > 0 {
+				ns := undropped.FilterNamespace().MustGetOneElement()
+				panic(sqlerrors.NewDisallowedSchemaChangeOnLDRTableErr(ns.Name, ldrJobIDs.JobIDs))
+			}
 		case *scpb.Sequence:
 			if t.IsTemporary {
 				panic(scerrors.NotImplementedErrorf(nil, "dropping a temporary sequence"))


### PR DESCRIPTION
Similar to how we block DROP TABLE, we now also block DROP DATABASE CASCADE. This change also checks in LDR that the descriptor returned by GetLeasedImmutableTableByID is not nil before using it, as the contract of the function expects us to do so.

The above two combined previously caused us to be able to drop the database, which would cause GetLeasedImmutableTableByID to return nil and panic our cluster.

Fixes: none
Epic: none
Release note: none