### PR TITLE
sql: retype NULL placeholder values to the declared type in execbuilder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -838,3 +838,19 @@ statement ok
 DEALLOCATE ALL
 
 subtest end
+
+# Regression test for having an untyped NULL as the placeholder value (#153687).
+statement ok
+SET plan_cache_mode = force_generic_plan;
+
+statement ok
+CREATE TABLE t153687 (i INT);
+
+statement ok
+PREPARE p153687(INT) AS SELECT SUBSTRING('k', $1, 1) FROM t153687;
+
+query empty
+EXECUTE p153687(NULL);
+
+statement ok
+RESET plan_cache_mode;

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -134,7 +134,20 @@ func (b *Builder) buildPlaceholder(
 	ctx *buildScalarCtx, scalar opt.ScalarExpr,
 ) (tree.TypedExpr, error) {
 	if b.evalCtx != nil && b.evalCtx.Placeholders != nil {
-		return eval.Expr(b.ctx, b.evalCtx, scalar.Private().(*tree.Placeholder))
+		d, err := eval.Expr(b.ctx, b.evalCtx, scalar.Private().(*tree.Placeholder))
+		if err != nil {
+			return nil, err
+		}
+		if d == tree.DNull {
+			// When a placeholder evaluates to NULL, the result is tree.DNull
+			// which has type Unknown. We must retype it to the placeholder's
+			// declared type so that downstream operators see the correct type.
+			retypedNull, ok := eval.ReType(tree.DNull, scalar.DataType())
+			if ok {
+				return retypedNull, nil
+			}
+		}
+		return d, nil
 	}
 	return b.buildTypedExpr(ctx, scalar)
 }


### PR DESCRIPTION
Previously, when a prepared statement with a generic plan was executed with a NULL placeholder value (e.g. `EXECUTE p(NULL)`), the execbuilder's `buildPlaceholder` would evaluate the placeholder to `tree.DNull`, which always has type `Unknown`. This untyped NULL would propagate through to downstream operators, causing the vectorized engine to fail with errors like "non-int start argument type unknown" when the operator expected a specific type.

This commit fixes the issue by retyping the NULL to the placeholder's declared type (from the memo's `PlaceholderExpr.DataType()`) when `eval.Expr` returns `DNull`. This mirrors the approach used in `buildNull` for `NullExpr` nodes.

Fixes: #153687.

Release note (bug fix): Fixed an internal error that could occur when executing a prepared statement with an untyped NULL argument.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>