### PR TITLE
kvserver: deflake TestCrashWhileTruncatingSideloadedEntries

### DIFF
--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rafttrace"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
-	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
@@ -36,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/pebble/vfs"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
@@ -290,6 +287,7 @@ func TestCrashWhileTruncatingSideloadedEntries(t *testing.T) {
 
 		tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 			ReplicationMode:     base.ReplicationManual,
+			EnablePartitioner:   true,
 			ReusableListenerReg: netReg,
 			ServerArgs: base.TestServerArgs{
 				Settings:   settings,
@@ -345,9 +343,6 @@ func TestCrashWhileTruncatingSideloadedEntries(t *testing.T) {
 		}
 		info(leader, "leader")
 		info(follower, "follower")
-
-		// Get the follower's file system.
-		memFS := vfsReg.Get("auto-node2-store1")
 
 		// Before writing more commands, block the raft commands application flow on
 		// the follower replica.
@@ -416,37 +411,14 @@ func TestCrashWhileTruncatingSideloadedEntries(t *testing.T) {
 		<-truncateApplied
 		t.Log("follower applied the truncation")
 
-		// Emulate process crash at this point.
-		//
-		//	1. First, block the outgoing RPC traffic.
-		//	2. Then capture the storage state and start ignoring all the syncs.
-		//	3. Turn down the follower node.
-		//
-		// Without step 1, a flake is possible and has been observed while writing
-		// this test. Between steps 2 and 3, the follower may persist a log entry and
-		// send an ack to leader thinking that it's durable. The leader now, too,
-		// thinks that it's durable, and may a) commit this entry, and b) send a
-		// commit index advancement to the follower. If (b) happens after the follower
-		// restarted and lost the last entry, it will panic because commit index the
-		// leader sent is now above the last index in the log.
-		for _, peer := range []int{0, 2} { // the leader and the other follower
-			dialer := tc.Servers[1].NodeDialer().(*nodedialer.Dialer)
-			for c := 0; c < rpcbase.NumConnectionClasses; c++ {
-				brk, found := dialer.GetCircuitBreaker(tc.Servers[peer].NodeID(), rpcbase.ConnectionClass(c))
-				if found {
-					brk.Report(errors.New("connection is terminated by the test"))
-				}
-			}
-		}
-		crashFS := memFS.CrashClone(vfs.CrashCloneCfg{})
+		// Emulate process crash at this point. CrashNode partitions the node
+		// from all peers (blocking both incoming and outgoing traffic), takes a
+		// CrashClone of the VFS, and stops the server.
 		info(follower, "follower")
 		t.Log("CRASH!")
-		// TODO(pavelkalinnikov): add "crash" helpers to the TestCluster.
-		tc.StopServer(1)
+		tc.CrashNode(1)
 
 		t.Log("restarting follower")
-		vfsReg.Set("auto-node2-store1", crashFS)
-		t.Logf("FS after restart:\n%s", crashFS.String())
 		require.NoError(t, tc.RestartServer(1))
 
 		// Update the follower variable to point at a newly restarted replica.


### PR DESCRIPTION
The test manually emulated a crash by tripping circuit breakers on the follower's dialer, taking a `CrashClone`, and stopping the server.

However, circuit breakers only block the follower's outgoing traffic — the leader can still send messages to the follower via the leader's own connection/stream. This caused a flake where the follower received and acknowledged a raft entry that wasn't synced to disk before `CrashClone`, leading to a panic on restart.

Replace the manual crash emulation with the canonical `tc.CrashNode()`, which uses `rpc.Partitioner` to add bidirectional partitions before taking the crash snapshot, blocking all traffic.

Informs #170454
Fixes #117785

Epic: none
Release note: None