### PR TITLE
release-26.2: roachtest: reduce index backfill tests from nightly to weekly

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -40,7 +40,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		// causing the bandwidth lower-bound check to flake.
 		// See: https://github.com/cockroachdb/cockroach/issues/167455
 		CompatibleClouds: registry.AllExceptAzure.NoIBM(),
-		Suites:           registry.Suites(registry.Nightly),
+		Suites:           registry.Suites(registry.Weekly),
 		// TODO(darryl): Enable FIPS once we can upgrade to Ubuntu 22 and use cgroups v2 for disk stalls.
 		Cluster: r.MakeClusterSpec(
 			2,

--- a/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_single_node_index_backfill.go
@@ -69,7 +69,7 @@ func registerSingleNodeIndexBackfill(r registry.Registry) {
 			Timeout:          12 * time.Hour,
 			Benchmark:        true,
 			CompatibleClouds: registry.OnlyGCE,
-			Suites:           registry.Suites(registry.Nightly),
+			Suites:           registry.Suites(registry.Weekly),
 			Cluster: r.MakeClusterSpec(
 				2, // 1 CRDB node + 1 workload node
 				// 16vCPUs so that CPU is not the bottleneck.


### PR DESCRIPTION
Backport 1/1 commits from #170543 on behalf of @angeladietz.

----

These tests have been fairly stable for a couple months, and disk bandwidth AC is not undergoing active code changes, so moving from the nightly to weekly test suites. This should also help lower the rate of infra flakes on these tests.

Epic: none
Release note: none

----

Release justification: