### PR TITLE
raftstorebench: skip TestBenchmarkRaftStoreSmokeTest on s390x

### DIFF
--- a/pkg/kv/kvserver/raftstorebench/bench_test.go
+++ b/pkg/kv/kvserver/raftstorebench/bench_test.go
@@ -168,5 +168,8 @@ func maybeReportMetrics(t T, res Result) {
 // is too heavyweight).
 func TestBenchmarkRaftStoreSmokeTest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	if runtime.GOARCH == "s390x" {
+		skip.IgnoreLint(t, "too slow on s390x (see #170571)")
+	}
 	benchmarkRaftStoreInner(t, true)
 }


### PR DESCRIPTION
The test is too slow on `s390x` and times out.

Fixes #170571
Fixes-26.1 #170619
Fixes-25.4 #170444

Epic: none
Release note: None