### PR TITLE
release-26.2.1-rc: build: use gha-releases service account for prod release uploads

### DIFF
--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -83,7 +83,7 @@ env:
   # in repo Variables. Dry-run forces dev GCP regardless, since it
   # writes to dev GCS / Artifact Registry.
   RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
-  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-artifacts@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-signing@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -59,7 +59,7 @@ env:
   # staging-prod repos can run the prod flow against dev GCP. Real prod
   # cutover requires both vars set to true. Dry-run forces dev GCP.
   RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
-  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-artifacts@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
 
 jobs:

--- a/pkg/cmd/release/pick_sha_test.go
+++ b/pkg/cmd/release/pick_sha_test.go
@@ -377,13 +377,12 @@ func TestPostReleaseNotes(t *testing.T) {
 		require.Equal(t, "secret-key", gotKey)
 		require.Equal(t, "application/json", gotContentType)
 
-		// The Go function wraps the payload in {"ReleaseNotesPayload": ...}
-		// so the docs API consumer keeps its existing field name.
-		var wrapped struct {
-			ReleaseNotesPayload releaseNotesPayload `json:"ReleaseNotesPayload"`
-		}
-		require.NoError(t, json.Unmarshal(gotBody, &wrapped))
-		require.Equal(t, payload, wrapped.ReleaseNotesPayload)
+		// The docs API expects the payload fields at the top level of the
+		// request body; an envelope causes 400s on the required-field
+		// validators (Request.CurrentRelease / ReleaseDate / ReleaseSHA).
+		var got releaseNotesPayload
+		require.NoError(t, json.Unmarshal(gotBody, &got))
+		require.Equal(t, payload, got)
 	})
 
 	t.Run("non-2xx returns error including status and body", func(t *testing.T) {

--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -53,9 +53,7 @@ type releaseNotesPayload struct {
 // docs team can re-trigger manually. URL is injected (rather than reading
 // the constant directly) so tests can point at an httptest server.
 func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
-	body, err := json.Marshal(map[string]interface{}{
-		"ReleaseNotesPayload": p,
-	})
+	body, err := json.Marshal(p)
 	if err != nil {
 		return errors.Wrap(err, "marshalling payload")
 	}


### PR DESCRIPTION
Backport 1/1 commits from #170649 on behalf of @rail.

----

The prod RELEASE_GCP_SERVICE_ACCOUNT in release-build-and-sign.yml and release-publish.yml pointed at release-artifacts@releases-prod, whose Gaia ID does not resolve. GCS uploads of release artifacts failed with a 404 ("Gaia id not found").

Point both workflows at gha-releases@releases-prod.iam.gserviceaccount.com, matching what release-pick-sha.yml and release-branch-cut.yml already use.

Epic: none
Release note: None

----

Release justification: release automation changes