### PR TITLE
roachprod: fix ListVolumes on clusters with local SSDs

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1004,23 +1004,32 @@ func (p *Provider) ListVolumes(l *logger.Logger, v *vm.VM) ([]vm.Volume, error) 
 		}
 	}
 
-	// Unfortunately the above responses contain no common identifier to join
-	// on, so we must resort to indexing. This does not work if the number of
-	// attached disks is different from the number of described volumes, i.e.
-	// if the cluster is using local SSDs.
-	if len(attachedDisks) != len(describedVolumes) {
-		err := errors.Newf("expected to find the same number of attached disks (%d) as described volumes (%d)",
-			len(attachedDisks), len(describedVolumes))
-		return nil, errors.WithHint(err, "is the cluster using local SSD?")
+	// We join the two sets based on their disk name. describedVolumes contains
+	// the metadata required, so we iterate over describedVolumes to retrieve the
+	// needed information. Local SSDs appear in attachedDisks, so we drop them
+	// when creating the bootByName mapping and exclude them from the join. The
+	// boot disk only holds the OS so it is skipped in the join loop. Described
+	// volumes with no matching attached disks are logged and skipped as this can
+	// happen when the two gcloud responses disagree (during a detach).
+	bootByName := make(map[string]bool, len(attachedDisks))
+	for _, a := range attachedDisks {
+		if a.Source == "" && a.Type == "SCRATCH" {
+			continue
+		}
+		bootByName[lastComponent(a.Source)] = a.Boot
 	}
 
 	var volumes []vm.Volume
-	for idx := range attachedDisks {
-		attachedDisk := attachedDisks[idx]
-		if attachedDisk.Boot {
+	for _, describedVolume := range describedVolumes {
+		isBoot, ok := bootByName[describedVolume.Name]
+		if !ok {
+			l.Printf("WARNING: described volume %q on VM %q has no matching attached disk; skipping",
+				describedVolume.Name, v.Name)
 			continue
 		}
-		describedVolume := describedVolumes[idx]
+		if isBoot {
+			continue
+		}
 		size, err := strconv.Atoi(describedVolume.SizeGB)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
ListVolumes joined the responses from `gcloud compute instances describe` and `gcloud compute disks list` by slice index, requiring the two lists to be the same length. Local SSDs appear in the former but not the latter, so on any VM with local SSDs the join failed with:

     expected to find the same number of attached disks (N) as described
     volumes (M)
     HINT: is the cluster using local SSD?

This prevented roachtest from creating "invariant-problem" snapshots on local-SSD clusters.

Switch to a name-keyed join: build a name->boot lookup from the attachedDisks (skipping scratch disks, which have no Source), then iterate the describedVolumes list and use the lookup to skip the boot disk. If a described volume does not have a matching attached disk then a warning is logged and the process continues, as this can occur transiently (e.g. during a detach)

Informs: #168544
Epic: none

Release note: None