### PR TITLE
release-26.2: kvserver: deflake TestStoreRangeSplitBackpressureWrites

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1584,7 +1584,16 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var activateSplitFilter int32
 			splitKey := roachpb.RKey(bootstrap.TestingUserTableDataMin(keys.SystemSQLCodec))
-			splitPending, blockSplits := make(chan struct{}), make(chan struct{})
+			// splitPending is buffered so the request filter doesn't block
+			// indefinitely if the test fails before reading the signal.
+			splitPending, blockSplits := make(chan struct{}, 1), make(chan struct{})
+			// backpressureRegistered receives one signal per write that
+			// successfully registered a backpressure callback with the split
+			// queue. This lets the test wait until both writes are registered
+			// before unblocking the split, avoiding a time-based coordination
+			// race on slow hardware (e.g. s390x). Buffered so the knob never
+			// blocks if the test stops listening early.
+			backpressureRegistered := make(chan roachpb.RangeID, 8)
 
 			// Set maxBytes to something small so we can exceed the maximum split
 			// size without adding 2x64MB of data.
@@ -1626,6 +1635,12 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 						DisableMergeQueue:              true,
 						DisableSplitQueue:              true,
 						TestingRequestFilter:           testingRequestFilter,
+						TestingBackpressureCallbackRegistered: func(id roachpb.RangeID) {
+							select {
+							case backpressureRegistered <- id:
+							default:
+							}
+						},
 					},
 				},
 			})
@@ -1664,7 +1679,11 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				}); err != nil {
 					t.Fatal(err)
 				}
-				<-splitPending
+				select {
+				case <-splitPending:
+				case <-time.After(testutils.DefaultSucceedsSoonDuration):
+					t.Fatal("timed out waiting for split filter to trigger")
+				}
 			} else if tc.splitImpossible {
 				store.TestingSetSplitQueueActive(true)
 				if err := store.ForceSplitScanAndProcess(); err != nil {
@@ -1701,17 +1720,29 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				})
 			}()
 
-			// Make sure the write doesn't return while a split is ongoing. If no
-			// split is ongoing, the write will return an error immediately.
+			// Wait for both writes to register a backpressure callback before
+			// unblocking the split. This ensures both writes will observe the
+			// split's outcome via their registered callbacks, avoiding a race
+			// where the split completes (and removes the range from the split
+			// queue's tracked replicas) before a slow goroutine calls
+			// MaybeAddCallback. While waiting, also fail fast if either write
+			// returns prematurely.
 			if tc.splitOngoing {
-				select {
-				case err := <-putRes:
-					close(blockSplits)
-					t.Fatalf("put was not blocked on split, returned err %v", err)
-				case err := <-delRes:
-					close(blockSplits)
-					t.Fatalf("delete was not blocked on split, returned err %v", err)
-				case <-time.After(100 * time.Millisecond):
+				timeout := time.After(testutils.DefaultSucceedsSoonDuration)
+				for registered := 0; registered < 2; {
+					select {
+					case err := <-putRes:
+						close(blockSplits)
+						t.Fatalf("put was not blocked on split, returned err %v", err)
+					case err := <-delRes:
+						close(blockSplits)
+						t.Fatalf("delete was not blocked on split, returned err %v", err)
+					case <-backpressureRegistered:
+						registered++
+					case <-timeout:
+						close(blockSplits)
+						t.Fatalf("timed out waiting for backpressure callbacks to register (got %d/2)", registered)
+					}
 				}
 
 				// Let split through. Write should follow.
@@ -1723,7 +1754,13 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 				"put":    putRes,
 				"delete": delRes,
 			} {
-				if err := <-resCh; tc.expErr == "" {
+				var err error
+				select {
+				case err = <-resCh:
+				case <-time.After(testutils.DefaultSucceedsSoonDuration):
+					t.Fatalf("timed out waiting for %s to return", op)
+				}
+				if tc.expErr == "" {
 					if err != nil {
 						t.Fatalf("%s returned err %v, expected success", op, err)
 					}

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -241,6 +241,10 @@ func (r *Replica) maybeBackpressureBatch(ctx context.Context, ba *kvpb.BatchRequ
 			return nil
 		}
 
+		if knobs := r.store.TestingKnobs(); knobs != nil && knobs.TestingBackpressureCallbackRegistered != nil {
+			knobs.TestingBackpressureCallbackRegistered(r.RangeID)
+		}
+
 		const errHint = `For help understanding this error and troubleshooting, visit:
 
     https://www.cockroachlabs.com/docs/stable/common-errors.html#split-failed-while-applying-backpressure-are-rows-updated-in-a-tight-loop`

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -65,6 +65,14 @@ type StoreTestingKnobs struct {
 	// handled and the batch is retried.
 	TestingConcurrencyRetryFilter kvserverbase.ReplicaConcurrencyRetryFilter
 
+	// TestingBackpressureCallbackRegistered, if set, is called from
+	// (*Replica).maybeBackpressureBatch after a backpressure callback has been
+	// successfully registered with the split queue. Tests use this to
+	// deterministically learn that a backpressured write is waiting on the
+	// callback (and thus will observe the split's outcome), which avoids
+	// time-based coordination on slow hardware.
+	TestingBackpressureCallbackRegistered func(roachpb.RangeID)
+
 	// TestingProposalFilter is called before proposing each command.
 	TestingProposalFilter kvserverbase.ReplicaProposalFilter
 	// TestingProposalSubmitFilter can be used by tests to observe and optionally


### PR DESCRIPTION
Backport 1/1 commits from #170478 on behalf of @tbg.

----

`TestStoreRangeSplitBackpressureWrites` has been flaking on slow hardware
(s390x) for some time. The `splitOngoing=true,splitErr=true` subtest fails
when a write returns `nil` instead of the expected
`split failed while applying backpressure ... boom` error.

The root cause is a race between two concurrent paths:

1. The test issues a Put and a Del in goroutines, then waits 100ms before
   closing `blockSplits` to unblock the (filter-injected) failing split.
2. Each write executes `maybeBackpressureBatch`, which calls
   `(*splitQueue).MaybeAddCallback` to register a callback that fires when
   the in-progress split completes (so the write can be failed with the
   split's error).
3. `finishProcessingReplica` removes the range from `bq.mu.replicas`
   *before* invoking registered callbacks. If a write goroutine is slow to
   reach `MaybeAddCallback`, the split may have already completed and
   removed the range, in which case `MaybeAddCallback` returns false and
   the write proceeds with a `nil` error.

Reproduced locally by sleeping 250ms in the test goroutines before
issuing the writes: the affected subtest then failed reliably (3/3).

The fix replaces the 100ms time-based coordination with an explicit
testing knob (`TestingBackpressureCallbackRegistered`) that fires from
`maybeBackpressureBatch` after `MaybeAddCallback` returns true. The test
installs the knob and waits for two registrations before unblocking the
split. This deterministically guarantees both writes are registered to
observe the split's outcome, regardless of goroutine scheduling.

While here, harden the test's channel-based coordination against missed
events: waits on `splitPending`, the registration loop, and the final
write results are now bounded by a 45s timeout that fails with a
diagnostic message rather than hanging until the Go test timeout, and
`splitPending` is given a buffer of 1 so the request filter doesn't
deadlock if the test fatals early.

Verified: passes under the 250ms-sleep repro (5/5) and under
`--stress --count=200` without the sleep (200/200).

Fixes #170321

Epic: none

Release note: None

----

Release justification: Test-only deflake; production code paths add a testing knob that only fires when set by tests.
