### PR TITLE
ui/cluster-ui: forward isEmbedded prop in JobsPageConnected

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/index.ts
@@ -5,5 +5,5 @@
 
 export * from "./jobDescriptionCell";
 export * from "./jobsPage";
-export * from "./jobsTable";
 export * from "./jobsPageConnected";
+export * from "./jobsTable";

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPageConnected.tsx
@@ -19,7 +19,14 @@ import { actions as localStorageActions } from "../../store/localStorage";
 
 import { JobsPage } from "./jobsPage";
 
-export const JobsPageConnected: React.FC = () => {
+export interface JobsPageConnectedProps {
+  // When true, suppresses the page header for use inside a parent layout
+  // that already provides its own heading (e.g. the console nav shell).
+  isEmbedded?: boolean;
+}
+
+export const JobsPageConnected: React.FC<JobsPageConnectedProps> = props => {
+  const { isEmbedded = false } = props;
   const dispatch = useDispatch();
   const sort = useSelector(selectSortSetting);
   const status = useSelector(selectStatusSetting);
@@ -107,6 +114,7 @@ export const JobsPageConnected: React.FC = () => {
       setShow={setShow}
       setType={setType}
       onColumnsChange={onColumnsChange}
+      isEmbedded={isEmbedded}
     />
   );
 };


### PR DESCRIPTION
In v26.2, JobsPageConnected was refactored from Redux connect() HOC to React hooks (useSelector/useDispatch) as part of the SWR migration. The connect() HOC automatically merged parent props with Redux props, but the hooks implementation dropped the props interface entirely, causing isEmbedded and other parent props to be silently ignored.

This caused duplicate "Jobs" titles to appear in CockroachDB Cloud Console when the navigationV2 feature flag is enabled, because the internal page header was always rendered regardless of the isEmbedded prop.

This fix adds JobsPageConnectedProps interface to accept isEmbedded and forwards it to the underlying JobsPage component, restoring the behavior that existed in v25.4 and earlier releases.

Resolves: CNSL-2268
Epic: CNSL-2004

Release note (bug fix): Fixed a regression in v26.2 where the Jobs page displayed duplicate titles when embedded in CockroachDB Cloud Console with the new navigation enabled.