### PR TITLE
schemachanger: implement `ALTER DOMAIN ... RENAME TO` for domains

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -148,6 +148,20 @@ func TestBackupRollbacks_base_alter_database_configure_zone_multiple(t *testing.
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacks_base_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_domain_set_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1062,6 +1076,20 @@ func TestBackupRollbacksMixedVersion_base_alter_database_configure_zone_multiple
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1982,6 +2010,20 @@ func TestBackupSuccess_base_alter_database_configure_zone_multiple(t *testing.T)
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccess_base_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_domain_set_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2896,6 +2938,20 @@ func TestBackupSuccessMixedVersion_base_alter_database_configure_zone_multiple(t
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_domain
+++ b/pkg/sql/logictest/testdata/logic_test/alter_domain
@@ -217,8 +217,67 @@ subtest end
 
 subtest rename_to
 
-statement error pgcode 0A000 ALTER DOMAIN RENAME TO is not supported
-ALTER DOMAIN d RENAME TO d2
+statement ok
+CREATE DOMAIN d_rename AS INT DEFAULT 10
+
+statement ok
+ALTER DOMAIN d_rename RENAME TO d_renamed
+
+query T
+SELECT 1::d_renamed
+----
+1
+
+# The old name no longer exist.
+statement error pgcode 42704 type "d_rename" does not exist
+SELECT 1::d_rename
+
+# The implicit array type is also renamed.
+query TT
+SELECT typname, nspname FROM pg_type JOIN pg_namespace ON typnamespace = pg_namespace.oid
+WHERE typname IN ('d_renamed', '_d_renamed') ORDER BY typname
+----
+_d_renamed  public
+d_renamed   public
+
+# Renaming to the same name is an error.
+statement error pgcode 42710 type "test.public.d_renamed" already exists
+ALTER DOMAIN d_renamed RENAME TO d_renamed
+
+# Renaming to a name that already exists fails.
+statement ok
+CREATE DOMAIN d_conflict AS TEXT
+
+statement error pgcode 42710 type "test.public.d_conflict" already exists
+ALTER DOMAIN d_renamed RENAME TO d_conflict
+
+# Renaming to a name that collides with a table fails.
+statement ok
+CREATE TABLE t_conflict (a INT)
+
+statement error pgcode 42P07 relation "test.public.t_conflict" already exists
+ALTER DOMAIN d_renamed RENAME TO t_conflict
+
+# A table referencing the domain by ID should still work after rename.
+statement ok
+CREATE DOMAIN d_ref_rename AS INT DEFAULT 42;
+CREATE TABLE t_dref2 (c d_ref_rename);
+INSERT INTO t_dref2 VALUES (1)
+
+statement ok
+ALTER DOMAIN d_ref_rename RENAME TO d_ref_renamed
+
+query T
+SELECT c FROM t_dref2
+----
+1
+
+statement ok
+DROP TABLE t_dref2;
+DROP DOMAIN d_ref_renamed;
+DROP DOMAIN d_renamed;
+DROP DOMAIN d_conflict;
+DROP TABLE t_conflict
 
 subtest end
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
@@ -176,7 +176,7 @@ func alterDomainOwner(
 func alterDomainRename(
 	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainRename,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN RENAME TO is not supported"))
+	renameForTypeDesc(b, tn, domainType, domainType.TypeID, domainType.ArrayTypeID, string(t.NewName))
 }
 
 func alterDomainSetSchema(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type_rename.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type_rename.go
@@ -6,108 +6,12 @@
 package scbuildstmt
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
-	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
 func alterTypeRename(
 	b BuildCtx, tn *tree.TypeName, enumType *scpb.EnumType, t *tree.AlterTypeRename,
 ) {
-	newName := string(t.NewName)
-
-	typeElts := b.QueryByID(enumType.TypeID)
-	currentNS := typeElts.FilterNamespace().NotToAbsent().MustGetOneElement()
-
-	// Unlike table rename (which no-ops on self-rename), Postgres treats type
-	// rename to the same name as an error.
-	if currentNS.Name == newName {
-		typeName := tree.MakeTableNameFromPrefix(
-			b.NamePrefix(currentNS), tree.Name(newName),
-		)
-		panic(sqlerrors.NewTypeAlreadyExistsError(typeName.String()))
-	}
-
-	checkTypeNameConflicts(b, newName, currentNS)
-
-	newNS := &scpb.Namespace{
-		DatabaseID:   currentNS.DatabaseID,
-		SchemaID:     currentNS.SchemaID,
-		DescriptorID: currentNS.DescriptorID,
-		Name:         newName,
-	}
-	b.Drop(currentNS)
-	b.Add(newNS)
-
-	// Rename the implicit array type.
-	arrayElts := b.QueryByID(enumType.ArrayTypeID)
-	arrayNS := arrayElts.FilterNamespace().NotToAbsent().MustGetOneElement()
-
-	newArrayName := findFreeNameInSchema(b, b.NamePrefix(currentNS), "_"+newName)
-	newArrayNS := &scpb.Namespace{
-		DatabaseID:   arrayNS.DatabaseID,
-		SchemaID:     arrayNS.SchemaID,
-		DescriptorID: arrayNS.DescriptorID,
-		Name:         newArrayName,
-	}
-	b.Drop(arrayNS)
-	b.Add(newArrayNS)
-
-	b.LogEventForExistingPayload(newNS, &eventpb.RenameType{
-		TypeName:    tn.FQString(),
-		NewTypeName: newName,
-	})
-}
-
-// checkTypeNameConflicts checks if the new type name conflicts with an
-// existing object in the same schema.
-func checkTypeNameConflicts(b BuildCtx, newName string, currentNS *scpb.Namespace) {
-	tn := tree.MakeTableNameFromPrefix(
-		b.NamePrefix(currentNS),
-		tree.Name(newName),
-	)
-	ers := b.ResolveRelation(tn.ToUnresolvedObjectName(),
-		ResolveParams{
-			IsExistenceOptional: true,
-			WithOffline:         true,
-			ResolveTypes:        true,
-		})
-	if ers == nil || ers.IsEmpty() {
-		return
-	}
-
-	existingNS := ers.FilterNamespace().NotToAbsent().MustGetZeroOrOneElement()
-	if existingNS == nil {
-		if !ers.FilterNamespace().ToAbsent().IsEmpty() {
-			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
-				"object %q being dropped, try again later", newName))
-		}
-		return
-	}
-
-	if !ers.FilterCompositeType().IsEmpty() || !ers.FilterEnumType().IsEmpty() || !ers.FilterDomainType().IsEmpty() {
-		panic(sqlerrors.NewTypeAlreadyExistsError(tn.String()))
-	}
-	panic(sqlerrors.NewRelationAlreadyExistsError(tn.String()))
-}
-
-// findFreeNameInSchema prepends underscores to candidateName until it doesn't
-// collide with any existing object in the given schema.
-func findFreeNameInSchema(b BuildCtx, prefix tree.ObjectNamePrefix, candidateName string) string {
-	for {
-		tn := tree.MakeTableNameFromPrefix(prefix, tree.Name(candidateName))
-		ers := b.ResolveRelation(tn.ToUnresolvedObjectName(),
-			ResolveParams{
-				IsExistenceOptional: true,
-				WithOffline:         true,
-				ResolveTypes:        true,
-			})
-		if ers == nil || ers.IsEmpty() {
-			return candidateName
-		}
-		candidateName = "_" + candidateName
-	}
+	renameForTypeDesc(b, tn, enumType, enumType.TypeID, enumType.ArrayTypeID, string(t.NewName))
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/type_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/type_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 )
 
@@ -163,6 +164,109 @@ func setSchemaForTypeDesc(
 		NewDescriptorName: newName.FQString(),
 		DescriptorType:    descriptorType,
 	})
+}
+
+// renameForTypeDesc implements RENAME TO for user-defined types that have an
+// associated array type (enums, composites, domains).
+func renameForTypeDesc(
+	b BuildCtx,
+	tn *tree.TypeName,
+	typeElem scpb.Element,
+	typeID catid.DescID,
+	arrayTypeID catid.DescID,
+	newName string,
+) {
+	typeElts := b.QueryByID(typeID)
+	currentNS := typeElts.FilterNamespace().NotToAbsent().MustGetOneElement()
+
+	// Unlike table rename (which no-ops on self-rename), Postgres treats type
+	// rename to the same name as an error.
+	if currentNS.Name == newName {
+		typeName := tree.MakeTableNameFromPrefix(
+			b.NamePrefix(currentNS), tree.Name(newName),
+		)
+		panic(sqlerrors.NewTypeAlreadyExistsError(typeName.String()))
+	}
+
+	checkTypeNameConflicts(b, newName, currentNS)
+
+	newNS := &scpb.Namespace{
+		DatabaseID:   currentNS.DatabaseID,
+		SchemaID:     currentNS.SchemaID,
+		DescriptorID: currentNS.DescriptorID,
+		Name:         newName,
+	}
+	b.Drop(currentNS)
+	b.Add(newNS)
+
+	// Rename the implicit array type.
+	arrayElts := b.QueryByID(arrayTypeID)
+	arrayNS := arrayElts.FilterNamespace().NotToAbsent().MustGetOneElement()
+
+	newArrayName := findFreeNameInSchema(b, b.NamePrefix(typeElem), "_"+newName)
+	newArrayNS := &scpb.Namespace{
+		DatabaseID:   arrayNS.DatabaseID,
+		SchemaID:     arrayNS.SchemaID,
+		DescriptorID: arrayNS.DescriptorID,
+		Name:         newArrayName,
+	}
+	b.Drop(arrayNS)
+	b.Add(newArrayNS)
+
+	b.LogEventForExistingPayload(newNS, &eventpb.RenameType{
+		TypeName:    tn.FQString(),
+		NewTypeName: newName,
+	})
+}
+
+// checkTypeNameConflicts checks if the new type name conflicts with an
+// existing object in the same schema.
+func checkTypeNameConflicts(b BuildCtx, newName string, currentNS *scpb.Namespace) {
+	tn := tree.MakeTableNameFromPrefix(
+		b.NamePrefix(currentNS),
+		tree.Name(newName),
+	)
+	ers := b.ResolveRelation(tn.ToUnresolvedObjectName(),
+		ResolveParams{
+			IsExistenceOptional: true,
+			WithOffline:         true,
+			ResolveTypes:        true,
+		})
+	if ers == nil || ers.IsEmpty() {
+		return
+	}
+
+	existingNS := ers.FilterNamespace().NotToAbsent().MustGetZeroOrOneElement()
+	if existingNS == nil {
+		if !ers.FilterNamespace().ToAbsent().IsEmpty() {
+			panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"object %q being dropped, try again later", newName))
+		}
+		return
+	}
+
+	if !ers.FilterCompositeType().IsEmpty() || !ers.FilterEnumType().IsEmpty() || !ers.FilterDomainType().IsEmpty() {
+		panic(sqlerrors.NewTypeAlreadyExistsError(tn.String()))
+	}
+	panic(sqlerrors.NewRelationAlreadyExistsError(tn.String()))
+}
+
+// findFreeNameInSchema prepends underscores to candidateName until it doesn't
+// collide with any existing object in the given schema.
+func findFreeNameInSchema(b BuildCtx, prefix tree.ObjectNamePrefix, candidateName string) string {
+	for {
+		tn := tree.MakeTableNameFromPrefix(prefix, tree.Name(candidateName))
+		ers := b.ResolveRelation(tn.ToUnresolvedObjectName(),
+			ResolveParams{
+				IsExistenceOptional: true,
+				WithOffline:         true,
+				ResolveTypes:        true,
+			})
+		if ers == nil || ers.IsEmpty() {
+			return candidateName
+		}
+		candidateName = "_" + candidateName
+	}
 }
 
 // moveDescriptorToSchema drops the old Namespace and SchemaChild elements for

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_domain
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_domain
@@ -18,6 +18,18 @@ build skip=sql_dependencies
 ALTER DOMAIN defaultdb.d SET SCHEMA public
 ----
 
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d RENAME TO d2
+----
+- [[Namespace:{DescID: 104, Name: d, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 104, name: d, schemaId: 101}
+- [[Namespace:{DescID: 104, Name: d2, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT]
+  {databaseId: 100, descriptorId: 104, name: d2, schemaId: 101}
+- [[Namespace:{DescID: 105, Name: _d, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]
+  {databaseId: 100, descriptorId: 105, name: _d, schemaId: 101}
+- [[Namespace:{DescID: 105, Name: _d2, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT]
+  {databaseId: 100, descriptorId: 105, name: _d2, schemaId: 101}
+
 setup
 CREATE SCHEMA s;
 ----

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -148,6 +148,20 @@ func TestEndToEndSideEffects_alter_database_configure_zone_multiple(t *testing.T
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_domain_set_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1062,6 +1076,20 @@ func TestExecuteWithDMLInjection_alter_database_configure_zone_multiple(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1982,6 +2010,20 @@ func TestGenerateSchemaChangeCorpus_alter_database_configure_zone_multiple(t *te
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_domain_set_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2896,6 +2938,20 @@ func TestPause_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3816,6 +3872,20 @@ func TestPauseMixedVersion_alter_database_configure_zone_multiple(t *testing.T) 
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_domain_set_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4730,6 +4800,20 @@ func TestRollback_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_multiple"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_domain_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_domain_rename_collision(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.definition
@@ -1,0 +1,7 @@
+setup
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+----
+
+test
+ALTER DOMAIN salmon RENAME TO trout;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.explain
@@ -1,0 +1,48 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+
+/* test */
+EXPLAIN (DDL) ALTER DOMAIN salmon RENAME TO trout;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_trout+), Name: "_trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         └── 6 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"_trout"}
+ │              └── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_trout","SchemaID":101}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_trout+), Name: "_trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-_trout+), Name: "_trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-_trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           └── 8 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"trout","TableID":104}
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":105,"Name":"_trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_trout","SchemaID":101}}
+                └── UpdateTTLScheduleMetadata {"NewName":"_trout","TableID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER DOMAIN salmon RENAME TO trout;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename/alter_domain_rename.side_effects
@@ -1,0 +1,92 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
+
+/* test */
+ALTER DOMAIN salmon RENAME TO trout;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER DOMAIN
+increment telemetry for sql.schema.alter_domain.rename
+write *eventpb.RenameType to event log:
+  newTypeName: trout
+  sql:
+    descriptorId: 104
+    statement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›
+    tag: ALTER DOMAIN
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 6 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 _trout} -> 105
+upsert descriptor #104
+  ...
+     kind: DOMAIN
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: _trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+     referencingDescriptorIds:
+     - 104
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 8 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 _trout} -> 105
+upsert descriptor #104
+  ...
+     kind: DOMAIN
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: _trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+     referencingDescriptorIds:
+     - 104
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TYPE _trout AS ENUM ('rainbow');
+----
+
+test
+ALTER DOMAIN salmon RENAME TO trout;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.explain
@@ -1,0 +1,49 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TYPE _trout AS ENUM ('rainbow');
+
+/* test */
+EXPLAIN (DDL) ALTER DOMAIN salmon RENAME TO trout;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-___trout+), Name: "___trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-___trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+ │         └── 6 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+ │              ├── SetNameInDescriptor {"DescriptorID":105,"Name":"___trout"}
+ │              └── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"___trout","SchemaID":101}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-___trout+), Name: "___trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-___trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 104 (salmon-trout+), Name: "trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 105 (_salmon-___trout+), Name: "___trout", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── PUBLIC → ABSENT Namespace:{DescID: 104 (salmon-trout+), Name: "salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 105 (_salmon-___trout+), Name: "_salmon", ReferencedDescID: 100 (defaultdb), IntValue: 101}
+           └── 8 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":104,"Name":"trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"trout","SchemaID":101}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"trout","TableID":104}
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"_salmon","SchemaID":101}}
+                ├── SetNameInDescriptor {"DescriptorID":105,"Name":"___trout"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":105,"Name":"___trout","SchemaID":101}}
+                └── UpdateTTLScheduleMetadata {"NewName":"___trout","TableID":105}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TYPE _trout AS ENUM ('rainbow');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER DOMAIN salmon RENAME TO trout;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision/alter_domain_rename_collision.side_effects
@@ -1,0 +1,95 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TYPE _trout AS ENUM ('rainbow');
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
++object {100 101 _trout} -> 106
++object {100 101 __trout} -> 107
+
+/* test */
+ALTER DOMAIN salmon RENAME TO trout;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER DOMAIN
+increment telemetry for sql.schema.alter_domain.rename
+write *eventpb.RenameType to event log:
+  newTypeName: trout
+  sql:
+    descriptorId: 104
+    statement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› RENAME TO ‹trout›
+    tag: ALTER DOMAIN
+    user: root
+  typeName: defaultdb.public.salmon
+## StatementPhase stage 1 of 1 with 6 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 ___trout} -> 105
+upsert descriptor #104
+  ...
+     kind: DOMAIN
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: ___trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+     referencingDescriptorIds:
+     - 104
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 8 MutationType ops
+delete object namespace entry {100 101 salmon} -> 104
+delete object namespace entry {100 101 _salmon} -> 105
+add object namespace entry {100 101 trout} -> 104
+add object namespace entry {100 101 ___trout} -> 105
+upsert descriptor #104
+  ...
+     kind: DOMAIN
+     modificationTime: {}
+  -  name: salmon
+  +  name: trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+         withGrantOption: "2"
+       version: 3
+  -  version: "1"
+  +  version: "2"
+upsert descriptor #105
+  ...
+     kind: ALIAS
+     modificationTime: {}
+  -  name: _salmon
+  +  name: ___trout
+     parentId: 100
+     parentSchemaId: 101
+  ...
+     referencingDescriptorIds:
+     - 104
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1


### PR DESCRIPTION
This change implements the `ALTER DOMAIN ...
RENAME TO` statement which was previously
unsupported. The legacy schemachanger did not
support domain types so logic tests are added to
cover the feature.

The `ALTER TYPE` implementation is refactored so
the `ALTER DOMAIN` implementation can use its
logic.

Closes: #166942
Epic: CRDB-62146

Release note (sql change): The `ALTER DOMAIN ...
RENAME TO` statement is supported.

----

**Stacked**: On #170489 so only the top commit needs a review.
