### PR TITLE
changefeedccl: register cluster metric on initialization time

### DIFF
--- a/pkg/ccl/changefeedccl/cluster_metrics_test.go
+++ b/pkg/ccl/changefeedccl/cluster_metrics_test.go
@@ -34,10 +34,6 @@ import (
 func TestClusterMetricsCheckpointLag_SetAndDelete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Cluster metric constructors panic in test builds when called
-	// outside an init() function
-	defer cmmetrics.TestingAllowNonInitConstruction()()
-
 	cm := &ClusterMetrics{
 		CheckpointLag: cmmetrics.NewWriteStopwatchVec(
 			metaCheckpointLag, timeutil.DefaultTimeSource{}, "job_id", "scope",

--- a/pkg/ccl/changefeedccl/metrics.go
+++ b/pkg/ccl/changefeedccl/metrics.go
@@ -1640,6 +1640,11 @@ func MakeMemoryMetrics(
 }
 
 func init() {
+	// Register metric so cmreader on other nodes knows this metric exists
+	// before any node constructs it.
+	cmmetrics.RegisterLabeledClusterMetric(
+		metaCheckpointLag.Name, metaCheckpointLag, []string{"job_id", "scope"},
+	)
 	jobs.MakeChangefeedMetricsHook = MakeMetrics
 	jobs.MakeChangefeedMemoryMetricsHook = MakeMemoryMetrics
 }


### PR DESCRIPTION
In the changes #169568, we introduced cluster metric for changefeed but we did not register the cluster metric on initialization which could cause panic, since cluster metric are required to be constructed on init time.

Fixes: none
Release note: none