### PR TITLE
admission: derive groupKey per-WorkQueue rather than per-mode

### DIFF
--- a/pkg/util/admission/cpu_time_token_filler.go
+++ b/pkg/util/admission/cpu_time_token_filler.go
@@ -255,8 +255,8 @@ type cpuTimeTokenAllocator struct {
 	// goroutines.
 	//
 	// TODO(ssd): Will be removed in a future commit. GetKVWorkQueue
-	// and groupKeyForWorkLocked can read the mode setting directly;
-	// activeMode and lastMode are unnecessary indirection.
+	// and cpuTimeTokenGroupKeyForWorkInfo can read the mode setting
+	// directly; activeMode and lastMode are unnecessary indirection.
 	lastMode cpuTimeTokenMode
 
 	// refillRates stores the number of CPU time tokens to add to each bucket

--- a/pkg/util/admission/cpu_time_token_grant_coordinator.go
+++ b/pkg/util/admission/cpu_time_token_grant_coordinator.go
@@ -291,6 +291,7 @@ func makeCPUTimeTokenGrantCoordinator(
 			tokensReturned: metrics.TokensReturnedPerTenant[tier],
 		}
 		opts.configHolder = configHolder
+		opts.groupKeyForWorkInfo = cpuTimeTokenGroupKeyForWorkInfo
 		requesters[tier] = makeWorkQueue(
 			ambientCtx, KVWork, &childGranters[tier], settings, wqMetrics, opts)
 		granter.requester[tier] = requesters[tier]

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -363,6 +363,15 @@ type WorkQueue struct {
 	// metrics. Only set when mode == usesCPUTimeTokens.
 	perGroupAggMetrics *groupAggMetrics
 
+	// groupKeyForWorkInfo derives the groupKey for an incoming
+	// request. Set at construction via workQueueOptions; defaults to
+	// tenantGroupKeyForWorkInfo. The CTT WorkQueue installs a
+	// variant that returns an rg-keyed key under resourceManagerMode.
+	// Queues for other purposes (StoreWorkQueue IO queues, SQL
+	// response queues) keep the default and are unaffected by CTT
+	// settings.
+	groupKeyForWorkInfo func(info WorkInfo, sv *settings.Values) groupKey
+
 	timeSource timeutil.TimeSource
 	knobs      *TestingKnobs
 }
@@ -386,6 +395,10 @@ type workQueueOptions struct {
 	// metrics. Only set when mode == usesCPUTimeTokens. See
 	// cpuTimeTokenMetrics for details.
 	perGroupAggMetrics *groupAggMetrics
+	// groupKeyForWorkInfo derives the groupKey for an incoming
+	// request. If nil, initWorkQueue installs tenantGroupKeyForWorkInfo
+	// as the default. See WorkQueue.groupKeyForWorkInfo.
+	groupKeyForWorkInfo func(info WorkInfo, sv *settings.Values) groupKey
 	// configHolder is the per-resource-group config for RM mode. The CTT
 	// grant coordinator passes a shared holder across both per-tier
 	// WorkQueues; other call sites leave this nil and initWorkQueue
@@ -477,6 +490,10 @@ func initWorkQueue(
 		q.configHolder = newResourceGroupConfigHolder(&settings.SV)
 	}
 	q.perGroupAggMetrics = opts.perGroupAggMetrics
+	q.groupKeyForWorkInfo = opts.groupKeyForWorkInfo
+	if q.groupKeyForWorkInfo == nil {
+		q.groupKeyForWorkInfo = tenantGroupKeyForWorkInfo
+	}
 	q.timeSource = timeSource
 	q.knobs = knobs
 	q.mu.defaultCPUTimeTokenEstimator = cpuTimeTokenEstimator{}
@@ -723,14 +740,18 @@ func priorityToResourceGroupKey(pri admissionpb.WorkPriority) groupKey {
 	return rgGroupKey(lowResourceGroupID)
 }
 
-// groupKeyForWorkLocked returns the groupKey for the given WorkInfo.
-// In RM mode the key is derived from WorkInfo.Priority (groupID only);
-// otherwise it is from TenantID (tenantID only).
-//
-// REQUIRES: q.mu is held.
-func (q *WorkQueue) groupKeyForWorkLocked(info WorkInfo) groupKey {
-	q.mu.AssertHeld()
-	if cpuTimeTokenACMode.Get(&q.settings.SV) == resourceManagerMode {
+// tenantGroupKeyForWorkInfo is the default groupKeyForWorkInfo
+// installed by initWorkQueue. Ignores the cluster settings argument.
+func tenantGroupKeyForWorkInfo(info WorkInfo, _ *settings.Values) groupKey {
+	return tenantGroupKey(info.TenantID.ToUint64())
+}
+
+// cpuTimeTokenGroupKeyForWorkInfo is the groupKeyForWorkInfo
+// installed by the CTT WorkQueue. In resourceManagerMode the key is
+// derived from WorkInfo.Priority; otherwise it falls back to
+// tenant-keyed grouping.
+func cpuTimeTokenGroupKeyForWorkInfo(info WorkInfo, sv *settings.Values) groupKey {
+	if cpuTimeTokenACMode.Get(sv) == resourceManagerMode {
 		return priorityToResourceGroupKey(info.Priority)
 	}
 	return tenantGroupKey(info.TenantID.ToUint64())
@@ -786,9 +807,9 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	// needs the flexibility of selectively unlocking on a certain code path.
 	// When changing the code, be careful in making sure the mutex is properly
 	// unlocked on all code paths.
+	gKey := q.groupKeyForWorkInfo(info, &q.settings.SV)
 	q.mu.Lock()
 
-	gKey := q.groupKeyForWorkLocked(info)
 	group, ok := q.mu.groups[gKey]
 	if !ok {
 		// See comment below about CPU time token estimation. If no groupInfo
@@ -900,9 +921,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 						info.ReplicatedWorkInfo.Ingested,
 					)
 				}
-				// Replicated work is a Serverless-mode-only path
-				// (StoreWorkQueue runs in usesTokens mode), so gKey is
-				// always tenant-keyed.
+				// StoreWorkQueue's inner queues install the default
+				// tenantGroupKeyForWorkInfo, so gKey here is always
+				// tenant-keyed and gKey.tenantID is the request's
+				// tenant.
 				q.onAdmittedReplicatedWork.admittedReplicatedWork(
 					roachpb.MustMakeTenantID(gKey.tenantID),
 					info.Priority,
@@ -936,7 +958,7 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 
 		// Re-derive gKey: the mode may have changed while the lock
 		// was released (though mode transitions are not yet supported).
-		gKey = q.groupKeyForWorkLocked(info)
+		gKey = q.groupKeyForWorkInfo(info, &q.settings.SV)
 		admitResponse.groupKey = gKey
 
 		// The group could have been removed. See the comment where the
@@ -1270,8 +1292,8 @@ func (q *WorkQueue) granted(grantChainID grantChainID) int64 {
 			)
 		}
 		defer releaseWaitingWork(item)
-		// Replicated work is a Serverless-mode-only path; same caveat
-		// as the fast-path admit site above.
+		// See the fast-path admit site above for why gKey is
+		// always tenant-keyed here.
 		q.onAdmittedReplicatedWork.admittedReplicatedWork(
 			roachpb.MustMakeTenantID(gKey.tenantID),
 			item.priority,

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -424,6 +424,7 @@ func runCPUTimeTokenWorkQueueTest(t *testing.T, path string) {
 					tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
 				}
 				opts.configHolder = newResourceGroupConfigHolder(&st.SV)
+				opts.groupKeyForWorkInfo = cpuTimeTokenGroupKeyForWorkInfo
 				q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 					workKind, tg, st, metrics, opts).(*WorkQueue)
 				q.knobs.DisableCPUTimeTokenEstimation = true
@@ -647,6 +648,7 @@ func TestCPUTimeTokenEstimation(t *testing.T) {
 		tokensUsed:     cpuMetrics.TokensUsedPerTenant[systemTenant],
 		tokensReturned: cpuMetrics.TokensReturnedPerTenant[systemTenant],
 	}
+	opts.groupKeyForWorkInfo = cpuTimeTokenGroupKeyForWorkInfo
 	timeSource = timeutil.NewManualTime(initialTime)
 	opts.timeSource = timeSource
 	opts.disableEpochClosingGoroutine = true
@@ -794,6 +796,7 @@ func makeCPUTimeTokenWorkQueue(
 	opts.disableEpochClosingGoroutine = true
 	opts.disableGCGroupsAndResetUsed = true
 	opts.configHolder = newResourceGroupConfigHolder(&st.SV)
+	opts.groupKeyForWorkInfo = cpuTimeTokenGroupKeyForWorkInfo
 
 	q = makeWorkQueue(log.MakeTestingAmbientContext(tracing.NewTracer()),
 		KVWork, tg, st, metrics, opts).(*WorkQueue)
@@ -1443,4 +1446,45 @@ func TestGCThenLazyRecreateRecoversFromHolder(t *testing.T) {
 		"recreated group should pick up configured weight, not default")
 	require.True(t, g2.cpuTimeBurstBucket.maxCPU,
 		"recreated group should pick up configured maxCPU, not default")
+}
+
+// TestGroupKeyForWorkInfoSelection verifies the per-WorkQueue
+// groupKey derivation policy: the default (tenantGroupKeyForWorkInfo)
+// ignores cpuTimeTokenACMode, while the CTT variant
+// (cpuTimeTokenGroupKeyForWorkInfo) honors it. This is the
+// invariant that keeps StoreWorkQueue's IO queues from being
+// reshaped by CTT settings.
+func TestGroupKeyForWorkInfoSelection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeTestingClusterSettings()
+	ctx := context.Background()
+	info := WorkInfo{
+		TenantID: roachpb.MustMakeTenantID(5),
+		Priority: admissionpb.NormalPri,
+	}
+
+	for _, tc := range []struct {
+		name string
+		mode cpuTimeTokenMode
+	}{
+		{"off", offMode},
+		{"serverless", serverlessMode},
+		{"resource_manager", resourceManagerMode},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cpuTimeTokenACMode.Override(ctx, &st.SV, tc.mode)
+
+			require.Equal(t, tenantGroupKey(5), tenantGroupKeyForWorkInfo(info, &st.SV),
+				"default keying must not depend on cpuTimeTokenACMode")
+
+			cttKey := cpuTimeTokenGroupKeyForWorkInfo(info, &st.SV)
+			if tc.mode == resourceManagerMode {
+				require.Equal(t, rgGroupKey(highResourceGroupID), cttKey)
+			} else {
+				require.Equal(t, tenantGroupKey(5), cttKey)
+			}
+		})
+	}
 }


### PR DESCRIPTION
`WorkQueue.groupKeyForWorkLocked` read the global `admission.cpu_time_tokens.mode` setting to decide whether to key work by tenant or by resource group. Every `WorkQueue` in the process — including `StoreWorkQueue`'s regular and elastic IO queues — went through this dispatch, so a CTT setting silently reshaped write-token accounting across the package. Setting the mode to `resource_manager` caused `StoreWorkQueue` to produce rg-keyed groupKeys (`tenantID=0`), and the replicated-write fast path crashed on `roachpb.MustMakeTenantID(gKey.tenantID)`.

This change replaces the dispatch method with a `groupKeyForWorkInfo` function field set at construction. The default, `tenantGroupKeyForWorkInfo`, ignores the cluster setting; the CTT grant coordinator installs `cpuTimeTokenGroupKeyForWorkInfo`, which honors `resourceManagerMode`. `StoreWorkQueue`'s IO queues take the default and are no longer affected by CTT settings.

Epic: none