### PR TITLE
execinfrapb: add progress_message bytes field to BulkProcessorProgress

### DIFF
--- a/pkg/crosscluster/logical/txnmode/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnmode/BUILD.bazel
@@ -56,7 +56,6 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_gogo_protobuf//types",
     ],
 )
 
@@ -76,6 +75,7 @@ go_test(
         "//pkg/crosscluster/logical/ldrdecoder",
         "//pkg/crosscluster/logical/ldrsettings",
         "//pkg/crosscluster/logical/ldrtestutils",
+        "//pkg/crosscluster/logical/txnpb",
         "//pkg/crosscluster/replicationtestutils",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
@@ -101,11 +101,11 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_gogo_protobuf//types",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/crosscluster/logical/txnmode/ldr_applier_processor.go
+++ b/pkg/crosscluster/logical/txnmode/ldr_applier_processor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
-	pbtypes "github.com/gogo/protobuf/types"
 )
 
 var (
@@ -183,7 +182,11 @@ func (p *ldrApplierProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerM
 				p.MoveToDraining(nil)
 				break
 			}
-			meta := p.encodeFrontierMeta(frontier)
+			meta, err := p.encodeFrontierMeta(frontier)
+			if err != nil {
+				p.MoveToDraining(err)
+				break
+			}
 			return nil, meta
 		}
 	}
@@ -310,23 +313,23 @@ func (p *ldrApplierProcessor) encodeDepResolverEvent(
 }
 
 // encodeFrontierMeta creates a ProducerMetadata carrying the applier's
-// frontier timestamp. The gateway metadata handler unmarshals this and
+// frontier timestamp. The gateway metadata handler extracts this and
 // persists it as the job's replicated time.
 func (p *ldrApplierProcessor) encodeFrontierMeta(
 	frontier hlc.Timestamp,
-) *execinfrapb.ProducerMetadata {
-	// TODO(msbutler): any protos are the enemy. Refactor this.
-	marshalledFrontier, err := pbtypes.MarshalAny(&frontier)
+) (*execinfrapb.ProducerMetadata, error) {
+	progressBytes, err := protoutil.Marshal(&txnpb.TxnLDRProcProgress{
+		ApplierID:  p.spec.ApplierID,
+		Checkpoint: frontier,
+	})
 	if err != nil {
-		panic(errors.NewAssertionErrorWithWrappedErrf(
-			err, "marshaling frontier timestamp"))
+		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "marshaling applier frontier progress")
 	}
 	return &execinfrapb.ProducerMetadata{
 		BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
-			ProgressDetails: *marshalledFrontier,
-			NodeID:          base.SQLInstanceID(p.spec.ApplierID),
+			ProgressMessage: progressBytes,
 		},
-	}
+	}, nil
 }
 
 func init() {

--- a/pkg/crosscluster/logical/txnmode/txnmode_dist.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_dist.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrsettings"
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnpb"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -23,9 +24,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	pbtypes "github.com/gogo/protobuf/types"
 )
 
 // PlanTxnReplication constructs a 3-stage DistSQL physical plan for
@@ -385,22 +386,31 @@ func newCheckpointHandler(
 	}
 }
 
+// handleMeta is a MetadataCallbackWriter callback. It only extracts frontier
+// progress; meta.Err is handled separately by DistSQLReceiver.pushMeta, which
+// calls r.SetError(meta.Err) after this callback returns.
 func (ch *checkpointHandler) handleMeta(
 	ctx context.Context, meta *execinfrapb.ProducerMetadata,
 ) error {
-	if meta.BulkProcessorProgress == nil {
+	if meta.BulkProcessorProgress == nil ||
+		len(meta.BulkProcessorProgress.ProgressMessage) == 0 {
 		return nil
 	}
 
-	var frontier hlc.Timestamp
-	if err := pbtypes.UnmarshalAny(
-		&meta.BulkProcessorProgress.ProgressDetails, &frontier,
+	var progress txnpb.TxnLDRProcProgress
+	if err := protoutil.Unmarshal(
+		meta.BulkProcessorProgress.ProgressMessage, &progress,
 	); err != nil {
-		return errors.Wrap(err, "unmarshaling applier frontier")
+		return errors.NewAssertionErrorWithWrappedErrf(
+			err, "unmarshaling applier frontier progress")
 	}
 
-	applierID := meta.BulkProcessorProgress.NodeID
-	ch.applierFrontiers[applierID] = frontier
+	applierID := base.SQLInstanceID(progress.ApplierID)
+	if _, ok := ch.applierFrontiers[applierID]; !ok {
+		return errors.AssertionFailedf(
+			"received frontier progress from unknown applier %d", applierID)
+	}
+	ch.applierFrontiers[applierID] = progress.Checkpoint
 
 	replicatedTime := ch.minFrontier()
 	if !replicatedTime.IsSet() {

--- a/pkg/crosscluster/logical/txnmode/txnmode_dist_test.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_dist_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/ldrsettings"
+	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/txnpb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -27,8 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -251,14 +252,16 @@ func mkts(wallTime int64) hlc.Timestamp {
 func makeFrontierMeta(
 	applierID base.SQLInstanceID, frontier hlc.Timestamp,
 ) *execinfrapb.ProducerMetadata {
-	marshalled, err := pbtypes.MarshalAny(&frontier)
+	progressBytes, err := protoutil.Marshal(&txnpb.TxnLDRProcProgress{
+		ApplierID:  int32(applierID),
+		Checkpoint: frontier,
+	})
 	if err != nil {
 		panic(err)
 	}
 	return &execinfrapb.ProducerMetadata{
 		BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
-			ProgressDetails: *marshalled,
-			NodeID:          applierID,
+			ProgressMessage: progressBytes,
 		},
 	}
 }

--- a/pkg/crosscluster/logical/txnpb/txn.proto
+++ b/pkg/crosscluster/logical/txnpb/txn.proto
@@ -86,3 +86,12 @@ message LDRDepResolverEvent {
     DepResolverForwardUpdate forward_update = 4;
   }
 }
+
+// TxnLDRProcProgress carries the frontier timestamp from a transactional LDR
+// applier processor back to the gateway's checkpoint handler. It is serialized
+// into BulkProcessorProgress.ProgressMessage by the applier and deserialized
+// by the gateway's checkpointHandler.
+message TxnLDRProcProgress {
+  int32 applier_id = 1 [(gogoproto.customname) = "ApplierID"];
+  util.hlc.Timestamp checkpoint = 2 [(gogoproto.nullable) = false];
+}

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -303,7 +303,11 @@ message RemoteProducerMetadata {
     optional bool drained = 9 [(gogoproto.nullable) = false];
     // ProcessorID is the ID of the processor that published the metadata.
     optional int32 processor_id = 10 [(gogoproto.nullable) = false, (gogoproto.customname) = "ProcessorID"];
-    // NEXT ID: 11
+    // ProgressMessage is an opaque bytes field that job-specific DistSQL
+    // processors can use to marshal their own progress protos into. Prefer
+    // this over ProgressDetails, which uses google.protobuf.Any.
+    optional bytes progress_message = 11;
+    // NEXT ID: 12
   }
   // Metrics are unconditionally emitted by table readers.
   message Metrics {


### PR DESCRIPTION
crosscluster/logical: use TxnLDRProcProgress for LDR frontier updates

Define TxnLDRProcProgress in txnpb and use it to carry applier frontier
timestamps through BulkProcessorProgress.ProgressMessage, replacing the
prior approach of marshaling hlc.Timestamp as a protobuf.Any into
BulkProcessorProgress.ProgressDetails.

No mixed-version concerns since txnLDR has not been released.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>

----

execinfrapb: add progress_message bytes field to BulkProcessorProgress

Add an opaque `bytes progress_message` field to BulkProcessorProgress
that job-specific DistSQL processors can use to marshal their own
progress protos into, avoiding the Any type-registration complexity
of the existing progress_details field.

Epic: none
Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>