### PR TITLE
roachtest: log artifact failover to runner logs

### DIFF
--- a/pkg/cmd/roachtest/teamcity_artifacts.go
+++ b/pkg/cmd/roachtest/teamcity_artifacts.go
@@ -52,7 +52,7 @@ type artifactUploader func(ctx context.Context, bucket, object, filePath string)
 // archive is uploaded to GCS instead, and the local artifacts.zip is replaced
 // with a small marker archive that contains the artifact's GCS URI.
 func publishTeamCityArtifactsWithFailover(
-	ctx context.Context, t *testImpl, l *logger.Logger, stdout io.Writer,
+	ctx context.Context, t *testImpl, runnerL *logger.Logger, stdout io.Writer,
 ) {
 	publishTeamCityArtifacts := func() {
 		// Tell TeamCity to collect this test's artifacts now. The TC job
@@ -61,18 +61,18 @@ func publishTeamCityArtifactsWithFailover(
 		// finished are available in the UI even before the job as a whole
 		// has completed. We're using the exact same destination to avoid
 		// duplication of any of the artifacts.
-		shout(ctx, l, stdout, "##teamcity[publishArtifacts '%s']", t.artifactsSpec)
+		shout(ctx, runnerL, stdout, "##teamcity[publishArtifacts '%s']", t.artifactsSpec)
 	}
 
 	artifactsZipSizeBytes, err := artifactsZipSize(t)
 	if err != nil {
-		shout(ctx, l, stdout, "unable to check roachtest artifacts for failover: %s", err)
+		runnerL.PrintfCtx(ctx, "unable to check roachtest artifacts for failover for test %q: %s", t.Name(), err)
 	}
 	artifactFailoverMaxBytes, maxBytesErr := roachtestArtifactFailoverMaxBytes()
 	if maxBytesErr != nil {
-		shout(ctx, l, stdout,
-			"unable to parse roachtest artifact failover max bytes; using default %d bytes: %s",
-			teamCityMaxArtifactFileSizeBytes, maxBytesErr)
+		runnerL.PrintfCtx(ctx,
+			"unable to parse roachtest artifact failover max bytes for test %q; using default %d bytes: %s",
+			t.Name(), teamCityMaxArtifactFileSizeBytes, maxBytesErr)
 	}
 	if err != nil || artifactsZipSizeBytes < artifactFailoverMaxBytes {
 		// Publish the artifacts directory without failover.
@@ -80,30 +80,30 @@ func publishTeamCityArtifactsWithFailover(
 		return
 	}
 
-	shout(ctx, l, stdout,
-		"roachtest artifacts failover uploading oversized %s (%d bytes) to GCS bucket %s",
-		artifactsZipName, artifactsZipSizeBytes, roachtestArtifactFailoverBucket())
+	runnerL.PrintfCtx(ctx,
+		"roachtest artifacts failover uploading oversized %s (%d bytes) for test %q to GCS bucket %s",
+		artifactsZipName, artifactsZipSizeBytes, t.Name(), roachtestArtifactFailoverBucket())
 	uploadStart := timeutil.Now()
 	failover, err := failoverOversizedArtifactsZip(ctx, t, artifactsZipSizeBytes)
 	uploadDuration := timeutil.Since(uploadStart)
 	if err != nil {
-		shout(ctx, l, stdout,
-			"roachtest artifacts failover failed after %.2fs for oversized %s (%d bytes): %s; "+
+		runnerL.PrintfCtx(ctx,
+			"roachtest artifacts failover failed after %.2fs for oversized %s (%d bytes) for test %q: %s; "+
 				"skipping TeamCity artifact publish for %s to avoid exceeding the TeamCity artifact file size limit",
-			uploadDuration.Seconds(), artifactsZipName, failover.sizeBytes, err, t.artifactsSpec)
+			uploadDuration.Seconds(), artifactsZipName, failover.sizeBytes, t.Name(), err, t.artifactsSpec)
 		return
 	}
 	if err := replaceArtifactsZipWithFailoverMarker(t, failover); err != nil {
-		shout(ctx, l, stdout,
-			"roachtest artifacts failover uploaded oversized %s (%d bytes) to %s in %.2fs, but failed to replace the local zip with a marker archive: %s; "+
+		runnerL.PrintfCtx(ctx,
+			"roachtest artifacts failover uploaded oversized %s (%d bytes) for test %q to %s in %.2fs, but failed to replace the local zip with a marker archive: %s; "+
 				"skipping TeamCity artifact publish for %s to avoid exceeding the TeamCity artifact file size limit",
-			artifactsZipName, failover.sizeBytes, failover.gcsURI, uploadDuration.Seconds(), err, t.artifactsSpec)
+			artifactsZipName, failover.sizeBytes, t.Name(), failover.gcsURI, uploadDuration.Seconds(), err, t.artifactsSpec)
 		return
 	}
 
-	shout(ctx, l, stdout,
-		"roachtest artifacts failover uploaded oversized %s (%d bytes) to %s in %.2fs",
-		artifactsZipName, failover.sizeBytes, failover.gcsURI, uploadDuration.Seconds())
+	runnerL.PrintfCtx(ctx,
+		"roachtest artifacts failover uploaded oversized %s (%d bytes) for test %q to %s in %.2fs",
+		artifactsZipName, failover.sizeBytes, t.Name(), failover.gcsURI, uploadDuration.Seconds())
 	// Publish the artifacts directory with a small artifacts.zip marker
 	// archive pointing to the full archive in GCS.
 	publishTeamCityArtifacts()

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1191,7 +1191,7 @@ func (r *testRunner) runWorker(
 				logTestParameters(testL, getTestParameters(t, c, vmCreateOpts))
 
 				r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL,
-					github, issueInfo)
+					workerL, github, issueInfo)
 			}
 		}
 
@@ -1277,6 +1277,7 @@ func (r *testRunner) runTest(
 	c testCluster,
 	stdout io.Writer,
 	l *logger.Logger,
+	runnerL *logger.Logger,
 	github GithubPoster,
 	issueInfo *githubIssueInfo,
 ) {
@@ -1447,7 +1448,7 @@ func (r *testRunner) runTest(
 			}
 
 			if t.artifactsSpec != "" {
-				publishTeamCityArtifactsWithFailover(ctx, t, l, stdout)
+				publishTeamCityArtifactsWithFailover(ctx, t, runnerL, stdout)
 			}
 		}
 


### PR DESCRIPTION
Previously, artifact upload failover logs were written to per-test logs.
Because failover logic runs after per-test Datadog upload, Datadog
log monitors could not observe failover logs.

In publishTeamCityArtifactsWithFailover, use the runner logger for
failover diagnostics. Runner logs are uploaded to Datadog at the end
of the roachtest run, so log monitors can observe artifact failover
events.

Epic: None