### PR TITLE
roachtest/cdc: add linger-tradeoff perf variants

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3648,7 +3648,11 @@ CONFIGURE ZONE USING
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCLingerLoadMatrix(ctx, t, c,
 				[]string{"10ms", "100ms", "1s"},
-				[]int{12000, 25000, 40000, 60000, 80000})
+				// Loads zoom on the saturation transition zone. The earlier
+				// matrix at 12k/25k showed cadences are indistinguishable
+				// well below saturation, so the interesting question is the
+				// exact rate at which each cadence's pipeline tips over.
+				[]int{40000, 45000, 50000, 55000, 60000, 70000})
 		},
 	})
 }
@@ -3804,8 +3808,15 @@ func runCDCLingerLoadMatrix(
 			if _, err := conn.ExecContext(ctx, fmt.Sprintf("CANCEL JOB %d", currentJobID)); err != nil {
 				t.Fatal(err)
 			}
+			// resolved = '' enables resolved-timestamp emission with the
+			// default cadence, matching what ct.newChangefeed configures for
+			// the kafka sink (cdc.go:541). Without this, the topic consumer
+			// stops seeing resolved timestamps and the Max Changefeed Latency
+			// Grafana panel freezes — the row data still flows but the lag
+			// signal is lost.
 			createSQL := fmt.Sprintf(
 				`CREATE CHANGEFEED FOR kv.kv INTO '%s' WITH initial_scan = 'no', `+
+					`resolved = '', `+
 					`kafka_sink_config = '{"Flush": {"Frequency": "%s"}}'`,
 				sinkURI, cadence)
 			if err := conn.QueryRowContext(ctx, createSQL).Scan(&currentJobID); err != nil {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3643,17 +3643,29 @@ CONFIGURE ZONE USING
 	// transaction overhead and admission control — so the sink is more
 	// likely to be the binding constraint than in the ramp tests. This
 	// is the regime where slack flush cadence should buy throughput by
-	// amortizing per-flush overhead. Three variants:
+	// amortizing per-flush overhead. Variants:
 	//   control: no kafka_sink_config; kgo defaults
 	//   10ms / 100ms: explicit linger cadence
-	for _, flushFreq := range []string{"", "10ms", "100ms"} {
-		flushFreq := flushFreq
-		name := "cdc/linger/initial-scan/control"
-		if flushFreq != "" {
-			name = fmt.Sprintf("cdc/linger/initial-scan/%s", flushFreq)
-		}
+	//   100ms-cap1500 / 100ms-cap10000: 100ms linger with Flush.Messages cap.
+	//     A size cap fires the flush as soon as the batch reaches that many
+	//     events, even if linger hasn't elapsed. At high enough load this
+	//     dominates the linger setting and makes effective cadence ~
+	//     cap/throughput rather than the configured linger.
+	initialScanVariants := []struct {
+		name      string
+		flushFreq string
+		maxMsgs   int
+	}{
+		{name: "control", flushFreq: "", maxMsgs: 0},
+		{name: "10ms", flushFreq: "10ms", maxMsgs: 0},
+		{name: "100ms", flushFreq: "100ms", maxMsgs: 0},
+		{name: "100ms-cap1500", flushFreq: "100ms", maxMsgs: 1500},
+		{name: "100ms-cap10000", flushFreq: "100ms", maxMsgs: 10000},
+	}
+	for _, v := range initialScanVariants {
+		v := v
 		r.Add(registry.TestSpec{
-			Name:             name,
+			Name:             fmt.Sprintf("cdc/linger/initial-scan/%s", v.name),
 			Owner:            registry.OwnerCDC,
 			Benchmark:        true,
 			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
@@ -3661,7 +3673,7 @@ CONFIGURE ZONE USING
 			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 			Suites:           registry.Suites(registry.Weekly),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runCDCInitialScanBench(ctx, t, c, flushFreq)
+				runCDCInitialScanBench(ctx, t, c, v.flushFreq, v.maxMsgs)
 			},
 		})
 	}
@@ -3788,13 +3800,15 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 //
 // Empty flushFrequency means the control: kafka_sink_config omitted entirely
 // (no CDC-level linger, kgo defaults). Non-empty means we explicitly set
-// kafka_sink_config.Flush.Frequency to that value.
+// kafka_sink_config.Flush.Frequency to that value. A non-zero maxMessages
+// adds kafka_sink_config.Flush.Messages as a size-based flush trigger that
+// fires once the batch reaches that many events even if linger hasn't.
 //
 // Throughput is the row count divided by the changefeed's wall-clock
 // duration, logged via t.Status. The Grafana panels span the run for
 // shape-of-the-curve inspection.
 func runCDCInitialScanBench(
-	ctx context.Context, t test.Test, c cluster.Cluster, flushFrequency string,
+	ctx context.Context, t test.Test, c cluster.Cluster, flushFrequency string, maxMessages int,
 ) {
 	// 4 crdb + 1 kafka + 1 workload, all in one zone.
 	ct := newCDCTester(ctx, t, c, withNumSinkNodes(1))
@@ -3823,12 +3837,16 @@ func runCDCInitialScanBench(
 		"initial_scan": "'only'",
 	}
 	if flushFrequency != "" {
-		opts["kafka_sink_config"] = fmt.Sprintf(
-			`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency)
+		flushFields := fmt.Sprintf(`"Frequency": "%s"`, flushFrequency)
+		if maxMessages > 0 {
+			flushFields += fmt.Sprintf(`, "Messages": %d`, maxMessages)
+		}
+		opts["kafka_sink_config"] = fmt.Sprintf(`'{"Flush": {%s}}'`, flushFields)
 	}
 
 	startTime := timeutil.Now()
-	t.Status(fmt.Sprintf("starting initial-scan-only changefeed (Flush.Frequency=%q)", flushFrequency))
+	t.Status(fmt.Sprintf("starting initial-scan-only changefeed (Flush.Frequency=%q, Messages=%d)",
+		flushFrequency, maxMessages))
 	feed := ct.newChangefeed(feedArgs{
 		sinkType: kafkaSink,
 		targets:  []string{"kv.kv"},

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3732,13 +3732,7 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 	// are suppressed during the ramp (workload/cli/run.go:636), so they would
 	// silently drop the data we care about. All time-series come from prometheus.
 	//
-	// Concurrency of 8 per data node (32 total) is deliberately well below the
-	// sink-saturation point seen at 64/node (~256 total), where every Flush.Frequency
-	// variant overran the changefeed pipeline and triggered source-side
-	// backpressure that collapsed throughput. The aim here is to stay in the
-	// sustainable regime so latency reflects flush cadence rather than buffer
-	// fill — i.e. the regime where the linger tradeoff is actually visible.
-	concurrency := len(ct.crdbNodes) * 8
+	concurrency := len(ct.crdbNodes) * 64
 	const (
 		ramp     = 10 * time.Minute
 		duration = 2 * time.Minute

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3607,46 +3607,42 @@ CONFIGURE ZONE USING
 		}
 	}
 
-	// cdc/linger/sweep walks the v2 kafka sink's time-based flush trigger
-	// (batchingSink.minFlushFrequency, fed from kafka_sink_config.Flush.Frequency
-	// at sink_kafka_v2.go:430) across a range of values back-to-back on a
-	// single cluster. Each frequency runs the same kv --ramp workload, so the
-	// shared Grafana dashboard traces a labeled epoch per variant: low cadence
-	// at the start, slack cadence at the end, with the linger tradeoff visible
-	// in the latency and emit-rate panels.
-	r.Add(registry.TestSpec{
-		Name:             "cdc/linger/sweep",
-		Owner:            registry.OwnerCDC,
-		Benchmark:        true,
-		Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
-		Leases:           registry.MetamorphicLeases,
-		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
-		Suites:           registry.Suites(registry.Weekly),
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runCDCLingerSweep(ctx, t, c, []string{"10ms", "100ms", "500ms", "1s", "5s"})
-		},
-	})
+	// cdc/linger/* are roachperf benchmarks for the v2 kafka sink's
+	// time-based flush trigger (batchingSink.minFlushFrequency, fed from
+	// kafka_sink_config.Flush.Frequency at sink_kafka_v2.go:430). Each variant
+	// runs the same kv --ramp workload; differing only in the configured
+	// Flush.Frequency, the set traces the linger tradeoff across cadences.
+	// Run the whole sweep on one reused cluster with:
+	//   bin/roachtest run --cluster <name> --wipe cdc/linger
+	for _, flushFreq := range []string{"10ms", "100ms", "500ms", "1s", "5s"} {
+		flushFreq := flushFreq
+		r.Add(registry.TestSpec{
+			Name:             fmt.Sprintf("cdc/linger/%s", flushFreq),
+			Owner:            registry.OwnerCDC,
+			Benchmark:        true,
+			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+			Leases:           registry.MetamorphicLeases,
+			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+			Suites:           registry.Suites(registry.Weekly),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runCDCLingerBench(ctx, t, c, flushFreq)
+			},
+		})
+	}
 }
 
-// runCDCLingerSweep runs the same kv --ramp workload back-to-back against a
-// v2 Kafka changefeed configured with each of the supplied Flush.Frequency
-// values. The v2 sink wires kafka_sink_config.Flush.Frequency directly into
-// batchingSink.minFlushFrequency (sink_kafka_v2.go:430), so each variant
-// exercises a different point on the linger tradeoff curve — tight cadences
-// keep latency low at low load but cap throughput; slack cadences saturate
-// higher throughput but pay latency at low load.
+// runCDCLingerBench runs a kv workload that ramps from ~0 to system
+// saturation while a v2 Kafka changefeed is active. The v2 sink's
+// minFlushFrequency is wired directly from kafka_sink_config.Flush.Frequency
+// (sink_kafka_v2.go:430), so varying that string exposes the linger
+// tradeoff: a tight cadence (e.g. "10ms") keeps commit latency low at the
+// low end of the ramp but caps achievable throughput; a slack cadence (e.g.
+// "5s") saturates higher throughput but pays latency at low load.
 //
-// Variants share one cluster and one Kafka install. The first variant uses
-// newChangefeed (which sets up Kafka, creates the topic, and starts the
-// topic consumers); subsequent variants cancel the previous changefeed job
-// and issue CREATE CHANGEFEED directly against the cached sink URI. The
-// topic consumers stay up across variants and drain whichever changefeed is
-// currently producing.
-//
-// No per-variant artifacts are written — variant boundaries are recorded as
-// t.Status timestamps in test.log, and the shared Grafana dashboard spans
-// the full run so each variant is identifiable by its time range.
-func runCDCLingerSweep(ctx context.Context, t test.Test, c cluster.Cluster, frequencies []string) {
+// Server-side changefeed.commit_latency (p50, p99) and the rate of
+// changefeed.emitted_messages are exported to roachperf as per-tick
+// time-series, so each variant traces a latency-vs-throughput curve.
+func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flushFrequency string) {
 	// withNumSinkNodes(1) splits the workload+sink node into two, isolating
 	// the kafka broker from the workload runner so neither poisons the other's
 	// perf signal. With 6 cluster nodes: 4 crdb + 1 kafka + 1 workload.
@@ -3665,65 +3661,50 @@ func runCDCLingerSweep(ctx context.Context, t test.Test, c cluster.Cluster, freq
 	// compression, count-based flush triggers, new_kafka_sink.enabled) are
 	// left at default so the test reads plainly and so the only knob
 	// differing between variants is Flush.Frequency.
-	firstFeed := ct.newChangefeed(feedArgs{
+	feed := ct.newChangefeed(feedArgs{
 		sinkType: kafkaSink,
 		targets:  []string{"kv.kv"},
 		opts: map[string]string{
-			"initial_scan":      "'no'",
-			"kafka_sink_config": fmt.Sprintf(`'{"Flush": {"Frequency": "%s"}}'`, frequencies[0]),
+			"initial_scan": "'no'",
+			"kafka_sink_config": fmt.Sprintf(
+				`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency),
 		},
 	})
-	sinkURI := firstFeed.sinkURI
-	currentJobID := firstFeed.jobID
+	_ = feed
+
+	// startStatsCollection records the window start now; the deferred closure
+	// pulls per-tick prometheus series for the configured aggregations at
+	// teardown and writes a stats.json roachperf consumes.
+	doneStats := ct.startStatsCollection(
+		changefeedCommitLatencyP50Agg,
+		changefeedCommitLatencyP99Agg,
+		changefeedEmittedMessagesRateAgg,
+		cpuUsageAgg,
+	)
+	defer doneStats()
 
 	// --ramp staggers worker startup over 10m (workload/cli/run.go:580-590),
 	// so concurrency — and therefore offered load — grows roughly linearly
 	// from ~0 to N until the system saturates. --duration is additive with
 	// --ramp (workload/cli/run.go:51), so a 2m duration gives a 2-minute
-	// steady-state tail past the ramp — 12m of workload total per variant.
-	// --read-percent=0 makes every op a write so every op produces a
-	// changefeed event.
+	// steady-state tail past the ramp — 12m of workload total. --read-percent=0
+	// makes every op a write so every op produces a changefeed event. We
+	// intentionally do not pass --histograms: workload-side per-tick snapshots
+	// are suppressed during the ramp (workload/cli/run.go:636), so they would
+	// silently drop the data we care about. All time-series come from prometheus.
 	concurrency := len(ct.crdbNodes) * 64
 	const (
 		ramp     = 10 * time.Minute
 		duration = 2 * time.Minute
 	)
-
-	for i, freq := range frequencies {
-		if i > 0 {
-			// Cancel the previous variant's changefeed and start a fresh one
-			// against the same sink URI with the new Flush.Frequency. The
-			// topic consumers from setupSink keep draining the topic
-			// regardless of which changefeed job is producing.
-			t.Status(fmt.Sprintf("cancelling job %d before variant %d/%d (Flush.Frequency=%s)",
-				currentJobID, i+1, len(frequencies), freq))
-			if _, err := conn.ExecContext(ctx, fmt.Sprintf("CANCEL JOB %d", currentJobID)); err != nil {
-				t.Fatal(err)
-			}
-			createSQL := fmt.Sprintf(
-				`CREATE CHANGEFEED FOR kv.kv INTO '%s' WITH initial_scan = 'no', `+
-					`kafka_sink_config = '{"Flush": {"Frequency": "%s"}}'`,
-				sinkURI, freq)
-			if err := conn.QueryRowContext(ctx, createSQL).Scan(&currentJobID); err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		variantStart := timeutil.Now()
-		t.Status(fmt.Sprintf("=== variant %d/%d START Flush.Frequency=%s at %s (job %d) ===",
-			i+1, len(frequencies), freq, variantStart.Format(time.RFC3339), currentJobID))
-		if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
-			`./cockroach workload run kv `+
-				`--ramp %s --duration %s --read-percent 0 --concurrency %d `+
-				`{pgurl:%d-%d}`,
-			ramp, duration, concurrency,
-			ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
-			t.Fatal(err)
-		}
-		variantEnd := timeutil.Now()
-		t.Status(fmt.Sprintf("=== variant %d/%d END Flush.Frequency=%s at %s (took %s) ===",
-			i+1, len(frequencies), freq, variantEnd.Format(time.RFC3339),
-			variantEnd.Sub(variantStart).Round(time.Second)))
+	t.Status("running kv workload with ramp")
+	if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+		`./cockroach workload run kv `+
+			`--ramp %s --duration %s --read-percent 0 --concurrency %d `+
+			`{pgurl:%d-%d}`,
+		ramp, duration, concurrency,
+		ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3802,11 +3802,12 @@ func runCDCInitialScanBench(
 
 	conn := ct.DB()
 
-	// 10M rows at ~75 B/row = ~750 MB. Long enough to give stable throughput
-	// readings (several minutes at sink-bound rates) without inflating wall
-	// clock unnecessarily. --data-loader import bulk-loads via IMPORT, much
+	// 50M rows at ~75 B/row = ~3.75 GB. The earlier 10M run only produced
+	// ~30s of throughput plateau before the scan completed, too brief to
+	// compare variants. 50M gives several minutes of plateau at the rates
+	// we've been seeing. --data-loader import bulk-loads via IMPORT, much
 	// faster than --insert which would itself become the bottleneck.
-	const numRows = 10_000_000
+	const numRows = 50_000_000
 
 	t.Status("initializing kv table")
 	c.Run(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3692,7 +3692,14 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 	// intentionally do not pass --histograms: workload-side per-tick snapshots
 	// are suppressed during the ramp (workload/cli/run.go:636), so they would
 	// silently drop the data we care about. All time-series come from prometheus.
-	concurrency := len(ct.crdbNodes) * 64
+	//
+	// Concurrency of 8 per data node (32 total) is deliberately well below the
+	// sink-saturation point seen at 64/node (~256 total), where every Flush.Frequency
+	// variant overran the changefeed pipeline and triggered source-side
+	// backpressure that collapsed throughput. The aim here is to stay in the
+	// sustainable regime so latency reflects flush cadence rather than buffer
+	// fill — i.e. the regime where the linger tradeoff is actually visible.
+	concurrency := len(ct.crdbNodes) * 8
 	const (
 		ramp     = 10 * time.Minute
 		duration = 2 * time.Minute

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"math"
 	"math/big"
 	"net"
 	"net/http"
@@ -146,7 +147,12 @@ func (ct *cdcTester) startStatsCollection(aggs ...clusterstats.AggQuery) func() 
 	startTime := timeutil.Now()
 	return func() {
 		endTime := timeutil.Now()
-		_, err := statsCollector.Exporter().Export(ct.ctx, ct.cluster, ct.t, false, /* dryRun */
+		// Collect via dryRun so we can scrub NaN values before serializing. NaN
+		// shows up in histogram_quantile-based aggregations whenever the rate
+		// window has zero increments (e.g. before the first event or after the
+		// workload stops), and Go's encoding/json refuses to serialize NaN,
+		// which would fail the entire export.
+		testRun, err := statsCollector.Exporter().Export(ct.ctx, ct.cluster, ct.t, true, /* dryRun */
 			startTime,
 			endTime,
 			aggs,
@@ -169,7 +175,38 @@ func (ct *cdcTester) startStatsCollection(aggs ...clusterstats.AggQuery) func() 
 			},
 		)
 		if err != nil {
+			ct.t.Errorf("error collecting stats: %s", err)
+			return
+		}
+		scrubNaNStats(testRun)
+		if err := testRun.SerializeOutRun(ct.ctx, ct.t, ct.cluster, ct.t.ExportOpenmetrics()); err != nil {
 			ct.t.Errorf("error exporting stats file: %s", err)
+		}
+	}
+}
+
+// scrubNaNStats replaces NaN values inside a ClusterStatRun with 0 so the
+// run can be JSON-serialized. NaN typically surfaces from
+// histogram_quantile-based aggregations when the rate window has no
+// increments at the head or tail of the collection window.
+func scrubNaNStats(r *clusterstats.ClusterStatRun) {
+	for name, v := range r.Total {
+		if math.IsNaN(v) {
+			r.Total[name] = 0
+		}
+	}
+	for _, stat := range r.Stats {
+		for i, v := range stat.Value {
+			if math.IsNaN(v) {
+				stat.Value[i] = 0
+			}
+		}
+		for _, vals := range stat.Tagged {
+			for i, v := range vals {
+				if math.IsNaN(v) {
+					vals[i] = 0
+				}
+			}
 		}
 	}
 }
@@ -3647,17 +3684,18 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 
 	// --ramp staggers worker startup over 10m (workload/cli/run.go:580-590),
 	// so concurrency — and therefore offered load — grows roughly linearly
-	// from ~0 to N until the system saturates. The 2-minute tail past the
-	// ramp gives the run a steady-state segment at peak. --read-percent=0
-	// makes every op a write so every op produces a changefeed event. We
-	// intentionally do not pass --histograms: workload-side per-tick
-	// snapshots are suppressed during the ramp (workload/cli/run.go:636), so
-	// they would silently drop the data we care about. All time-series come
-	// from prometheus.
+	// from ~0 to N until the system saturates. --duration is additive with
+	// --ramp (workload/cli/run.go:51), so a 2m duration gives a 2-minute
+	// steady-state tail past the ramp — 12m of workload total.
+	// --read-percent=0 makes every op a write so every op produces a
+	// changefeed event. We intentionally do not pass --histograms:
+	// workload-side per-tick snapshots are suppressed during the ramp
+	// (workload/cli/run.go:636), so they would silently drop the data we
+	// care about. All time-series come from prometheus.
 	concurrency := len(ct.crdbNodes) * 64
 	const (
 		ramp     = 10 * time.Minute
-		duration = 12 * time.Minute
+		duration = 2 * time.Minute
 	)
 	t.Status("running kv workload with ramp")
 	if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3607,41 +3607,46 @@ CONFIGURE ZONE USING
 		}
 	}
 
-	// cdc/linger/* are roachperf benchmarks for the v2 kafka sink's
-	// time-based flush trigger (batchingSink.minFlushFrequency, fed from
-	// kafka_sink_config.Flush.Frequency at sink_kafka_v2.go:430). Each variant
-	// runs the same kv workload with a 10-minute ramp; differing only in the
-	// configured Flush.Frequency, the pair traces both ends of the linger
-	// tradeoff so they can be overlaid in roachperf.
-	for _, flushFreq := range []string{"10ms", "5s"} {
-		flushFreq := flushFreq
-		r.Add(registry.TestSpec{
-			Name:             fmt.Sprintf("cdc/linger/%s", flushFreq),
-			Owner:            registry.OwnerCDC,
-			Benchmark:        true,
-			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
-			Leases:           registry.MetamorphicLeases,
-			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
-			Suites:           registry.Suites(registry.Weekly),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runCDCLingerBench(ctx, t, c, flushFreq)
-			},
-		})
-	}
+	// cdc/linger/sweep walks the v2 kafka sink's time-based flush trigger
+	// (batchingSink.minFlushFrequency, fed from kafka_sink_config.Flush.Frequency
+	// at sink_kafka_v2.go:430) across a range of values back-to-back on a
+	// single cluster. Each frequency runs the same kv --ramp workload, so the
+	// shared Grafana dashboard traces a labeled epoch per variant: low cadence
+	// at the start, slack cadence at the end, with the linger tradeoff visible
+	// in the latency and emit-rate panels.
+	r.Add(registry.TestSpec{
+		Name:             "cdc/linger/sweep",
+		Owner:            registry.OwnerCDC,
+		Benchmark:        true,
+		Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+		Suites:           registry.Suites(registry.Weekly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runCDCLingerSweep(ctx, t, c, []string{"10ms", "100ms", "500ms", "1s", "5s"})
+		},
+	})
 }
 
-// runCDCLingerBench runs a kv workload that ramps from ~0 to system
-// saturation while a v2 Kafka changefeed is active. The v2 sink's
-// minFlushFrequency is wired directly from kafka_sink_config.Flush.Frequency
-// (sink_kafka_v2.go:430), so varying that string exposes the linger
-// tradeoff: a tight cadence (e.g. "10ms") keeps commit latency low at the
-// low end of the ramp but caps achievable throughput; a slack cadence (e.g.
-// "5s") saturates higher throughput but pays latency at low load.
+// runCDCLingerSweep runs the same kv --ramp workload back-to-back against a
+// v2 Kafka changefeed configured with each of the supplied Flush.Frequency
+// values. The v2 sink wires kafka_sink_config.Flush.Frequency directly into
+// batchingSink.minFlushFrequency (sink_kafka_v2.go:430), so each variant
+// exercises a different point on the linger tradeoff curve — tight cadences
+// keep latency low at low load but cap throughput; slack cadences saturate
+// higher throughput but pay latency at low load.
 //
-// Server-side changefeed.commit_latency (p50, p99) and the rate of
-// changefeed.emitted_messages are exported to roachperf as per-tick
-// time-series, so each variant traces a latency-vs-throughput curve.
-func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flushFrequency string) {
+// Variants share one cluster and one Kafka install. The first variant uses
+// newChangefeed (which sets up Kafka, creates the topic, and starts the
+// topic consumers); subsequent variants cancel the previous changefeed job
+// and issue CREATE CHANGEFEED directly against the cached sink URI. The
+// topic consumers stay up across variants and drain whichever changefeed is
+// currently producing.
+//
+// No per-variant artifacts are written — variant boundaries are recorded as
+// t.Status timestamps in test.log, and the shared Grafana dashboard spans
+// the full run so each variant is identifiable by its time range.
+func runCDCLingerSweep(ctx context.Context, t test.Test, c cluster.Cluster, frequencies []string) {
 	// withNumSinkNodes(1) splits the workload+sink node into two, isolating
 	// the kafka broker from the workload runner so neither poisons the other's
 	// perf signal. With 6 cluster nodes: 4 crdb + 1 kafka + 1 workload.
@@ -3660,51 +3665,65 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 	// compression, count-based flush triggers, new_kafka_sink.enabled) are
 	// left at default so the test reads plainly and so the only knob
 	// differing between variants is Flush.Frequency.
-	feed := ct.newChangefeed(feedArgs{
+	firstFeed := ct.newChangefeed(feedArgs{
 		sinkType: kafkaSink,
 		targets:  []string{"kv.kv"},
 		opts: map[string]string{
-			"initial_scan": "'no'",
-			"kafka_sink_config": fmt.Sprintf(
-				`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency),
+			"initial_scan":      "'no'",
+			"kafka_sink_config": fmt.Sprintf(`'{"Flush": {"Frequency": "%s"}}'`, frequencies[0]),
 		},
 	})
-	_ = feed
-
-	// startStatsCollection records the window start now; the deferred closure
-	// pulls per-tick prometheus series for the configured aggregations at
-	// teardown and writes a stats.json roachperf consumes.
-	doneStats := ct.startStatsCollection(
-		changefeedCommitLatencyP50Agg,
-		changefeedCommitLatencyP99Agg,
-		changefeedEmittedMessagesRateAgg,
-		cpuUsageAgg,
-	)
-	defer doneStats()
+	sinkURI := firstFeed.sinkURI
+	currentJobID := firstFeed.jobID
 
 	// --ramp staggers worker startup over 10m (workload/cli/run.go:580-590),
 	// so concurrency — and therefore offered load — grows roughly linearly
 	// from ~0 to N until the system saturates. --duration is additive with
 	// --ramp (workload/cli/run.go:51), so a 2m duration gives a 2-minute
-	// steady-state tail past the ramp — 12m of workload total.
+	// steady-state tail past the ramp — 12m of workload total per variant.
 	// --read-percent=0 makes every op a write so every op produces a
-	// changefeed event. We intentionally do not pass --histograms:
-	// workload-side per-tick snapshots are suppressed during the ramp
-	// (workload/cli/run.go:636), so they would silently drop the data we
-	// care about. All time-series come from prometheus.
+	// changefeed event.
 	concurrency := len(ct.crdbNodes) * 64
 	const (
 		ramp     = 10 * time.Minute
 		duration = 2 * time.Minute
 	)
-	t.Status("running kv workload with ramp")
-	if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
-		`./cockroach workload run kv `+
-			`--ramp %s --duration %s --read-percent 0 --concurrency %d `+
-			`{pgurl:%d-%d}`,
-		ramp, duration, concurrency,
-		ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
-		t.Fatal(err)
+
+	for i, freq := range frequencies {
+		if i > 0 {
+			// Cancel the previous variant's changefeed and start a fresh one
+			// against the same sink URI with the new Flush.Frequency. The
+			// topic consumers from setupSink keep draining the topic
+			// regardless of which changefeed job is producing.
+			t.Status(fmt.Sprintf("cancelling job %d before variant %d/%d (Flush.Frequency=%s)",
+				currentJobID, i+1, len(frequencies), freq))
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("CANCEL JOB %d", currentJobID)); err != nil {
+				t.Fatal(err)
+			}
+			createSQL := fmt.Sprintf(
+				`CREATE CHANGEFEED FOR kv.kv INTO '%s' WITH initial_scan = 'no', `+
+					`kafka_sink_config = '{"Flush": {"Frequency": "%s"}}'`,
+				sinkURI, freq)
+			if err := conn.QueryRowContext(ctx, createSQL).Scan(&currentJobID); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		variantStart := timeutil.Now()
+		t.Status(fmt.Sprintf("=== variant %d/%d START Flush.Frequency=%s at %s (job %d) ===",
+			i+1, len(frequencies), freq, variantStart.Format(time.RFC3339), currentJobID))
+		if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+			`./cockroach workload run kv `+
+				`--ramp %s --duration %s --read-percent 0 --concurrency %d `+
+				`{pgurl:%d-%d}`,
+			ramp, duration, concurrency,
+			ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
+			t.Fatal(err)
+		}
+		variantEnd := timeutil.Now()
+		t.Status(fmt.Sprintf("=== variant %d/%d END Flush.Frequency=%s at %s (took %s) ===",
+			i+1, len(frequencies), freq, variantEnd.Format(time.RFC3339),
+			variantEnd.Sub(variantStart).Round(time.Second)))
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3614,22 +3614,8 @@ CONFIGURE ZONE USING
 	// Flush.Frequency, the set traces the linger tradeoff across cadences.
 	// cdc/linger/control is the no-batching baseline: kafka_sink_config is
 	// omitted entirely so the sink uses defaults (no CDC-level linger; kgo
-	// handles its own producer-side batching).
-	//
-	// The cluster is multi-region with the kafka sink node in us-west1 and
-	// everything else (crdb + workload) in us-east1. Cross-region RTT to the
-	// sink (~25-35ms) makes per-flush network cost a meaningful fraction of
-	// total work, which is the regime where the linger tradeoff actually
-	// manifests as a throughput effect. The earlier colocated runs showed
-	// per-flush overhead was sub-ms in a same-zone setup, so cadence had no
-	// measurable throughput impact — the bottleneck was always upstream.
-	//
-	// Layout (withNumSinkNodes(1) at runtime):
-	//   node 1-4: crdb       (us-east1-b)
-	//   node 5:   kafka sink (us-west1-b)
-	//   node 6:   workload   (us-east1-b)
-	//
-	// Run the whole sweep on one reused cluster with:
+	// handles its own producer-side batching). Run the whole sweep on one
+	// reused cluster with:
 	//   bin/roachtest run --cluster <name> --wipe cdc/linger
 	for _, flushFreq := range []string{"", "10ms", "100ms", "500ms", "1s", "5s"} {
 		flushFreq := flushFreq
@@ -3638,16 +3624,44 @@ CONFIGURE ZONE USING
 			name = fmt.Sprintf("cdc/linger/%s", flushFreq)
 		}
 		r.Add(registry.TestSpec{
-			Name:      name,
-			Owner:     registry.OwnerCDC,
-			Benchmark: true,
-			Cluster: r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode(),
-				spec.Geo(), spec.GCEZones("us-east1-b,us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-east1-b")),
+			Name:             name,
+			Owner:            registry.OwnerCDC,
+			Benchmark:        true,
+			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
 			Leases:           registry.MetamorphicLeases,
-			CompatibleClouds: registry.OnlyGCE,
+			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 			Suites:           registry.Suites(registry.Weekly),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCDCLingerBench(ctx, t, c, flushFreq)
+			},
+		})
+	}
+
+	// cdc/linger/initial-scan/* runs an initial-scan-only changefeed against
+	// a pre-populated kv table. The initial scan emits events as fast as
+	// the source-to-sink pipeline can drain, decoupled from per-write
+	// transaction overhead and admission control — so the sink is more
+	// likely to be the binding constraint than in the ramp tests. This
+	// is the regime where slack flush cadence should buy throughput by
+	// amortizing per-flush overhead. Three variants:
+	//   control: no kafka_sink_config; kgo defaults
+	//   10ms / 100ms: explicit linger cadence
+	for _, flushFreq := range []string{"", "10ms", "100ms"} {
+		flushFreq := flushFreq
+		name := "cdc/linger/initial-scan/control"
+		if flushFreq != "" {
+			name = fmt.Sprintf("cdc/linger/initial-scan/%s", flushFreq)
+		}
+		r.Add(registry.TestSpec{
+			Name:             name,
+			Owner:            registry.OwnerCDC,
+			Benchmark:        true,
+			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+			Leases:           registry.MetamorphicLeases,
+			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+			Suites:           registry.Suites(registry.Weekly),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runCDCInitialScanBench(ctx, t, c, flushFreq)
 			},
 		})
 	}
@@ -3761,6 +3775,69 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 		ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// runCDCInitialScanBench pre-populates the kv table with bulk-imported rows,
+// then runs a single initial_scan='only' changefeed and waits for it to
+// complete. The initial scan emits events as fast as the source-to-sink
+// pipeline can drain — no per-write transaction overhead, no admission
+// control gating, just sorted scan + emit. That makes the sink more likely
+// to be the binding constraint than under a live write workload, which is
+// the regime where slack linger cadence should amortize per-flush overhead
+// into a real throughput win.
+//
+// Empty flushFrequency means the control: kafka_sink_config omitted entirely
+// (no CDC-level linger, kgo defaults). Non-empty means we explicitly set
+// kafka_sink_config.Flush.Frequency to that value.
+//
+// Throughput is the row count divided by the changefeed's wall-clock
+// duration, logged via t.Status. The Grafana panels span the run for
+// shape-of-the-curve inspection.
+func runCDCInitialScanBench(
+	ctx context.Context, t test.Test, c cluster.Cluster, flushFrequency string,
+) {
+	// 4 crdb + 1 kafka + 1 workload, all in one zone.
+	ct := newCDCTester(ctx, t, c, withNumSinkNodes(1))
+	defer ct.Close()
+
+	conn := ct.DB()
+
+	// 10M rows at ~75 B/row = ~750 MB. Long enough to give stable throughput
+	// readings (several minutes at sink-bound rates) without inflating wall
+	// clock unnecessarily. --data-loader import bulk-loads via IMPORT, much
+	// faster than --insert which would itself become the bottleneck.
+	const numRows = 10_000_000
+
+	t.Status("initializing kv table")
+	c.Run(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+		`./cockroach workload init kv --splits 100 {pgurl:%d}`, ct.crdbNodes[0]))
+	require.NoError(t, roachtestutil.WaitFor3XReplication(ctx, t.L(), conn))
+
+	t.Status(fmt.Sprintf("bulk-loading %d rows via IMPORT", numRows))
+	c.Run(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+		`./cockroach workload init kv --insert-count %d --data-loader import {pgurl:%d}`,
+		numRows, ct.crdbNodes[0]))
+
+	opts := map[string]string{
+		"initial_scan": "'only'",
+	}
+	if flushFrequency != "" {
+		opts["kafka_sink_config"] = fmt.Sprintf(
+			`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency)
+	}
+
+	startTime := timeutil.Now()
+	t.Status(fmt.Sprintf("starting initial-scan-only changefeed (Flush.Frequency=%q)", flushFrequency))
+	feed := ct.newChangefeed(feedArgs{
+		sinkType: kafkaSink,
+		targets:  []string{"kv.kv"},
+		opts:     opts,
+	})
+	feed.waitForCompletion()
+	elapsed := timeutil.Since(startTime)
+	rate := int64(float64(numRows) / elapsed.Seconds())
+	t.Status(fmt.Sprintf("initial scan complete: %s (~%d rows/sec)",
+		elapsed.Round(time.Second), rate))
 }
 
 // runCDCLingerLoadMatrix sweeps a (cadence x offered-rate) matrix on a

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3614,8 +3614,22 @@ CONFIGURE ZONE USING
 	// Flush.Frequency, the set traces the linger tradeoff across cadences.
 	// cdc/linger/control is the no-batching baseline: kafka_sink_config is
 	// omitted entirely so the sink uses defaults (no CDC-level linger; kgo
-	// handles its own producer-side batching). Run the whole sweep on one
-	// reused cluster with:
+	// handles its own producer-side batching).
+	//
+	// The cluster is multi-region with the kafka sink node in us-west1 and
+	// everything else (crdb + workload) in us-east1. Cross-region RTT to the
+	// sink (~25-35ms) makes per-flush network cost a meaningful fraction of
+	// total work, which is the regime where the linger tradeoff actually
+	// manifests as a throughput effect. The earlier colocated runs showed
+	// per-flush overhead was sub-ms in a same-zone setup, so cadence had no
+	// measurable throughput impact — the bottleneck was always upstream.
+	//
+	// Layout (withNumSinkNodes(1) at runtime):
+	//   node 1-4: crdb       (us-east1-b)
+	//   node 5:   kafka sink (us-west1-b)
+	//   node 6:   workload   (us-east1-b)
+	//
+	// Run the whole sweep on one reused cluster with:
 	//   bin/roachtest run --cluster <name> --wipe cdc/linger
 	for _, flushFreq := range []string{"", "10ms", "100ms", "500ms", "1s", "5s"} {
 		flushFreq := flushFreq
@@ -3624,12 +3638,13 @@ CONFIGURE ZONE USING
 			name = fmt.Sprintf("cdc/linger/%s", flushFreq)
 		}
 		r.Add(registry.TestSpec{
-			Name:             name,
-			Owner:            registry.OwnerCDC,
-			Benchmark:        true,
-			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+			Name:      name,
+			Owner:     registry.OwnerCDC,
+			Benchmark: true,
+			Cluster: r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode(),
+				spec.Geo(), spec.GCEZones("us-east1-b,us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-east1-b")),
 			Leases:           registry.MetamorphicLeases,
-			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Weekly),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runCDCLingerBench(ctx, t, c, flushFreq)
@@ -3722,11 +3737,11 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 	)
 	defer doneStats()
 
-	// --ramp staggers worker startup over 10m (workload/cli/run.go:580-590),
+	// --ramp staggers worker startup over 5m (workload/cli/run.go:580-590),
 	// so concurrency — and therefore offered load — grows roughly linearly
 	// from ~0 to N until the system saturates. --duration is additive with
-	// --ramp (workload/cli/run.go:51), so a 2m duration gives a 2-minute
-	// steady-state tail past the ramp — 12m of workload total. --read-percent=0
+	// --ramp (workload/cli/run.go:51), so a 1m duration gives a 1-minute
+	// steady-state tail past the ramp — 6m of workload total. --read-percent=0
 	// makes every op a write so every op produces a changefeed event. We
 	// intentionally do not pass --histograms: workload-side per-tick snapshots
 	// are suppressed during the ramp (workload/cli/run.go:636), so they would
@@ -3734,8 +3749,8 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 	//
 	concurrency := len(ct.crdbNodes) * 64
 	const (
-		ramp     = 10 * time.Minute
-		duration = 2 * time.Minute
+		ramp     = 5 * time.Minute
+		duration = 1 * time.Minute
 	)
 	t.Status("running kv workload with ramp")
 	if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3829,9 +3829,15 @@ func runCDCLingerLoadMatrix(
 			cellStart := timeutil.Now()
 			t.Status(fmt.Sprintf("=== cell %d/%d START cadence=%s load=%d ops/s at %s (job %d) ===",
 				cellIdx, totalCells, cadence, load, cellStart.Format(time.RFC3339), currentJobID))
+			// --tolerate-errors keeps the workload running through transient
+			// SQL errors (e.g. NEW_LEASE_PREVENTS_TXN, ambiguous results
+			// from gRPC cancellations) that can fire when the cluster is
+			// under sustained backpressure from prior over-saturation cells.
+			// Without it, the first such error kills the workload and the
+			// whole matrix aborts mid-stream.
 			if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
 				`./cockroach workload run kv `+
-					`--ramp 0 --duration %s --max-rate %d --read-percent 0 --concurrency %d `+
+					`--ramp 0 --duration %s --max-rate %d --read-percent 0 --concurrency %d --tolerate-errors `+
 					`{pgurl:%d-%d}`,
 				cellDuration, load, concurrency,
 				ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3629,6 +3629,28 @@ CONFIGURE ZONE USING
 			},
 		})
 	}
+
+	// cdc/linger/loadmatrix sweeps a (cadence x offered-rate) matrix on one
+	// cluster. Each cell runs at a fixed --max-rate for a few minutes, so
+	// every (cadence, load) point has a steady-state latency reading. The
+	// resulting grid is what produces the latency-vs-throughput curve #170574
+	// wants for release notes, and also resolves whether tight cadences
+	// actually cost throughput on a real sink (#170200) — by pushing offered
+	// load above the saturation point seen with the unconstrained sweep.
+	r.Add(registry.TestSpec{
+		Name:             "cdc/linger/loadmatrix",
+		Owner:            registry.OwnerCDC,
+		Benchmark:        true,
+		Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+		Suites:           registry.Suites(registry.Weekly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runCDCLingerLoadMatrix(ctx, t, c,
+				[]string{"10ms", "100ms", "1s"},
+				[]int{12000, 25000, 40000, 60000, 80000})
+		},
+	})
 }
 
 // runCDCLingerBench runs a kv workload that ramps from ~0 to system
@@ -3712,6 +3734,103 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 		ramp, duration, concurrency,
 		ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// runCDCLingerLoadMatrix sweeps a (cadence x offered-rate) matrix on a
+// single cluster. For each cadence, it (re)creates the changefeed with that
+// kafka_sink_config.Flush.Frequency, then runs a sequence of fixed-rate kv
+// workloads — one per offered-rate value — back-to-back. Each cell produces
+// a steady-state latency and achieved-throughput point that can be read off
+// the Grafana dashboard by timestamp.
+//
+// --max-rate is a fixed rate.Limiter (workload/cli/run.go:438-443), so
+// combined with --ramp 0 the workload offers exactly that rate from t=0 with
+// no warmup ambiguity. Concurrency is set high so the limiter is the actual
+// bottleneck rather than worker count.
+//
+// Cell boundaries are logged as t.Status `=== cell N/M ===` lines so the
+// shared Grafana dashboard can be sliced into (cadence, rate) windows by
+// timestamp. No per-cell artifacts are written.
+func runCDCLingerLoadMatrix(
+	ctx context.Context, t test.Test, c cluster.Cluster, cadences []string, loadOpsPerSec []int,
+) {
+	// withNumSinkNodes(1) splits the workload+sink node into two, isolating
+	// the kafka broker from the workload runner. With 6 cluster nodes:
+	// 4 crdb + 1 kafka + 1 workload.
+	ct := newCDCTester(ctx, t, c, withNumSinkNodes(1))
+	defer ct.Close()
+
+	conn := ct.DB()
+
+	t.Status("initializing kv workload")
+	c.Run(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+		`./cockroach workload init kv --splits 100 {pgurl:%d}`, ct.crdbNodes[0]))
+	require.NoError(t, roachtestutil.WaitFor3XReplication(ctx, t.L(), conn))
+
+	// First changefeed uses newChangefeed so that setupSink runs once:
+	// installs kafka, creates the topic, starts the topic consumers. The
+	// consumers keep draining the topic for the rest of the test regardless
+	// of which changefeed job is currently producing.
+	firstFeed := ct.newChangefeed(feedArgs{
+		sinkType: kafkaSink,
+		targets:  []string{"kv.kv"},
+		opts: map[string]string{
+			"initial_scan":      "'no'",
+			"kafka_sink_config": fmt.Sprintf(`'{"Flush": {"Frequency": "%s"}}'`, cadences[0]),
+		},
+	})
+	sinkURI := firstFeed.sinkURI
+	currentJobID := firstFeed.jobID
+
+	// Each cell is a short fixed-rate run. 4 minutes gives ~30s for steady
+	// state to settle plus ~3.5 min of stable sampling for p99.
+	const cellDuration = 4 * time.Minute
+	// Workers need to be plentiful enough that --max-rate is the bottleneck,
+	// not concurrency. At ~200 ops/sec/worker (a conservative estimate for
+	// kv writes on this cluster), 512 workers can drive ~100k ops/sec,
+	// well above the matrix's top load value.
+	const concurrency = 512
+
+	totalCells := len(cadences) * len(loadOpsPerSec)
+	cellIdx := 0
+
+	for ci, cadence := range cadences {
+		if ci > 0 {
+			// Swap cadence: cancel the previous changefeed and create a fresh
+			// one against the same sink URI with the new Flush.Frequency.
+			t.Status(fmt.Sprintf("cancelling job %d to switch cadence to %s",
+				currentJobID, cadence))
+			if _, err := conn.ExecContext(ctx, fmt.Sprintf("CANCEL JOB %d", currentJobID)); err != nil {
+				t.Fatal(err)
+			}
+			createSQL := fmt.Sprintf(
+				`CREATE CHANGEFEED FOR kv.kv INTO '%s' WITH initial_scan = 'no', `+
+					`kafka_sink_config = '{"Flush": {"Frequency": "%s"}}'`,
+				sinkURI, cadence)
+			if err := conn.QueryRowContext(ctx, createSQL).Scan(&currentJobID); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		for _, load := range loadOpsPerSec {
+			cellIdx++
+			cellStart := timeutil.Now()
+			t.Status(fmt.Sprintf("=== cell %d/%d START cadence=%s load=%d ops/s at %s (job %d) ===",
+				cellIdx, totalCells, cadence, load, cellStart.Format(time.RFC3339), currentJobID))
+			if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+				`./cockroach workload run kv `+
+					`--ramp 0 --duration %s --max-rate %d --read-percent 0 --concurrency %d `+
+					`{pgurl:%d-%d}`,
+				cellDuration, load, concurrency,
+				ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
+				t.Fatal(err)
+			}
+			cellEnd := timeutil.Now()
+			t.Status(fmt.Sprintf("=== cell %d/%d END cadence=%s load=%d ops/s at %s (took %s) ===",
+				cellIdx, totalCells, cadence, load, cellEnd.Format(time.RFC3339),
+				cellEnd.Sub(cellStart).Round(time.Second)))
+		}
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -128,10 +128,14 @@ type cdcTester struct {
 
 // startStatsCollection sets the start point of the stats collection window
 // and returns a function which should be called at the end of the test to dump a
-// stats.json file to the artifacts directory.
-func (ct *cdcTester) startStatsCollection() func() {
+// stats.json file to the artifacts directory. If no aggregations are supplied,
+// a default set covering SQL latency, changefeed throughput, and CPU is used.
+func (ct *cdcTester) startStatsCollection(aggs ...clusterstats.AggQuery) func() {
 	if ct.promCfg == nil {
 		ct.t.Fatalf("prometheus configuration is nil")
+	}
+	if len(aggs) == 0 {
+		aggs = []clusterstats.AggQuery{sqlServiceLatencyAgg, changefeedThroughputAgg, cpuUsageAgg}
 	}
 	promClient, err := clusterstats.SetupCollectorPromClient(ct.ctx, ct.cluster, ct.t.L(), ct.promCfg)
 	if err != nil {
@@ -145,7 +149,7 @@ func (ct *cdcTester) startStatsCollection() func() {
 		_, err := statsCollector.Exporter().Export(ct.ctx, ct.cluster, ct.t, false, /* dryRun */
 			startTime,
 			endTime,
-			[]clusterstats.AggQuery{sqlServiceLatencyAgg, changefeedThroughputAgg, cpuUsageAgg},
+			aggs,
 			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
 				// TODO(jayant): update this metric to be more accurate.
 				// It may be worth plugging in real latency values from the latency
@@ -3564,6 +3568,105 @@ CONFIGURE ZONE USING
 				},
 			})
 		}
+	}
+
+	// cdc/linger/* are roachperf benchmarks for the v2 kafka sink's
+	// time-based flush trigger (batchingSink.minFlushFrequency, fed from
+	// kafka_sink_config.Flush.Frequency at sink_kafka_v2.go:430). Each variant
+	// runs the same kv workload with a 10-minute ramp; differing only in the
+	// configured Flush.Frequency, the pair traces both ends of the linger
+	// tradeoff so they can be overlaid in roachperf.
+	for _, flushFreq := range []string{"10ms", "5s"} {
+		flushFreq := flushFreq
+		r.Add(registry.TestSpec{
+			Name:             fmt.Sprintf("cdc/linger/%s", flushFreq),
+			Owner:            registry.OwnerCDC,
+			Benchmark:        true,
+			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+			Leases:           registry.MetamorphicLeases,
+			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
+			Suites:           registry.Suites(registry.Weekly),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runCDCLingerBench(ctx, t, c, flushFreq)
+			},
+		})
+	}
+}
+
+// runCDCLingerBench runs a kv workload that ramps from ~0 to system
+// saturation while a v2 Kafka changefeed is active. The v2 sink's
+// minFlushFrequency is wired directly from kafka_sink_config.Flush.Frequency
+// (sink_kafka_v2.go:430), so varying that string exposes the linger
+// tradeoff: a tight cadence (e.g. "10ms") keeps commit latency low at the
+// low end of the ramp but caps achievable throughput; a slack cadence (e.g.
+// "5s") saturates higher throughput but pays latency at low load.
+//
+// Server-side changefeed.commit_latency (p50, p99) and the rate of
+// changefeed.emitted_messages are exported to roachperf as per-tick
+// time-series, so each variant traces a latency-vs-throughput curve.
+func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flushFrequency string) {
+	// withNumSinkNodes(1) splits the workload+sink node into two, isolating
+	// the kafka broker from the workload runner so neither poisons the other's
+	// perf signal. With 6 cluster nodes: 4 crdb + 1 kafka + 1 workload.
+	ct := newCDCTester(ctx, t, c, withNumSinkNodes(1))
+	defer ct.Close()
+
+	conn := ct.DB()
+
+	t.Status("initializing kv workload")
+	c.Run(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+		`./cockroach workload init kv --splits 100 {pgurl:%d}`, ct.crdbNodes[0]))
+	require.NoError(t, roachtestutil.WaitFor3XReplication(ctx, t.L(), conn))
+
+	// Only the two options the experiment actually depends on are set; all
+	// others (format, min_checkpoint_frequency, resolved, envelope,
+	// compression, count-based flush triggers, new_kafka_sink.enabled) are
+	// left at default so the test reads plainly and so the only knob
+	// differing between variants is Flush.Frequency.
+	feed := ct.newChangefeed(feedArgs{
+		sinkType: kafkaSink,
+		targets:  []string{"kv.kv"},
+		opts: map[string]string{
+			"initial_scan": "'no'",
+			"kafka_sink_config": fmt.Sprintf(
+				`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency),
+		},
+	})
+	_ = feed
+
+	// startStatsCollection records the window start now; the deferred closure
+	// pulls per-tick prometheus series for the configured aggregations at
+	// teardown and writes a stats.json roachperf consumes.
+	doneStats := ct.startStatsCollection(
+		changefeedCommitLatencyP50Agg,
+		changefeedCommitLatencyP99Agg,
+		changefeedEmittedMessagesRateAgg,
+		cpuUsageAgg,
+	)
+	defer doneStats()
+
+	// --ramp staggers worker startup over 10m (workload/cli/run.go:580-590),
+	// so concurrency — and therefore offered load — grows roughly linearly
+	// from ~0 to N until the system saturates. The 2-minute tail past the
+	// ramp gives the run a steady-state segment at peak. --read-percent=0
+	// makes every op a write so every op produces a changefeed event. We
+	// intentionally do not pass --histograms: workload-side per-tick
+	// snapshots are suppressed during the ramp (workload/cli/run.go:636), so
+	// they would silently drop the data we care about. All time-series come
+	// from prometheus.
+	concurrency := len(ct.crdbNodes) * 64
+	const (
+		ramp     = 10 * time.Minute
+		duration = 12 * time.Minute
+	)
+	t.Status("running kv workload with ramp")
+	if err := c.RunE(ctx, option.WithNodes(ct.workloadNode), fmt.Sprintf(
+		`./cockroach workload run kv `+
+			`--ramp %s --duration %s --read-percent 0 --concurrency %d `+
+			`{pgurl:%d-%d}`,
+		ramp, duration, concurrency,
+		ct.crdbNodes[0], ct.crdbNodes[len(ct.crdbNodes)-1])); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -3612,12 +3612,19 @@ CONFIGURE ZONE USING
 	// kafka_sink_config.Flush.Frequency at sink_kafka_v2.go:430). Each variant
 	// runs the same kv --ramp workload; differing only in the configured
 	// Flush.Frequency, the set traces the linger tradeoff across cadences.
-	// Run the whole sweep on one reused cluster with:
+	// cdc/linger/control is the no-batching baseline: kafka_sink_config is
+	// omitted entirely so the sink uses defaults (no CDC-level linger; kgo
+	// handles its own producer-side batching). Run the whole sweep on one
+	// reused cluster with:
 	//   bin/roachtest run --cluster <name> --wipe cdc/linger
-	for _, flushFreq := range []string{"10ms", "100ms", "500ms", "1s", "5s"} {
+	for _, flushFreq := range []string{"", "10ms", "100ms", "500ms", "1s", "5s"} {
 		flushFreq := flushFreq
+		name := "cdc/linger/control"
+		if flushFreq != "" {
+			name = fmt.Sprintf("cdc/linger/%s", flushFreq)
+		}
 		r.Add(registry.TestSpec{
-			Name:             fmt.Sprintf("cdc/linger/%s", flushFreq),
+			Name:             name,
 			Owner:            registry.OwnerCDC,
 			Benchmark:        true,
 			Cluster:          r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
@@ -3686,15 +3693,21 @@ func runCDCLingerBench(ctx context.Context, t test.Test, c cluster.Cluster, flus
 	// others (format, min_checkpoint_frequency, resolved, envelope,
 	// compression, count-based flush triggers, new_kafka_sink.enabled) are
 	// left at default so the test reads plainly and so the only knob
-	// differing between variants is Flush.Frequency.
+	// differing between variants is Flush.Frequency. An empty
+	// flushFrequency omits kafka_sink_config entirely, giving the
+	// no-CDC-batching control: the v2 sink falls through to kgo's default
+	// producer-side batching.
+	opts := map[string]string{
+		"initial_scan": "'no'",
+	}
+	if flushFrequency != "" {
+		opts["kafka_sink_config"] = fmt.Sprintf(
+			`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency)
+	}
 	feed := ct.newChangefeed(feedArgs{
 		sinkType: kafkaSink,
 		targets:  []string{"kv.kv"},
-		opts: map[string]string{
-			"initial_scan": "'no'",
-			"kafka_sink_config": fmt.Sprintf(
-				`'{"Flush": {"Frequency": "%s"}}'`, flushFrequency),
-		},
+		opts:     opts,
 	})
 	_ = feed
 

--- a/pkg/cmd/roachtest/tests/cdc_stats.go
+++ b/pkg/cmd/roachtest/tests/cdc_stats.go
@@ -34,4 +34,30 @@ var (
 		Query: "avg(sys_cpu_combined_percent_normalized) * 100",
 		Tag:   "CPU Utilization (%)",
 	}
+
+	// changefeedCommitLatency is the changefeed.commit_latency prometheus
+	// histogram (nanoseconds). It measures the gap between an event's MVCC
+	// timestamp and downstream sink acknowledgement.
+	changefeedCommitLatency = clusterstats.ClusterStat{LabelName: "node", Query: "changefeed_commit_latency_bucket"}
+	// changefeedCommitLatencyP50Agg is the cluster-wide p50 commit latency in ms.
+	changefeedCommitLatencyP50Agg = clusterstats.AggQuery{
+		Stat:  changefeedCommitLatency,
+		Query: "histogram_quantile(0.50, sum by(le) (rate(changefeed_commit_latency_bucket[30s]))) / (1000*1000)",
+		Tag:   "Commit Latency P50 (ms)",
+	}
+	// changefeedCommitLatencyP99Agg is the cluster-wide p99 commit latency in ms.
+	changefeedCommitLatencyP99Agg = clusterstats.AggQuery{
+		Stat:  changefeedCommitLatency,
+		Query: "histogram_quantile(0.99, sum by(le) (rate(changefeed_commit_latency_bucket[30s]))) / (1000*1000)",
+		Tag:   "Commit Latency P99 (ms)",
+	}
+
+	// changefeedEmittedMessages is the changefeed.emitted_messages prometheus counter.
+	changefeedEmittedMessages = clusterstats.ClusterStat{LabelName: "node", Query: "changefeed_emitted_messages"}
+	// changefeedEmittedMessagesRateAgg is the cluster-wide emitted rows per second.
+	changefeedEmittedMessagesRateAgg = clusterstats.AggQuery{
+		Stat:  changefeedEmittedMessages,
+		Query: "sum(rate(changefeed_emitted_messages[30s]))",
+		Tag:   "Emitted Rows/sec",
+	}
 )


### PR DESCRIPTION
Add cdc/linger/10ms and cdc/linger/5s as Weekly-suite benchmarks of the v2 kafka sink. Both run the same kv workload with `--ramp 10m --duration 12m --read-percent 0` against a single-table changefeed and differ only in `kafka_sink_config.Flush.Frequency`, which the v2 kafka path wires straight into `batchingSink.minFlushFrequency`
(pkg/ccl/changefeedccl/sink_kafka_v2.go:430). Together the two curves trace the linger tradeoff on a real Kafka sink: the tight cadence should win at low load, the slack cadence at saturation. This closes the microbench gap called out in #170200, where the existing batching benchmarks don't capture per-flush network/broker cost.

Server-side `changefeed.commit_latency` (p50, p99) and the rate of `changefeed.emitted_messages` are exported to roachperf as per-tick prometheus series via a parameterized `startStatsCollection`. When the no-linger sink lands, a third registration that flips `changefeed.no_linger_sink.enabled` will overlay against the same methodology and produce the comparison plot #170574 asks for.

Informs: #170200
Epic: CRDB-62737
Release note: None