### PR TITLE
release: bump release-notes API client timeout to 2 minutes

### DIFF
--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -63,7 +63,10 @@ func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", apiKey)
-	client := httputil.NewClientWithTimeout(30 * time.Second)
+	// The endpoint is a Cloud Function that synthesizes a release-notes
+	// draft; cold starts plus the docs work itself can easily exceed
+	// 30s, so allow a couple of minutes before giving up.
+	client := httputil.NewClientWithTimeout(2 * time.Minute)
 	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "posting to release-notes API")


### PR DESCRIPTION
The docs release-notes endpoint is a Cloud Function that synthesizes a release-notes draft. Cold starts plus the docs work itself can easily exceed the previous 30s client timeout; pick-sha runs were failing the post-pick release-notes call with "context deadline exceeded".

Raise the timeout to 2 minutes so the legitimate work has time to complete while still bounding pathological hangs.

Epic: none
Release note: None