### PR TITLE
opt: add underscore wildcard operator to PlanGram syntax

### DIFF
--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -51,6 +51,8 @@ import (
 //	root: (Select (IndexJoin scan));
 //	scan: (Scan Index="abc_b_idx") | (Scan Index="abc_c_idx");
 //
+// Use "_" as a wildcard operator to match any expression, e.g. "root: (_);".
+//
 // The grammar is stored as a linked graph of terms, starting with the "root"
 // nonterminal. The graph could contain cycles (for example to match a plan with
 // a FK cascade cycle).
@@ -237,7 +239,11 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 			b.WriteString(t.name)
 		case *planGramExpr:
 			b.WriteRune('(')
-			b.WriteString(t.op.CamelCase())
+			if t.op == opt.UnknownOp {
+				b.WriteRune('_')
+			} else {
+				b.WriteString(t.op.CamelCase())
+			}
 			for _, field := range t.fields {
 				b.WriteRune(' ')
 				// Assume field names don't need to be quoted.
@@ -497,9 +503,15 @@ func (p *planGramParser) parseExpr() (planGramTerm, error) {
 	if err != nil {
 		return nil, err
 	}
-	op, ok := opt.OperatorByCamelCase(opName)
-	if !ok {
-		return nil, errors.Newf("unknown operator %q", opName)
+	var op opt.Operator
+	if opName == "_" {
+		op = opt.UnknownOp
+	} else {
+		var ok bool
+		op, ok = opt.OperatorByCamelCase(opName)
+		if !ok {
+			return nil, errors.Newf("unknown operator %q", opName)
+		}
 	}
 	expr := &planGramExpr{op: op}
 

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -190,6 +190,21 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			expectedNewlines: "root: (Select none);\n",
 		},
 		{
+			name:             "wildcard expression",
+			plangram:         PlanGram{root: &planGramExpr{op: opt.UnknownOp}},
+			expectedOneLine:  "root: (_);",
+			expectedNewlines: "root: (_);\n",
+		},
+		{
+			name: "wildcard child",
+			plangram: PlanGram{root: &planGramExpr{
+				op:       opt.SelectOp,
+				children: []planGramTerm{&planGramExpr{op: opt.UnknownOp}},
+			}},
+			expectedOneLine:  "root: (Select (_));",
+			expectedNewlines: "root: (Select (_));\n",
+		},
+		{
 			name: "with nonterminal production",
 			plangram: PlanGram{root: &planGramExpr{
 				op: opt.SelectOp,
@@ -347,10 +362,37 @@ func TestPlanGramMatches(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "wildcard op matches any expr",
+			name:     "wildcard op matches scan",
 			pg:       PlanGram{root: &planGramExpr{op: opt.UnknownOp}},
 			expr:     scanExpr,
 			expected: true,
+		},
+		{
+			name:     "wildcard op matches select",
+			pg:       PlanGram{root: &planGramExpr{op: opt.UnknownOp}},
+			expr:     selectExpr,
+			expected: true,
+		},
+		{
+			name: "wildcard op with children",
+			pg: PlanGram{root: &planGramExpr{
+				op:       opt.UnknownOp,
+				children: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+			}},
+			expr:     selectExpr,
+			expected: true,
+		},
+		{
+			name: "wildcard op with too many children",
+			pg: PlanGram{root: &planGramExpr{
+				op: opt.UnknownOp,
+				children: []planGramTerm{
+					&planGramExpr{op: opt.ScanOp},
+					&planGramExpr{op: opt.ScanOp},
+				},
+			}},
+			expr:     selectExpr,
+			expected: false,
 		},
 		{
 			name: "fewer PG children than expr children",
@@ -828,6 +870,10 @@ func TestPlanGramParse(t *testing.T) {
 			name:  "nullary expression",
 			input: "root: (Scan);",
 		},
+		{
+			name:  "wildcard expression",
+			input: "root: (_);",
+		},
 		// Expressions with fields.
 		{
 			name:  "one field",
@@ -842,6 +888,14 @@ func TestPlanGramParse(t *testing.T) {
 			input: `root: (Scan Index="has \"quotes\" and spaces");`,
 		},
 		// Expressions with children.
+		{
+			name:  "wildcard child",
+			input: "root: (Select (_));",
+		},
+		{
+			name:  "wildcard with children",
+			input: "root: (_ (Scan));",
+		},
 		{
 			name:  "child referencing any",
 			input: "root: (Select any);",


### PR DESCRIPTION
Allow `_` as a wildcard operator in PlanGram expressions. `(_)` matches any optimizer expression regardless of operator type. This is useful for constraining plan shape without pinning to a specific operator.

Parsing maps `_` to `opt.UnknownOp`, which the matcher already treats as a wildcard. Printing maps `UnknownOp` back to `_` for round-trip fidelity.

Informs: #152053

Release note: None