### PR TITLE
opt: add HasConstraint, HasLimit, and JoinType PlanGram field matching

### DIFF
--- a/pkg/sql/opt/memo/plangram.go
+++ b/pkg/sql/opt/memo/plangram.go
@@ -6,26 +6,46 @@
 package memo
 
 import (
+	"strconv"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
+	"github.com/cockroachdb/errors"
 )
+
+// scanConstraintFields returns the HasConstraint and HasLimit fields for a
+// ScanPrivate.
+func scanConstraintFields(sp *ScanPrivate) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{
+			Key: "HasConstraint",
+			Val: strconv.FormatBool(
+				(sp.Constraint != nil && !sp.Constraint.IsUnconstrained()) ||
+					sp.InvertedConstraint != nil,
+			),
+		},
+		{Key: "HasLimit", Val: strconv.FormatBool(sp.HardLimit.IsSet())},
+	}
+}
 
 // PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
 func (e *ScanExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
 	tab := md.Table(e.Table)
-	return []physical.PlanGramField{
+	fields := []physical.PlanGramField{
 		{Key: "Table", Val: string(tab.Name())},
 		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
 	}
+	return append(fields, scanConstraintFields(&e.ScanPrivate)...)
 }
 
 // PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
 func (e *PlaceholderScanExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
 	tab := md.Table(e.Table)
-	return []physical.PlanGramField{
+	fields := []physical.PlanGramField{
 		{Key: "Table", Val: string(tab.Name())},
 		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
 	}
+	return append(fields, scanConstraintFields(&e.ScanPrivate)...)
 }
 
 // PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
@@ -43,6 +63,7 @@ func (e *LookupJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.Pl
 	return []physical.PlanGramField{
 		{Key: "Table", Val: string(tab.Name())},
 		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+		{Key: "JoinType", Val: joinTypeFieldVal(e.JoinType)},
 	}
 }
 
@@ -52,6 +73,7 @@ func (e *InvertedJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.
 	return []physical.PlanGramField{
 		{Key: "Table", Val: string(tab.Name())},
 		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+		{Key: "JoinType", Val: joinTypeFieldVal(e.JoinType)},
 	}
 }
 
@@ -64,6 +86,7 @@ func (e *ZigzagJoinExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.Pl
 		{Key: "RightTable", Val: string(rightTab.Name())},
 		{Key: "LeftIndex", Val: string(leftTab.Index(e.LeftIndex).Name())},
 		{Key: "RightIndex", Val: string(rightTab.Index(e.RightIndex).Name())},
+		{Key: "JoinType", Val: joinTypeFieldVal(opt.InnerJoinOp)},
 	}
 }
 
@@ -73,6 +96,13 @@ func (e *VectorSearchExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.
 	return []physical.PlanGramField{
 		{Key: "Table", Val: string(tab.Name())},
 		{Key: "Index", Val: string(tab.Index(e.Index).Name())},
+		{
+			Key: "HasConstraint",
+			Val: strconv.FormatBool(
+				e.PrefixConstraint != nil && !e.PrefixConstraint.IsUnconstrained(),
+			),
+		},
+		{Key: "HasLimit", Val: "true"},
 	}
 }
 
@@ -119,5 +149,102 @@ func (e *DeleteExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGr
 func (e *LockExpr) PlanGramMatchableFields(md *opt.Metadata) []physical.PlanGramField {
 	return []physical.PlanGramField{
 		{Key: "Table", Val: string(md.Table(e.Table).Name())},
+	}
+}
+
+// joinTypeFieldVal returns the short lowercase name for a join operator.
+func joinTypeFieldVal(op opt.Operator) string {
+	switch op {
+	case opt.InnerJoinOp, opt.InnerJoinApplyOp:
+		return "inner"
+	case opt.LeftJoinOp, opt.LeftJoinApplyOp:
+		return "left"
+	case opt.RightJoinOp:
+		return "right"
+	case opt.FullJoinOp:
+		return "full"
+	case opt.SemiJoinOp, opt.SemiJoinApplyOp:
+		return "semi"
+	case opt.AntiJoinOp, opt.AntiJoinApplyOp:
+		return "anti"
+	default:
+		panic(errors.AssertionFailedf("unexpected join operator %s", op))
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *MergeJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: joinTypeFieldVal(e.JoinType)},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *InnerJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "inner"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *LeftJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "left"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *RightJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "right"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *FullJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "full"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *SemiJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "semi"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *AntiJoinExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "anti"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *InnerJoinApplyExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "inner"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *LeftJoinApplyExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "left"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *SemiJoinApplyExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "semi"},
+	}
+}
+
+// PlanGramMatchableFields implements physical.PlanGramFieldMatchableExpr.
+func (e *AntiJoinApplyExpr) PlanGramMatchableFields(*opt.Metadata) []physical.PlanGramField {
+	return []physical.PlanGramField{
+		{Key: "JoinType", Val: "anti"},
 	}
 }

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -686,12 +686,26 @@ func (p PlanGram) Matches(e opt.Expr, md *opt.Metadata) bool {
 }
 
 func containsPlanGramField(fields []PlanGramField, f PlanGramField) bool {
+	ci := caseInsensitivePlanGramField(f.Key)
 	for _, ef := range fields {
-		if ef.Key == f.Key && ef.Val == f.Val {
+		if ef.Key == f.Key &&
+			(ci && strings.EqualFold(ef.Val, f.Val) || !ci && ef.Val == f.Val) {
 			return true
 		}
 	}
 	return false
+}
+
+// caseInsensitivePlanGramField returns true for field keys whose values should
+// be matched case-insensitively (e.g. boolean and enum fields). Table and Index
+// names remain exact-match because quoted identifiers can be case-sensitive.
+func caseInsensitivePlanGramField(key string) bool {
+	switch key {
+	case "JoinType", "HasConstraint", "HasLimit":
+		return true
+	default:
+		return false
+	}
 }
 
 // Child returns the PlanGram for the nth child of this term. If this PlanGram

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -283,6 +283,38 @@ func TestPlanGramMatches(t *testing.T) {
 			{Key: "Index", Val: "abc_b_idx"},
 		},
 	}
+	scanWithConstraint := &mockFieldExpr{
+		mockExpr: mockExpr{op: opt.ScanOp},
+		fields: []PlanGramField{
+			{Key: "Table", Val: "abc"},
+			{Key: "Index", Val: "abc_b_idx"},
+			{Key: "HasConstraint", Val: "true"},
+			{Key: "HasLimit", Val: "false"},
+		},
+	}
+	scanWithLimit := &mockFieldExpr{
+		mockExpr: mockExpr{op: opt.ScanOp},
+		fields: []PlanGramField{
+			{Key: "Table", Val: "abc"},
+			{Key: "Index", Val: "abc_b_idx"},
+			{Key: "HasConstraint", Val: "false"},
+			{Key: "HasLimit", Val: "true"},
+		},
+	}
+	innerJoinWithType := &mockFieldExpr{
+		mockExpr: mockExpr{op: opt.InnerJoinOp, children: []opt.Expr{scanExpr, scanExpr}},
+		fields: []PlanGramField{
+			{Key: "JoinType", Val: "inner"},
+		},
+	}
+	lookupJoinWithType := &mockFieldExpr{
+		mockExpr: mockExpr{op: opt.LookupJoinOp, children: []opt.Expr{scanExpr}},
+		fields: []PlanGramField{
+			{Key: "Table", Val: "abc"},
+			{Key: "Index", Val: "abc_pkey"},
+			{Key: "JoinType", Val: "left"},
+		},
+	}
 
 	tests := []struct {
 		name     string
@@ -395,6 +427,102 @@ func TestPlanGramMatches(t *testing.T) {
 			pg:       PlanGram{root: &planGramExpr{op: opt.ScanOp}},
 			expr:     scanWithFields,
 			expected: true,
+		},
+		{
+			name: "HasConstraint match true",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "HasConstraint", Val: "true"}},
+			}},
+			expr:     scanWithConstraint,
+			expected: true,
+		},
+		{
+			name: "HasConstraint mismatch",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "HasConstraint", Val: "true"}},
+			}},
+			expr:     scanWithLimit,
+			expected: false,
+		},
+		{
+			name: "HasLimit match true",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "HasLimit", Val: "true"}},
+			}},
+			expr:     scanWithLimit,
+			expected: true,
+		},
+		{
+			name: "HasLimit mismatch",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "HasLimit", Val: "true"}},
+			}},
+			expr:     scanWithConstraint,
+			expected: false,
+		},
+		{
+			name: "JoinType match",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.InnerJoinOp,
+				fields: []PlanGramField{{Key: "JoinType", Val: "inner"}},
+			}},
+			expr:     innerJoinWithType,
+			expected: true,
+		},
+		{
+			name: "JoinType mismatch",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.InnerJoinOp,
+				fields: []PlanGramField{{Key: "JoinType", Val: "left"}},
+			}},
+			expr:     innerJoinWithType,
+			expected: false,
+		},
+		{
+			name: "JoinType case-insensitive match",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.InnerJoinOp,
+				fields: []PlanGramField{{Key: "JoinType", Val: "Inner"}},
+			}},
+			expr:     innerJoinWithType,
+			expected: true,
+		},
+		{
+			name: "HasConstraint case-insensitive match",
+			pg: PlanGram{root: &planGramExpr{
+				op:     opt.ScanOp,
+				fields: []PlanGramField{{Key: "HasConstraint", Val: "True"}},
+			}},
+			expr:     scanWithConstraint,
+			expected: true,
+		},
+		{
+			name: "combined Table + JoinType match",
+			pg: PlanGram{root: &planGramExpr{
+				op: opt.LookupJoinOp,
+				fields: []PlanGramField{
+					{Key: "Table", Val: "abc"},
+					{Key: "JoinType", Val: "left"},
+				},
+			}},
+			expr:     lookupJoinWithType,
+			expected: true,
+		},
+		{
+			name: "combined Table match + JoinType mismatch",
+			pg: PlanGram{root: &planGramExpr{
+				op: opt.LookupJoinOp,
+				fields: []PlanGramField{
+					{Key: "Table", Val: "abc"},
+					{Key: "JoinType", Val: "inner"},
+				},
+			}},
+			expr:     lookupJoinWithType,
+			expected: false,
 		},
 	}
 

--- a/pkg/sql/opt/xform/testdata/physprops/plangram
+++ b/pkg/sql/opt/xform/testdata/physprops/plangram
@@ -1888,3 +1888,320 @@ top-k
       │    └── filters (true)
       └── projections
            └── v:2 <-> '[1,2,3]' [as=column5:5, outer=(2), immutable]
+
+# HasConstraint — true on constrained scan.
+
+opt format=show-cost plangram=(root: (Select (IndexJoin (Scan HasConstraint="true")));)
+SELECT * FROM abc WHERE b = 1 AND c > 0
+----
+select
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cost: 89.0700007
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 88.9400007
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3)
+ │    └── scan abc@abc_b_idx
+ │         ├── columns: a:1!null b:2!null
+ │         ├── constraint: /2/1: [/1 - /1]
+ │         ├── cost: 28.4200001
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: ()-->(2)
+ └── filters
+      └── c:3 > 0 [outer=(3)]
+
+# HasConstraint — false on unconstrained scan.
+
+opt format=show-cost plangram=(root: (Scan HasConstraint="false");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# HasConstraint — mismatch (expect true, but scan is unconstrained).
+
+opt format=show-cost plangram=(root: (Scan HasConstraint="true");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# HasLimit — true on limited scan.
+
+opt format=show-cost plangram=(root: (Scan HasLimit="true");)
+SELECT * FROM abc LIMIT 5
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── limit: 5
+ ├── cost: 13.31
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# HasLimit — false on unlimited scan.
+
+opt format=show-cost plangram=(root: (Scan HasLimit="false");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# HasLimit — mismatch (expect true, but scan has no limit).
+
+opt format=show-cost plangram=(root: (Scan HasLimit="true");)
+SELECT * FROM abc
+----
+scan abc
+ ├── columns: a:1!null b:2 c:3
+ ├── cost: 1088.62
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# LookupJoin — JoinType match (inner).
+
+opt format=show-cost plangram=(root: (LookupJoin JoinType="inner" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (lookup abc)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── key columns: [6] = [1]
+ ├── lookup columns are key
+ ├── cost: 7142.44
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+# LookupJoin — JoinType mismatch (expect left, but it's inner).
+
+opt format=show-cost plangram=(root: (LookupJoin JoinType="left" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (merge)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── left ordering: +1
+ ├── right ordering: +6
+ ├── cost: 2187.06
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── filters (true)
+
+# MergeJoin — JoinType match (inner).
+
+opt format=show-cost plangram=(root: (MergeJoin JoinType="inner" (Scan) (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (merge)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── left ordering: +1
+ ├── right ordering: +6
+ ├── cost: 2187.06
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── filters (true)
+
+# InnerJoin — JoinType match (inner).
+
+opt format=show-cost plangram=(root: (InnerJoin JoinType="inner" (Scan) (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (hash)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── cost: 2197.20625
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── a:1 = x:6 [outer=(1,6), fd=(1)==(6), (6)==(1)]
+
+# InnerJoin — JoinType mismatch (inner with left expected).
+
+opt format=show-cost plangram=(root: (InnerJoin JoinType="left" (Scan) (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (merge)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── left ordering: +1
+ ├── right ordering: +6
+ ├── cost: 2187.06
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── filters (true)
+
+# ZigzagJoin — JoinType match (inner, hard-coded).
+
+opt format=show-cost plangram=(root: (ZigzagJoin JoinType="inner");)
+SELECT * FROM abc WHERE b = 1 AND c = 1
+----
+inner-join (zigzag abc@abc_b_idx abc@abc_c_idx)
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── eq columns: [1] = [1]
+ ├── left fixed columns: [2] = [1]
+ ├── right fixed columns: [3] = [1]
+ ├── cost: 30.14
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── filters
+      ├── b:2 = 1 [outer=(2), fd=()-->(2)]
+      └── c:3 = 1 [outer=(3), fd=()-->(3)]
+
+# LookupJoin — combined Table + JoinType match.
+
+opt format=show-cost plangram=(root: (LookupJoin Table="abc" JoinType="inner" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (lookup abc)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── key columns: [6] = [1]
+ ├── lookup columns are key
+ ├── cost: 7142.44
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters (true)
+
+# LookupJoin — Table match + JoinType mismatch.
+
+opt format=show-cost plangram=(root: (LookupJoin Table="abc" JoinType="left" (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (merge)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── left ordering: +1
+ ├── right ordering: +6
+ ├── cost: 2187.06
+ ├── cost-flags: plangram-mismatch unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── ordering: +1
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: plangram-mismatch unbounded-cardinality
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    └── ordering: +6
+ └── filters (true)
+
+# JoinType — case-insensitive match.
+
+opt format=show-cost plangram=(root: (InnerJoin JoinType="Inner" (Scan) (Scan));)
+SELECT * FROM abc, xy WHERE a = x
+----
+inner-join (hash)
+ ├── columns: a:1!null b:2 c:3 x:6!null y:7
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── cost: 2197.20625
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (6)
+ ├── fd: (1)-->(2,3), (6)-->(7), (1)==(6), (6)==(1)
+ ├── scan abc
+ │    ├── columns: a:1!null b:2 c:3
+ │    ├── cost: 1088.62
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ ├── scan xy
+ │    ├── columns: x:6!null y:7
+ │    ├── cost: 1068.42
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── a:1 = x:6 [outer=(1,6), fd=(1)==(6), (6)==(1)]


### PR DESCRIPTION
Extend PlanGram field matching with three new fields to improve plan gist matching fidelity:

- HasConstraint (boolean): true if the scan has a constraint or inverted constraint. Supported on ScanExpr, PlaceholderScanExpr, and VectorSearchExpr.
- HasLimit (boolean): true if the scan has a hard limit set. Supported on ScanExpr, PlaceholderScanExpr, and VectorSearchExpr (always true).
- JoinType (enum): the short lowercase join type name (inner, left, right, full, semi, anti). Supported on all join expression types including hash, merge, lookup, inverted, zigzag, index, and apply joins. Hard-coded for some joins (e.g. always "left" for LeftJoin).

Boolean and enum field values (HasConstraint, HasLimit, JoinType) are matched case-insensitively, while Table and Index names remain exact-match to respect quoted identifiers.

Informs: #152053

Release note: None