### PR TITLE
release-25.2: crosscluster/logical: switch ownership to CDC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -266,7 +266,9 @@
 /pkg/ccl/jobsccl/            @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
 /pkg/ccl/changefeedccl/      @cockroachdb/cdc-prs
 
-/pkg/crosscluster/       @cockroachdb/disaster-recovery
+/pkg/crosscluster/*.*        @cockroachdb/disaster-recovery
+/pkg/crosscluster/logical    @cockroachdb/cdc-prs
+/pkg/crosscluster/ldrrandgen    @cockroachdb/cdc-prs
 /pkg/backup/          @cockroachdb/disaster-recovery
 /pkg//backup/*_job.go  @cockroachdb/disaster-recovery @cockroachdb/jobs-prs
 /pkg/revert/          @cockroachdb/disaster-recovery

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -222,7 +222,7 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:             sp.name,
-			Owner:            registry.OwnerDisasterRecovery,
+			Owner:            registry.OwnerCDC,
 			Timeout:          60 * time.Minute,
 			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/mixed_version_ldr.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_ldr.go
@@ -41,7 +41,7 @@ func registerLDRMixedVersions(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:             "ldr/mixed-version",
-		Owner:            registry.OwnerDisasterRecovery,
+		Owner:            registry.OwnerCDC,
 		Cluster:          r.MakeClusterSpec(sp.leftNodes+sp.rightNodes+1, spec.WorkloadNode()),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),


### PR DESCRIPTION
Backport 2/2 commits from #163935.

/cc @cockroachdb/release

---

Epic: none

Release note: none

Release justification: test-only changes