### PR TITLE
sql: support mixed float and int division

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -145,7 +145,9 @@
 <tr><td><a href="decimal.html">decimal</a> <code>/</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>/</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>/</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>/</code> <a href="int.html">int</a></td><td><a href="float.html">float</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>/</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>/</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>/</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>/</code> <a href="float.html">float</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>/</code> <a href="int.html">int</a></td><td><a href="interval.html">interval</a></td></tr>

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -13675,6 +13675,107 @@ func (p projDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 	return batch, nil
 }
 
+type projDivInt16Float64Op struct {
+	projOpBase
+}
+
+func (p projDivInt16Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		projCol := projVec.Float64()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Int16()
+		col2 := vec2.Float64()
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						//gcassert:bce
+						arg1 := col1.Get(i)
+						//gcassert:bce
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg1 := col1.Get(i)
+					//gcassert:bce
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
 type projDivInt16DecimalOp struct {
 	projOpBase
 }
@@ -14196,6 +14297,107 @@ func (p projDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						}
 					}
 
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivInt32Float64Op struct {
+	projOpBase
+}
+
+func (p projDivInt32Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		projCol := projVec.Float64()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Int32()
+		col2 := vec2.Float64()
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						//gcassert:bce
+						arg1 := col1.Get(i)
+						//gcassert:bce
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg1 := col1.Get(i)
+					//gcassert:bce
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
 				}
 			}
 		}
@@ -14731,6 +14933,107 @@ func (p projDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 	return batch, nil
 }
 
+type projDivInt64Float64Op struct {
+	projOpBase
+}
+
+func (p projDivInt64Float64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		projCol := projVec.Float64()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Int64()
+		col2 := vec2.Float64()
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						//gcassert:bce
+						arg1 := col1.Get(i)
+						//gcassert:bce
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg1 := col1.Get(i)
+					//gcassert:bce
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
 type projDivInt64DecimalOp struct {
 	projOpBase
 }
@@ -14877,6 +15180,309 @@ func (p projDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 					}
 
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64Int16Op struct {
+	projOpBase
+}
+
+func (p projDivFloat64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		projCol := projVec.Float64()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Float64()
+		col2 := vec2.Int16()
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						//gcassert:bce
+						arg1 := col1.Get(i)
+						//gcassert:bce
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg1 := col1.Get(i)
+					//gcassert:bce
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64Int32Op struct {
+	projOpBase
+}
+
+func (p projDivFloat64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		projCol := projVec.Float64()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Float64()
+		col2 := vec2.Int32()
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						//gcassert:bce
+						arg1 := col1.Get(i)
+						//gcassert:bce
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg1 := col1.Get(i)
+					//gcassert:bce
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64Int64Op struct {
+	projOpBase
+}
+
+func (p projDivFloat64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		projCol := projVec.Float64()
+		vec1 := batch.ColVec(p.col1Idx)
+		vec2 := batch.ColVec(p.col2Idx)
+		col1 := vec1.Float64()
+		col2 := vec2.Int64()
+		_outNulls := projVec.Nulls()
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
+			col1Nulls := vec1.Nulls()
+			col2Nulls := vec2.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						arg1 := col1.Get(i)
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
+						// We only want to perform the projection operation if both values are not
+						// null.
+						//gcassert:bce
+						arg1 := col1.Get(i)
+						//gcassert:bce
+						arg2 := col2.Get(i)
+
+						{
+							if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg1) / float64(arg2)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg1 := col1.Get(i)
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col1.Get(n - 1)
+				_ = col2.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg1 := col1.Get(i)
+					//gcassert:bce
+					arg2 := col2.Get(i)
+
+					{
+						if arg2 == 0 && !math.IsNaN(float64(arg1)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg1) / float64(arg2)
+					}
 				}
 			}
 		}
@@ -53015,6 +53621,13 @@ func GetProjectionOperator(
 							op := &projDivInt16Int64Op{projOpBase: projOpBase}
 							return op, nil
 						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt16Float64Op{projOpBase: projOpBase}
+							return op, nil
+						}
 					case types.DecimalFamily:
 						switch rightType.Width() {
 						case -1:
@@ -53036,6 +53649,13 @@ func GetProjectionOperator(
 						case -1:
 						default:
 							op := &projDivInt32Int64Op{projOpBase: projOpBase}
+							return op, nil
+						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt32Float64Op{projOpBase: projOpBase}
 							return op, nil
 						}
 					case types.DecimalFamily:
@@ -53062,6 +53682,13 @@ func GetProjectionOperator(
 							op := &projDivInt64Int64Op{projOpBase: projOpBase}
 							return op, nil
 						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt64Float64Op{projOpBase: projOpBase}
+							return op, nil
+						}
 					case types.DecimalFamily:
 						switch rightType.Width() {
 						case -1:
@@ -53076,6 +53703,19 @@ func GetProjectionOperator(
 				case -1:
 				default:
 					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
+					case types.IntFamily:
+						switch rightType.Width() {
+						case 16:
+							op := &projDivFloat64Int16Op{projOpBase: projOpBase}
+							return op, nil
+						case 32:
+							op := &projDivFloat64Int32Op{projOpBase: projOpBase}
+							return op, nil
+						case -1:
+						default:
+							op := &projDivFloat64Int64Op{projOpBase: projOpBase}
+							return op, nil
+						}
 					case types.FloatFamily:
 						switch rightType.Width() {
 						case -1:

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -101,6 +101,82 @@ func TestProjDivFloat64Float64Op(t *testing.T) {
 		})
 }
 
+func TestProjMixedFloatIntDivOps(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
+	flowCtx := &execinfra.FlowCtx{
+		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
+		Cfg: &execinfra.ServerConfig{
+			Settings: st,
+		},
+	}
+	testCases := []struct {
+		name           string
+		input          []colexectestutils.Tuples
+		expected       colexectestutils.Tuples
+		inputTypes     []*types.T
+		projectingExpr string
+	}{
+		{
+			name:           "float-int",
+			input:          []colexectestutils.Tuples{{{8.0, 2}, {9.0, 4}, {nil, 5}, {7.0, nil}}},
+			expected:       colexectestutils.Tuples{{8.0, 2, 4.0}, {9.0, 4, 2.25}, {nil, 5, nil}, {7.0, nil, nil}},
+			inputTypes:     []*types.T{types.Float, types.Int},
+			projectingExpr: "@1 / @2",
+		},
+		{
+			name:           "int-float",
+			input:          []colexectestutils.Tuples{{{8, 2.0}, {9, 4.0}, {nil, 5.0}, {7, nil}}},
+			expected:       colexectestutils.Tuples{{8, 2.0, 4.0}, {9, 4.0, 2.25}, {nil, 5.0, nil}, {7, nil, nil}},
+			inputTypes:     []*types.T{types.Int, types.Float},
+			projectingExpr: "@1 / @2",
+		},
+		{
+			name:           "float-int-const",
+			input:          []colexectestutils.Tuples{{{8.0}, {9.0}, {nil}}},
+			expected:       colexectestutils.Tuples{{8.0, 4.0}, {9.0, 4.5}, {nil, nil}},
+			inputTypes:     []*types.T{types.Float},
+			projectingExpr: "@1 / 2::int",
+		},
+		{
+			name:           "int-float-const",
+			input:          []colexectestutils.Tuples{{{8}, {9}, {nil}}},
+			expected:       colexectestutils.Tuples{{8, 4.0}, {9, 4.5}, {nil, nil}},
+			inputTypes:     []*types.T{types.Int},
+			projectingExpr: "@1 / 2.0::float",
+		},
+		{
+			name:           "float-const-int",
+			input:          []colexectestutils.Tuples{{{2}, {4}, {nil}}},
+			expected:       colexectestutils.Tuples{{2, 4.0}, {4, 2.0}, {nil, nil}},
+			inputTypes:     []*types.T{types.Int},
+			projectingExpr: "8.0::float / @1",
+		},
+		{
+			name:           "int-const-float",
+			input:          []colexectestutils.Tuples{{{2.0}, {4.0}, {nil}}},
+			expected:       colexectestutils.Tuples{{2.0, 4.0}, {4.0, 2.0}, {nil, nil}},
+			inputTypes:     []*types.T{types.Float},
+			projectingExpr: "8::int / @1",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colexectestutils.RunTests(t, testAllocator, tc.input, tc.expected, colexectestutils.OrderedVerifier,
+				func(input []colexecop.Operator) (colexecop.Operator, error) {
+					return colexectestutils.CreateTestProjectingOperator(
+						ctx, flowCtx, input[0], tc.inputTypes, tc.projectingExpr, testMemAcc,
+					)
+				})
+		})
+	}
+}
+
 // TestRandomComparisons runs comparisons against all scalar types with random
 // non-null data verifying that the result of Datum.Compare matches the result
 // of the exec projection.

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -12661,6 +12661,99 @@ func (p projDivInt16ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMe
 	return batch, nil
 }
 
+type projDivInt16ConstFloat64Op struct {
+	projConstOpBase
+	constArg int16
+}
+
+func (p projDivInt16ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Float64s
+	col = vec.Float64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if arg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if arg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if arg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if arg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
 type projDivInt16ConstDecimalOp struct {
 	projConstOpBase
 	constArg int16
@@ -13150,6 +13243,99 @@ func (p projDivInt32ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMe
 						}
 					}
 
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivInt32ConstFloat64Op struct {
+	projConstOpBase
+	constArg int32
+}
+
+func (p projDivInt32ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Float64s
+	col = vec.Float64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if arg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if arg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if arg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if arg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
 				}
 			}
 		}
@@ -13653,6 +13839,99 @@ func (p projDivInt64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMe
 	return batch, nil
 }
 
+type projDivInt64ConstFloat64Op struct {
+	projConstOpBase
+	constArg int64
+}
+
+func (p projDivInt64ConstFloat64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Float64s
+	col = vec.Float64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if arg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if arg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if arg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if arg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
 type projDivInt64ConstDecimalOp struct {
 	projConstOpBase
 	constArg int64
@@ -13791,6 +14070,285 @@ func (p projDivInt64ConstDecimalOp) Next() (coldata.Batch, *execinfrapb.Producer
 
 					}
 
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64ConstInt16Op struct {
+	projConstOpBase
+	constArg float64
+}
+
+func (p projDivFloat64ConstInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Int16s
+	col = vec.Int16()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64ConstInt32Op struct {
+	projConstOpBase
+	constArg float64
+}
+
+func (p projDivFloat64ConstInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Int32s
+	col = vec.Int32()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64ConstInt64Op struct {
+	projConstOpBase
+	constArg float64
+}
+
+func (p projDivFloat64ConstInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Int64s
+	col = vec.Int64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(p.constArg) / float64(arg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if arg == 0 && !math.IsNaN(float64(p.constArg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(p.constArg) / float64(arg)
+					}
 				}
 			}
 		}
@@ -25405,6 +25963,16 @@ func GetProjectionLConstOperator(
 							}
 							return op, nil
 						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt16ConstFloat64Op{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(int16),
+							}
+							return op, nil
+						}
 					case types.DecimalFamily:
 						switch rightType.Width() {
 						case -1:
@@ -25435,6 +26003,16 @@ func GetProjectionLConstOperator(
 						case -1:
 						default:
 							op := &projDivInt32ConstInt64Op{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(int32),
+							}
+							return op, nil
+						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt32ConstFloat64Op{
 								projConstOpBase: projConstOpBase,
 								constArg:        c.(int32),
 							}
@@ -25476,6 +26054,16 @@ func GetProjectionLConstOperator(
 							}
 							return op, nil
 						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt64ConstFloat64Op{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(int64),
+							}
+							return op, nil
+						}
 					case types.DecimalFamily:
 						switch rightType.Width() {
 						case -1:
@@ -25493,6 +26081,28 @@ func GetProjectionLConstOperator(
 				case -1:
 				default:
 					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
+					case types.IntFamily:
+						switch rightType.Width() {
+						case 16:
+							op := &projDivFloat64ConstInt16Op{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(float64),
+							}
+							return op, nil
+						case 32:
+							op := &projDivFloat64ConstInt32Op{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(float64),
+							}
+							return op, nil
+						case -1:
+						default:
+							op := &projDivFloat64ConstInt64Op{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(float64),
+							}
+							return op, nil
+						}
 					case types.FloatFamily:
 						switch rightType.Width() {
 						case -1:

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -12670,6 +12670,99 @@ func (p projDivInt16Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 	return batch, nil
 }
 
+type projDivInt16Float64ConstOp struct {
+	projConstOpBase
+	constArg float64
+}
+
+func (p projDivInt16Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Int16s
+	col = vec.Int16()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
 type projDivInt16DecimalConstOp struct {
 	projConstOpBase
 	constArg apd.Decimal
@@ -13159,6 +13252,99 @@ func (p projDivInt32Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 						}
 					}
 
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivInt32Float64ConstOp struct {
+	projConstOpBase
+	constArg float64
+}
+
+func (p projDivInt32Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Int32s
+	col = vec.Int32()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
 				}
 			}
 		}
@@ -13662,6 +13848,99 @@ func (p projDivInt64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMe
 	return batch, nil
 }
 
+type projDivInt64Float64ConstOp struct {
+	projConstOpBase
+	constArg float64
+}
+
+func (p projDivInt64Float64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Int64s
+	col = vec.Int64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0.0 {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0.0 {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
 type projDivInt64DecimalConstOp struct {
 	projConstOpBase
 	constArg apd.Decimal
@@ -13800,6 +14079,285 @@ func (p projDivInt64DecimalConstOp) Next() (coldata.Batch, *execinfrapb.Producer
 
 					}
 
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64Int16ConstOp struct {
+	projConstOpBase
+	constArg int16
+}
+
+func (p projDivFloat64Int16ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Float64s
+	col = vec.Float64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64Int32ConstOp struct {
+	projConstOpBase
+	constArg int32
+}
+
+func (p projDivFloat64Int32ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Float64s
+	col = vec.Float64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			}
+		}
+	})
+	return batch, nil
+}
+
+type projDivFloat64Int64ConstOp struct {
+	projConstOpBase
+	constArg int64
+}
+
+func (p projDivFloat64Int64ConstOp) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
+	batch, meta := p.Input.Next()
+	if meta != nil {
+		return nil, meta
+	}
+	n := batch.Length()
+	if n == 0 {
+		return coldata.ZeroBatch, nil
+	}
+	vec := batch.ColVec(p.colIdx)
+	var col coldata.Float64s
+	col = vec.Float64()
+	projVec := batch.ColVec(p.outputIdx)
+	p.allocator.PerformOperation([]*coldata.Vec{projVec}, func() {
+		// Capture col to force bounds check to work. See
+		// https://github.com/golang/go/issues/39756
+		col := col
+		projCol := projVec.Float64()
+		_outNulls := projVec.Nulls()
+		if vec.Nulls().MaybeHasNulls() {
+			colNulls := vec.Nulls()
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
+						// We only want to perform the projection operation if the value is not null.
+						//gcassert:bce
+						arg := col.Get(i)
+
+						{
+							if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+								colexecerror.ExpectedError(tree.ErrDivByZero)
+							}
+							projCol[i] = float64(arg) / float64(p.constArg)
+						}
+					}
+				}
+			}
+			projVec.SetNulls(_outNulls.Or(*colNulls))
+		} else {
+			if sel := batch.Selection(); sel != nil {
+				sel = sel[:n]
+				for _, i := range sel {
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
+				}
+			} else {
+				_ = projCol.Get(n - 1)
+				_ = col.Get(n - 1)
+				for i := 0; i < n; i++ {
+					//gcassert:bce
+					arg := col.Get(i)
+
+					{
+						if p.constArg == 0 && !math.IsNaN(float64(arg)) {
+							colexecerror.ExpectedError(tree.ErrDivByZero)
+						}
+						projCol[i] = float64(arg) / float64(p.constArg)
+					}
 				}
 			}
 		}
@@ -50116,6 +50674,16 @@ func GetProjectionRConstOperator(
 							}
 							return op, nil
 						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt16Float64ConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(float64),
+							}
+							return op, nil
+						}
 					case types.DecimalFamily:
 						switch rightType.Width() {
 						case -1:
@@ -50148,6 +50716,16 @@ func GetProjectionRConstOperator(
 							op := &projDivInt32Int64ConstOp{
 								projConstOpBase: projConstOpBase,
 								constArg:        c.(int64),
+							}
+							return op, nil
+						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt32Float64ConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(float64),
 							}
 							return op, nil
 						}
@@ -50187,6 +50765,16 @@ func GetProjectionRConstOperator(
 							}
 							return op, nil
 						}
+					case types.FloatFamily:
+						switch rightType.Width() {
+						case -1:
+						default:
+							op := &projDivInt64Float64ConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(float64),
+							}
+							return op, nil
+						}
 					case types.DecimalFamily:
 						switch rightType.Width() {
 						case -1:
@@ -50204,6 +50792,28 @@ func GetProjectionRConstOperator(
 				case -1:
 				default:
 					switch typeconv.TypeFamilyToCanonicalTypeFamily(rightType.Family()) {
+					case types.IntFamily:
+						switch rightType.Width() {
+						case 16:
+							op := &projDivFloat64Int16ConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(int16),
+							}
+							return op, nil
+						case 32:
+							op := &projDivFloat64Int32ConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(int32),
+							}
+							return op, nil
+						case -1:
+						default:
+							op := &projDivFloat64Int64ConstOp{
+								projConstOpBase: projConstOpBase,
+								constArg:        c.(int64),
+							}
+							return op, nil
+						}
 					case types.FloatFamily:
 						switch rightType.Width() {
 						case -1:

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -136,6 +136,10 @@ func registerBinOpOutputTypes() {
 			binOpOutputTypes[treebin.Div][typePair{types.IntFamily, leftIntWidth, types.IntFamily, rightIntWidth}] = types.Decimal
 		}
 	}
+	for _, intWidth := range supportedWidthsByCanonicalTypeFamily[types.IntFamily] {
+		binOpOutputTypes[treebin.Div][typePair{types.FloatFamily, anyWidth, types.IntFamily, intWidth}] = types.Float
+		binOpOutputTypes[treebin.Div][typePair{types.IntFamily, intWidth, types.FloatFamily, anyWidth}] = types.Float
+	}
 	binOpOutputTypes[treebin.Minus][typePair{types.TimestampTZFamily, anyWidth, types.TimestampTZFamily, anyWidth}] = types.Interval
 	binOpOutputTypes[treebin.Plus][typePair{types.IntervalFamily, anyWidth, types.IntervalFamily, anyWidth}] = types.Interval
 	binOpOutputTypes[treebin.Minus][typePair{types.IntervalFamily, anyWidth, types.IntervalFamily, anyWidth}] = types.Interval
@@ -405,6 +409,44 @@ func (c floatCustomizer) getBinOpAssignFunc() assignFunc {
 			colexecerror.InternalError(err)
 		}
 		return buf.String()
+	}
+}
+
+func (c floatIntCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+		switch op.overloadBase.BinOp {
+		case treebin.Div:
+			return fmt.Sprintf(`
+				{
+					if %[3]s == 0 && !math.IsNaN(float64(%[2]s)) {
+						colexecerror.ExpectedError(tree.ErrDivByZero)
+					}
+					%[1]s = float64(%[2]s) / float64(%[3]s)
+				}`,
+				targetElem, leftElem, rightElem)
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("unhandled binary operator %s", op.overloadBase.BinOp.String()))
+		}
+		return ""
+	}
+}
+
+func (c intFloatCustomizer) getBinOpAssignFunc() assignFunc {
+	return func(op *lastArgWidthOverload, targetElem, leftElem, rightElem, targetCol, leftCol, rightCol string) string {
+		switch op.overloadBase.BinOp {
+		case treebin.Div:
+			return fmt.Sprintf(`
+				{
+					if %[3]s == 0.0 {
+						colexecerror.ExpectedError(tree.ErrDivByZero)
+					}
+					%[1]s = float64(%[2]s) / float64(%[3]s)
+				}`,
+				targetElem, leftElem, rightElem)
+		default:
+			colexecerror.InternalError(errors.AssertionFailedf("unhandled binary operator %s", op.overloadBase.BinOp.String()))
+		}
+		return ""
 	}
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/operator
+++ b/pkg/sql/logictest/testdata/logic_test/operator
@@ -4,6 +4,92 @@ SELECT |/ -1.0::float
 query error cannot take square root of a negative number
 SELECT |/ -1.0::decimal
 
+query RRTT
+SELECT 8::float / 8::int, 8::int / 8::float,
+       pg_typeof(8::float / 8::int), pg_typeof(8::int / 8::float)
+----
+1  1  double precision  double precision
+
+query RRTT
+SELECT 8::float / 8::int4, 8::int4 / 8::float,
+       pg_typeof(8::float / 8::int4), pg_typeof(8::int4 / 8::float)
+----
+1  1  double precision  double precision
+
+
+statement ok
+CREATE TABLE float_int_div (f FLOAT8, i INT8, i4 INT4)
+
+statement ok
+INSERT INTO float_int_div VALUES (8, 8, 8)
+
+query RRTT
+SELECT f / i, i / f, pg_typeof(f / i), pg_typeof(i / f) FROM float_int_div
+----
+1  1  double precision  double precision
+
+query RRTT
+SELECT f / i4, i4 / f, pg_typeof(f / i4), pg_typeof(i4 / f) FROM float_int_div
+----
+1  1  double precision  double precision
+
+statement ok
+CREATE TABLE float_int_div_insert (x FLOAT8)
+
+statement ok
+INSERT INTO float_int_div_insert(x) VALUES (3/2), (1)
+
+query R
+SELECT x FROM float_int_div_insert ORDER BY x
+----
+1
+1.5
+
+statement ok
+PREPARE float_int_div_stmt AS
+  SELECT $1::FLOAT8 / $2::INT8, $2::INT8 / $1::FLOAT8,
+         pg_typeof($1::FLOAT8 / $2::INT8), pg_typeof($2::INT8 / $1::FLOAT8)
+
+query RRTT
+EXECUTE float_int_div_stmt(8, 8)
+----
+1  1  double precision  double precision
+
+statement ok
+DEALLOCATE float_int_div_stmt
+
+statement ok
+SET vectorize = off
+
+query RR
+SELECT f / i, i / f FROM float_int_div
+----
+1  1
+
+statement ok
+SET vectorize = experimental_always
+
+query RR
+SELECT f / i, i / f FROM float_int_div
+----
+1  1
+
+statement ok
+RESET vectorize
+
+query RRRRRR
+SELECT 'NaN'::FLOAT8 / 0::INT8, 'NaN'::FLOAT8 / 0::INT4,
+       'Infinity'::FLOAT8 / 2::INT8, 2::INT8 / 'Infinity'::FLOAT8,
+       NULL::FLOAT8 / 1::INT8, 1::INT8 / NULL::FLOAT8
+----
+NaN  NaN  +Inf  0  NULL  NULL
+
+statement error division by zero
+SELECT 1::FLOAT8 / 0::INT8
+
+statement error division by zero
+SELECT 1::INT8 / 0::FLOAT8
+
 query I
 SELECT ~-1;
 ----

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -436,6 +436,17 @@ func (e *evaluator) EvalDivDecimalIntOp(
 	return dd, err
 }
 
+func (e *evaluator) EvalDivFloatIntOp(
+	ctx context.Context, _ *tree.DivFloatIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
+	l := float64(*left.(*tree.DFloat))
+	r := tree.MustBeDInt(right)
+	if r == 0 && !math.IsNaN(l) {
+		return nil, tree.ErrDivByZero
+	}
+	return tree.NewDFloat(tree.DFloat(l / float64(r))), nil
+}
+
 func (e *evaluator) EvalDivDecimalOp(
 	ctx context.Context, _ *tree.DivDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
@@ -476,6 +487,17 @@ func (e *evaluator) EvalDivIntDecimalOp(
 	dd.SetInt64(int64(l))
 	_, err := tree.DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, r)
 	return dd, err
+}
+
+func (e *evaluator) EvalDivIntFloatOp(
+	ctx context.Context, _ *tree.DivIntFloatOp, left, right tree.Datum,
+) (tree.Datum, error) {
+	l := tree.MustBeDInt(left)
+	r := float64(*right.(*tree.DFloat))
+	if r == 0.0 {
+		return nil, tree.ErrDivByZero
+	}
+	return tree.NewDFloat(tree.DFloat(float64(l) / r)), nil
 }
 
 func (e *evaluator) EvalDivIntOp(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1125,6 +1125,27 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*BinOpOverloads{
 			EvalOp:     &DivIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
+		// Keep the mixed float/integer overloads unpreferred so they are used
+		// for typed operands like 8::FLOAT / 2::INT, but do not win tie-breaks
+		// for untyped constants in a FLOAT context. The existing overload
+		// preference heuristic lets the homogeneous FLOAT overload win without
+		// adding division-specific resolution logic.
+		{
+			LeftType:           types.Float,
+			RightType:          types.Int,
+			ReturnType:         types.Float,
+			EvalOp:             &DivFloatIntOp{},
+			OverloadPreference: OverloadPreferenceUnpreferred,
+			Volatility:         volatility.Immutable,
+		},
+		{
+			LeftType:           types.Int,
+			RightType:          types.Float,
+			ReturnType:         types.Float,
+			EvalOp:             &DivIntFloatOp{},
+			OverloadPreference: OverloadPreferenceUnpreferred,
+			Volatility:         volatility.Immutable,
+		},
 		{
 			LeftType:   types.Interval,
 			RightType:  types.Int,

--- a/pkg/sql/sem/tree/eval_binary_ops.go
+++ b/pkg/sql/sem/tree/eval_binary_ops.go
@@ -276,10 +276,14 @@ type (
 	DivDecimalIntOp struct{}
 	// DivDecimalOp is a BinaryEvalOp.
 	DivDecimalOp struct{}
+	// DivFloatIntOp is a BinaryEvalOp.
+	DivFloatIntOp struct{}
 	// DivFloatOp is a BinaryEvalOp.
 	DivFloatOp struct{}
 	// DivIntDecimalOp is a BinaryEvalOp.
 	DivIntDecimalOp struct{}
+	// DivIntFloatOp is a BinaryEvalOp.
+	DivIntFloatOp struct{}
 	// DivIntOp is a BinaryEvalOp.
 	DivIntOp struct{}
 	// DivIntervalFloatOp is a BinaryEvalOp.

--- a/pkg/sql/sem/tree/eval_op_generated.go
+++ b/pkg/sql/sem/tree/eval_op_generated.go
@@ -80,8 +80,10 @@ type BinaryOpEvaluator interface {
 	EvalDistanceVectorOp(context.Context, *DistanceVectorOp, Datum, Datum) (Datum, error)
 	EvalDivDecimalIntOp(context.Context, *DivDecimalIntOp, Datum, Datum) (Datum, error)
 	EvalDivDecimalOp(context.Context, *DivDecimalOp, Datum, Datum) (Datum, error)
+	EvalDivFloatIntOp(context.Context, *DivFloatIntOp, Datum, Datum) (Datum, error)
 	EvalDivFloatOp(context.Context, *DivFloatOp, Datum, Datum) (Datum, error)
 	EvalDivIntDecimalOp(context.Context, *DivIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalDivIntFloatOp(context.Context, *DivIntFloatOp, Datum, Datum) (Datum, error)
 	EvalDivIntOp(context.Context, *DivIntOp, Datum, Datum) (Datum, error)
 	EvalDivIntervalFloatOp(context.Context, *DivIntervalFloatOp, Datum, Datum) (Datum, error)
 	EvalDivIntervalIntOp(context.Context, *DivIntervalIntOp, Datum, Datum) (Datum, error)
@@ -408,6 +410,11 @@ func (op *DivDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Da
 }
 
 // Eval is part of the BinaryEvalOp interface.
+func (op *DivFloatIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivFloatIntOp(ctx, op, a, b)
+}
+
+// Eval is part of the BinaryEvalOp interface.
 func (op *DivFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
 	return e.EvalDivFloatOp(ctx, op, a, b)
 }
@@ -415,6 +422,11 @@ func (op *DivFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datu
 // Eval is part of the BinaryEvalOp interface.
 func (op *DivIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
 	return e.EvalDivIntDecimalOp(ctx, op, a, b)
+}
+
+// Eval is part of the BinaryEvalOp interface.
+func (op *DivIntFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivIntFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1392,20 +1392,28 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		// The fourth heuristic is to prefer candidates that accept the "best"
 		// mutual type in the resolvable type set of all constants.
 		if bestConstType, ok := commonConstantType(s.exprs, s.constIdxs); ok {
-			// In case all overloads are filtered out at this step,
-			// keep track of previous overload indexes to return ambiguous error (>1 overloads)
-			// instead of unsupported error (0 overloads) when applicable.
+			// Treat bestConstType as a preference rather than a hard filter. If
+			// it eliminates all candidates, restore the previous candidates so
+			// later heuristics, such as overload preference, can still run.
 			prevOverloadIdxs := s.overloadIdxs
+
 			for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
 				filter := makeFilter(i, func(params TypeList, ordinal int) bool {
 					return params.GetAt(ordinal).Equivalent(bestConstType)
 				})
 				s.overloadIdxs = filterParams(s.overloadIdxs, s.overloads, s.params, filter)
 			}
-			if ok, err := checkReturn(ctx, semaCtx, s); ok {
-				if len(s.overloadIdxs) == 0 {
-					s.overloadIdxs = prevOverloadIdxs
+			if len(s.overloadIdxs) == 0 {
+				if err := defaultTypeCheck(ctx, semaCtx, s, false /* errorOnPlaceholders */); err != nil {
+					return err
 				}
+				s.overloadIdxs = prevOverloadIdxs
+				// Preserve existing placeholder ambiguity behavior. Continuing
+				// would try to type unresolved placeholders without a unique overload.
+				if !s.placeholderIdxs.Empty() {
+					return nil
+				}
+			} else if ok, err := checkReturn(ctx, semaCtx, s); ok {
 				return err
 			}
 			if homogeneousTyp != nil {

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -114,6 +114,8 @@ func TestTypeCheck(t *testing.T) {
 		{`DECIMAL '1.0'`, `1.0:::DECIMAL`},
 
 		{`1 + 2`, `1:::INT8 + 2:::INT8`},
+		{`1::float / 2::int`, `1.0:::FLOAT8 / 2:::INT8`},
+		{`1::int / 2::float`, `1:::INT8 / 2.0:::FLOAT8`},
 		{`1:::decimal + 2`, `1:::DECIMAL + 2:::DECIMAL`},
 		{`1:::float + 2`, `1.0:::FLOAT8 + 2.0:::FLOAT8`},
 		{`INTERVAL '1.5s' * 2`, `'00:00:01.5':::INTERVAL * 2:::INT8`},


### PR DESCRIPTION
**sql: support mixed float and int division**

Add division overloads for FLOAT / INT and INT / FLOAT so mixed
float-integer division matches PostgreSQL behavior without requiring an
explicit cast.

Mark the mixed overloads as unpreferred so contextual constant
expressions, such as inserting 3/2 into a FLOAT column, continue to
prefer the existing FLOAT / FLOAT overload when it is also applicable.

Adjust overload resolution when the best common constant type heuristic
eliminates all candidates. Since that heuristic is only a preference,
restore the previous candidate set. If unresolved placeholders are
present, stop after restoring to preserve existing ambiguity behavior;
otherwise continue to later heuristics so overload preference can break
ties among concrete constant expressions.

Fixes: #82478

Release note (bug fix): Fixed a bug where division between FLOAT and
INT values (e.g., `8.0::float / 2::int`) would fail with an 
"unsupported binary operator" error. Mixed float/integer division now
returns a FLOAT result, matching PostgreSQL behavior.

----

**sql: vectorize mixed float and int division**

Add vectorized projection support for FLOAT / INT and INT / FLOAT division.

Teach execgen that mixed float-integer division returns FLOAT, add assignment
customizers that cast the integer side before division, and regenerate the
constant and non-constant projection operators.

Add projection tests covering both argument orders and const-left/const-right
forms.

Epic: None
Release note: None
