### PR TITLE
obs/ash: enable ASH sampling by default

### DIFF
--- a/pkg/obs/ash/sampler.go
+++ b/pkg/obs/ash/sampler.go
@@ -35,7 +35,7 @@ var Enabled = settings.RegisterBoolSetting(
 	settings.SystemVisible,
 	"obs.ash.enabled",
 	"enable active session history sampling",
-	false,
+	true,
 	settings.WithPublic,
 )
 


### PR DESCRIPTION
Flip the `obs.ash.enabled` cluster setting default from `false` to `true`.

Epic: CRDB-63845
Release note (ops change): The `obs.ash.enabled` cluster setting now defaults to `true`, enabling active session history sampling by default.