### PR TITLE
ptstorage: lock the meta row during protect and release

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     name = "ptstorage_test",
     size = "large",
     srcs = [
+        "bench_test.go",
         "main_test.go",
         "metrics_test.go",
         "storage_test.go",
@@ -63,6 +64,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
+        "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/protectedts/ptstorage/bench_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/bench_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ptstorage_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptstorage"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// workerCounts is the parallelism sweep shared by the throughput benchmarks
+// in this file.
+// var workerCounts = []int{1, 2, 4, 8, 16, 32, 64, 128}
+var workerCounts = []int{128}
+
+// startBenchServer brings up a single-node in-process server suitable for the
+// throughput benchmarks.
+func startBenchServer(b *testing.B) (protectedts.Storage, func()) {
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(b, base.TestServerArgs{})
+	s := srv.ApplicationLayer()
+
+	protectedts.MaxBytes.Override(ctx, &s.ClusterSettings().SV, 0)
+	protectedts.MaxSpans.Override(ctx, &s.ClusterSettings().SV, 0)
+
+	pts := ptstorage.WithDatabase(
+		ptstorage.New(s.ClusterSettings(), &protectedts.TestingKnobs{}),
+		s.InternalDB().(isql.DB),
+	)
+	return pts, func() { srv.Stopper().Stop(ctx) }
+}
+
+// runConcurrent invokes op b.N times spread across `workers` goroutines and
+// then waits for them all to finish. op receives the per-invocation index in
+// [0, b.N), which is useful for indexing into a per-iteration data set.
+//
+// Errors returned by op are counted and reported as the "errs/op" metric
+// rather than failing the benchmark. Under heavy contention some operations
+// can exhaust the internal kv retry budget; counting rather than failing lets
+// us still produce a comparable baseline number.
+func runConcurrent(b *testing.B, ctx context.Context, workers int, op func(idx int) error) {
+	var (
+		next atomic.Int64
+		errs atomic.Int64
+	)
+
+	b.ResetTimer()
+	err := ctxgroup.GroupWorkers(ctx, workers, func(context.Context, int) error {
+		for {
+			idx := int(next.Add(1) - 1)
+			if idx >= b.N {
+				return nil
+			}
+			if err := op(idx); err != nil {
+				errs.Add(1)
+			}
+		}
+	})
+	require.NoError(b, err)
+	b.StopTimer()
+	b.ReportMetric(float64(errs.Load())/float64(b.N), "errs/op")
+}
+
+// BenchmarkProtect measures the throughput of protectedts.Storage.Protect
+// calls as a function of writer concurrency. Each iteration writes one new
+// record. Per-op wall-clock time reported by the framework is the inverse of
+// sustained throughput: ops/sec = 1e9 / ns/op.
+func BenchmarkProtect(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	pts, stop := startBenchServer(b)
+	defer stop()
+
+	now := hlc.Timestamp{WallTime: 1}
+	target := ptpb.MakeSchemaObjectsTarget([]descpb.ID{42})
+
+	for _, workers := range workerCounts {
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			runConcurrent(b, ctx, workers, func(_ int) error {
+				rec := ptpb.Record{
+					ID:        uuid.MakeV4().GetBytes(),
+					Timestamp: now,
+					Mode:      ptpb.PROTECT_AFTER,
+					Target:    target,
+				}
+				return pts.Protect(ctx, &rec)
+			})
+		})
+	}
+}
+
+// BenchmarkRelease measures the throughput of protectedts.Storage.Release
+// calls as a function of writer concurrency. Each sub-benchmark first
+// pre-populates b.N records (the setup time is excluded from the
+// measurement) and then releases each one exactly once.
+//
+// Like Protect, Release is a read-modify-write against the singleton meta
+// row, so it shares Protect's contention shape on that row.
+func BenchmarkRelease(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	pts, stop := startBenchServer(b)
+	defer stop()
+
+	now := hlc.Timestamp{WallTime: 1}
+	target := ptpb.MakeSchemaObjectsTarget([]descpb.ID{42})
+
+	for _, workers := range workerCounts {
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			ids := prePopulate(b, ctx, pts, workers, b.N, now, target)
+			runConcurrent(b, ctx, workers, func(idx int) error {
+				return pts.Release(ctx, ids[idx])
+			})
+		})
+	}
+}
+
+// prePopulate inserts n protected timestamp records in parallel using
+// `workers` goroutines and returns their IDs. It is intended for use as
+// benchmark setup (before b.ResetTimer); a Protect failure here is fatal
+// because it means the benchmark has nothing meaningful to measure.
+func prePopulate(
+	b *testing.B,
+	ctx context.Context,
+	pts protectedts.Storage,
+	workers, n int,
+	ts hlc.Timestamp,
+	target *ptpb.Target,
+) []uuid.UUID {
+	ids := make([]uuid.UUID, n)
+	var next atomic.Int64
+	err := ctxgroup.GroupWorkers(ctx, workers, func(context.Context, int) error {
+		for {
+			idx := int(next.Add(1) - 1)
+			if idx >= n {
+				return nil
+			}
+			id := uuid.MakeV4()
+			rec := ptpb.Record{
+				ID:        id.GetBytes(),
+				Timestamp: ts,
+				Mode:      ptpb.PROTECT_AFTER,
+				Target:    target,
+			}
+			if err := pts.Protect(ctx, &rec); err != nil {
+				return err
+			}
+			ids[idx] = id
+		}
+	})
+	require.NoError(b, err)
+	return ids
+}

--- a/pkg/kv/kvserver/protectedts/ptstorage/sql.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/sql.go
@@ -7,10 +7,14 @@ package ptstorage
 
 const (
 
-	// currentMetaCTE is used by all queries which access the meta row.
-	// The query returns a default row if there currently is no meta row.
-	// At the time of writing, there will never be a physical row in the meta
-	// table with version zero.
+	// currentMetaCTE reads the meta row, returning a default zero row if
+	// none exists yet. At the time of writing, there will never be a
+	// physical row in the meta table with version zero.
+	//
+	// This is the read-only variant, used by getMetadataQuery. Mutating
+	// queries (protect, release) use currentMetaCTEForUpdate to avoid the
+	// WriteTooOld retry storm that concurrent writers would otherwise
+	// trigger on the shared meta row.
 	currentMetaCTE = `
 SELECT
     version, num_records, num_spans, total_bytes
@@ -24,9 +28,35 @@ LIMIT
     1
 `
 
+	// currentMetaCTEForUpdate is the locking variant of currentMetaCTE used by
+	// the protect and release queries. Both are read-modify-writes against
+	// the singleton meta row: every concurrent caller reads the same row,
+	// then upserts a new version. Without serialization the writers race,
+	// producing a storm of WriteTooOld retries on the shared key. Acquiring
+	// an exclusive lock on the real meta row during the read forces those
+	// callers to queue rather than collide. The FOR UPDATE clause is bound
+	// to the real-table leg only; the synthetic zero-row fallback (used when
+	// no meta row exists yet) does not lock anything.
+	currentMetaCTEForUpdate = `
+SELECT
+    version, num_records, num_spans, total_bytes
+FROM
+    (
+        SELECT version, num_records, num_spans, total_bytes
+        FROM system.protected_ts_meta
+        FOR UPDATE
+    )
+UNION ALL
+    SELECT 0 AS version, 0 AS num_records, 0 AS num_spans, 0 AS total_bytes
+ORDER BY
+    version DESC
+LIMIT
+    1
+`
+
 	protectQuery = `
 WITH
-    current_meta AS (` + currentMetaCTE + `),
+    current_meta AS (` + currentMetaCTEForUpdate + `),
     checks AS (` + protectChecksCTE + `),
     updated_meta AS (` + protectUpsertMetaCTE + `),
     new_record AS (` + protectInsertRecordCTEWithChecks + `)
@@ -114,7 +144,7 @@ RETURNING
 
 	releaseQueryWithMeta = `
 WITH
-    current_meta AS (` + currentMetaCTE + `),
+    current_meta AS (` + currentMetaCTEForUpdate + `),
     record AS (` + releaseSelectRecordCTE + `),
     updated_meta AS (` + releaseUpsertMetaCTE + `)
 DELETE FROM


### PR DESCRIPTION
Both protect and release read the singleton `system.protected_ts_meta`
row via `currentMetaCTE`, then upsert a new version of it. Concurrent
callers all read the row at the same HLC, all try to write a new
version, and the losers retry on WriteTooOld. Beyond ~100 retries the
call errors out. Successful retries still leave MVCC versions piled up
on the meta row, so subsequent reads scan more history and slow down
over the life of the cluster.

This PR acquires an exclusive lock on the meta row during the CTE
read. Concurrent callers queue at the lock instead of colliding on the
upsert. `FOR UPDATE` is bound to the real-table leg of the CTE so the
synthetic zero-row fallback (used when no meta row exists yet) does
not lock anything. `getMetadataQuery` is read-only and keeps using the
non-locking CTE.

`BenchmarkProtect` and `BenchmarkRelease`, added alongside, measure
throughput at 128 concurrent writers on an in-process server:

```
name                    old sec/op     new sec/op     delta
Protect/workers=128-10  44.744m ± 25%   9.911m ± 42%  -77.85% (p=0.000 n=10)
Release/workers=128-10  55.683m ± 41%   9.768m ± 52%  -82.46% (p=0.000 n=10)
```

The baseline runs also produced retry-budget-exhaustion errors during
ramp-up (`errs/op` 0.13–0.32 in the first trial); after the change
`errs/op` is 0 across all trials.

Epic: none

Release note (performance improvement): Concurrent protected timestamp
protect and release calls (used heavily by backup and changefeed) now
serialize on the meta row rather than racing into WriteTooOld retries.
Workloads that create or release many protected timestamp records at
once see substantially higher throughput.