### PR TITLE
roachtest: add bounds check for empty TableStatistics slice to awsdms roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -450,6 +450,9 @@ func checkFullLargeDataLoad(ctx context.Context, t test.Test, dmsCli *dms.Client
 				}
 				// If the task is stopped and stop reason is full load finished, we have succeeded.
 				if *task.Status == "stopped" && *task.StopReason == "Stop Reason FULL_LOAD_ONLY_FINISHED" {
+					if len(tableStats.TableStatistics) == 0 {
+						return errors.New("table statistics not yet available")
+					}
 					// Check we full loaded the right number of rows
 					if tableStats.TableStatistics[0].FullLoadRows == awsrdsNumInitialRows {
 						t.L().Printf("test_table_large successfully replicated all rows")
@@ -459,6 +462,9 @@ func checkFullLargeDataLoad(ctx context.Context, t test.Test, dmsCli *dms.Client
 					}
 					close(closer)
 				} else if *task.Status == "running" {
+					if len(tableStats.TableStatistics) == 0 {
+						return errors.New("table statistics not yet available")
+					}
 					if tableStats.TableStatistics[0].FullLoadRows != awsrdsNumInitialRows {
 						if tableStats.TableStatistics[0].FullLoadRows > int64(numRows) {
 							nonUpdate = 0


### PR DESCRIPTION
## Description

Tracked in [MIG-1133](https://cockroachlabs.atlassian.net/browse/MIG-1133).

Adds bounds check for empty TableStatistics slice to awsdms roachtest to address the case when the DMS task is in `running` status but hasn't yet populated table statistics. There is already a retry loop with exponential backoff that will handle retrying after the error is thrown.

## Testing

awsdms roachtest passes with implemented changes:

```
(feature/himanshu/add-bounds-check-to-awsdms-roachtest)⚡ % PATH="/tmp/pd:$PATH" /opt/homebrew/bin/bash -c '/opt/homebrew/bin/bash pkg/cmd/roachtest/roachstress.sh -b -c 1 "awsdms" -- --cloud=aws'                    ~/go/src/github.com/cockroachdb/cockroach
Running artifacts/62f4c9be2ab-dirty/roachtest  run awsdms --port 8882 --prom-port 2562 --workload artifacts/62f4c9be2ab-dirty/workload --cockroach artifacts/62f4c9be2ab-dirty/cockroach --artifacts artifacts/62f4c9be2ab-dirty/125654 --count 1 --cloud=aws
Locating and verifying binaries for os="linux", arch="amd64"
WARN: unable to find "cockroach-ea" for "amd64": binary or library "cockroach-ea" not found (or was not executable)
WARN: unable to find library libgeos, ignoring: binary or library "libgeos" not found (or was not executable)
WARN: unable to find library libgeos_c, ignoring: binary or library "libgeos_c" not found (or was not executable)
WARN: unable to find library libgeos, ignoring: binary or library "libgeos" not found (or was not executable)
WARN: unable to find library libgeos_c, ignoring: binary or library "libgeos_c" not found (or was not executable)

Found the following binaries:
	cockroach "amd64" at: /Users/himanshushrivastava/go/src/github.com/cockroachdb/cockroach/artifacts/62f4c9be2ab-dirty/cockroach
AMD64 clusters will be provisioned with probability 1.00

Running tests which match regex "awsdms" and are compatible with cloud "aws".

fallback runner logs in: artifacts/62f4c9be2ab-dirty/125654/roachtest.crdb.log
2026/05/20 16:56:54 run.go:431: test runner logs in: artifacts/62f4c9be2ab-dirty/125654/_runner-logs/test_runner-1779296214.log
test runner logs in: artifacts/62f4c9be2ab-dirty/125654/_runner-logs/test_runner-1779296214.log
HTTP server listening on port 8882 on localhost: http://localhost:8882/
2026/05/20 16:56:54 run.go:178: global random seed: -2499191107705368714
2026/05/20 16:56:54 test_runner.go:524: test_run_id: himanshushrivastava-1779296214
test_run_id: himanshushrivastava-1779296214
[w0] 2026/05/20 16:56:54 work_pool.go:198: Acquired quota for 4 CPUs
[w0] 2026/05/20 16:56:54 cluster.go:3508: Using randomly chosen arch="amd64", awsdms
2026/05/20 16:56:54 test_runner.go:706: Creating new cluster for test awsdms: n1cpu4 (arch="amd64")
[w0] 2026/05/20 16:58:22 test_runner.go:948: Cluster himanshushrivastava-1779296214-01-n1cpu4 created for test awsdms (arch="amd64", logs: _runner-logs/cluster-create/himanshushrivastava-1779296214-01-n1cpu4.log)
Cluster himanshushrivastava-1779296214-01-n1cpu4 created for test awsdms (arch="amd64", logs: _runner-logs/cluster-create/himanshushrivastava-1779296214-01-n1cpu4.log)
[w0] 2026/05/20 16:58:22 test_runner.go:1034: Starting test: awsdms:1 on cluster=himanshushrivastava-1779296214-01-n1cpu4 (arch="amd64")
[w0] 2026/05/20 16:58:22 test_runner.go:1048: Setting up cluster himanshushrivastava-1779296214-01-n1cpu4 for test awsdms
Setting up cluster himanshushrivastava-1779296214-01-n1cpu4 for test awsdms
2026/05/20 16:58:22 test_impl.go:208: Runtime assertions disabled
2026/05/20 16:58:22 cluster.go:841: test status: uploading file
2026/05/20 16:58:34 cluster.go:841: test status:
[w0] 2026/05/20 16:58:34 test_runner.go:1073: Cluster himanshushrivastava-1779296214-01-n1cpu4 ready for test awsdms.
Cluster himanshushrivastava-1779296214-01-n1cpu4 ready for test awsdms.
2026/05/20 16:58:34 cluster.go:841: test status: running test
2026/05/20 16:58:34 cluster.go:841: test status: metamorphically using epoch leases
2026/05/20 16:58:34 cluster.go:841: test status: metamorphically setting "kv.transaction.write_buffering.enabled" to 'true'
2026/05/20 16:58:34 cluster.go:841: test status: Enabling DRPC
2026/05/20 16:58:35 test_runner.go:1555: === RUN   awsdms  [metrics: https://go.crdb.dev/roachtest-grafana/himanshushrivastava-1779296214/awsdms/1779296315201/1779298115201]
=== RUN   awsdms  [metrics: https://go.crdb.dev/roachtest-grafana/himanshushrivastava-1779296214/awsdms/1779296315201/1779298115201]
2026/05/20 16:58:36 awsdms.go:263: attempting to delete old instances
2026/05/20 16:58:38 awsdms.go:1108: waiting for all cluster db instances to be deleted
2026/05/20 16:58:38 awsdms.go:622: setting up new AWS RDS parameter group
2026/05/20 16:58:38 awsdms.go:568: setting up cockroach
2026/05/20 16:58:38 cluster.go:841: test status: starting nodes :1
2026/05/20 16:58:38 awsdms.go:591: setting up DMS replication instance
2026/05/20 16:58:38 cockroach.go:590: WARNING: Service registration and custom ports are not supported for this cluster.
Setting ports to default SQL Port: 26257, and Admin UI Port: 26258.
Attempting to start any additional external SQL processes will fail.
2026/05/20 16:58:39 cockroach.go:638: DRPC: enabling --use-new-rpc (version v26.3.0-alpha.00000000-dev-62f4c9be2abc811fcd580d82505660f46666a8cd-dirty)
2026/05/20 16:58:39 cockroach.go:644: himanshushrivastava-1779296214-01-n1cpu4 (system): starting cockroach processes
2026/05/20 16:58:39 cockroach.go:966: starting node 1
2026/05/20 16:58:39 awsdms.go:655: setting up new AWS RDS cluster
2026/05/20 16:58:41 cockroach.go:1564: himanshushrivastava-1779296214-01-n1cpu4 (system): setting cluster settings
2026/05/20 16:58:41 cockroach.go:1594: WARN: (cluster="himanshushrivastava-1779296214-01-n1cpu4") COCKROACH_DEV_LICENSE has effectively expired: 2019-07-24T20:05:38Z
2026/05/20 16:58:41 cockroach.go:1609: (cluster="himanshushrivastava-1779296214-01-n1cpu4") generated a fresh license: crl-0-EMGN29EGGAEiI0NvY2tyb2FjaCBMYWJzIC0gUHJvZHVjdGlvbiBUZXN0aW5nKAM
2026/05/20 16:58:41 awsdms.go:673: setting up new AWS RDS instance
2026/05/20 16:58:41 awsdms.go:604: waiting for all replication instance to be available
2026/05/20 16:58:42 cockroach.go:1574: SET CLUSTER SETTING
SET CLUSTER SETTING
NOTICE: "debug.panic_on_failed_assertions" is now an alias for "debug.panic_on_failed_assertions.enabled", the preferred setting name
SET CLUSTER SETTING
SET CLUSTER SETTING
SET CLUSTER SETTING
NOTICE: "kv.expiration_leases_only.enabled" is now an alias for "kv.lease.expiration_leases_only.enabled", the preferred setting name
SET CLUSTER SETTING
2026/05/20 16:58:42 cockroach.go:1879: no scheduled backup created as there exists a vm not on google cloud
2026/05/20 16:58:42 client.go:145: invoking PUT for URL: https://grafana.testeng.crdb.io/promhelpers/v1/instance-configs/himanshushrivastava-1779296214-01-n1cpu4
2026/05/20 16:58:44 awsdms.go:687: waiting for RDS instances to become available
2026/05/20 17:05:26 awsdms.go:795: creating replication endpoint roachtest-awsdms-rds-endpoint-local-26-3-0
2026/05/20 17:05:27 awsdms.go:804: testing replication endpoint roachtest-awsdms-rds-endpoint-local-26-3-0
2026/05/20 17:05:27 awsdms.go:850: replication endpoint test failed, retrying: replication test on roachtest-awsdms-rds-endpoint-local-26-3-0 not successful (testing)
2026/05/20 17:05:57 awsdms.go:847: test for roachtest-awsdms-rds-endpoint-local-26-3-0 successful
2026/05/20 17:05:57 awsdms.go:795: creating replication endpoint roachtest-awsdms-crdb-endpoint-local-26-3-0
2026/05/20 17:05:57 awsdms.go:804: testing replication endpoint roachtest-awsdms-crdb-endpoint-local-26-3-0
2026/05/20 17:05:57 awsdms.go:850: replication endpoint test failed, retrying: replication test on roachtest-awsdms-crdb-endpoint-local-26-3-0 not successful (testing)
2026/05/20 17:06:28 awsdms.go:847: test for roachtest-awsdms-crdb-endpoint-local-26-3-0 successful
2026/05/20 17:06:28 awsdms.go:795: creating replication endpoint roachtest-awsdms-large-rds-endpoint-local-26-3-0
2026/05/20 17:06:28 awsdms.go:804: testing replication endpoint roachtest-awsdms-large-rds-endpoint-local-26-3-0
2026/05/20 17:06:29 awsdms.go:850: replication endpoint test failed, retrying: replication test on roachtest-awsdms-large-rds-endpoint-local-26-3-0 not successful (testing)
2026/05/20 17:06:57 awsdms.go:847: test for roachtest-awsdms-large-rds-endpoint-local-26-3-0 successful
2026/05/20 17:06:57 awsdms.go:859: creating replication task for test_table
2026/05/20 17:06:58 awsdms.go:876: waiting for replication task to be ready
2026/05/20 17:07:58 awsdms.go:882: starting replication task
2026/05/20 17:07:59 awsdms.go:905: waiting for replication task to be running
2026/05/20 17:09:00 awsdms.go:859: creating replication task for test_table_no_pk
2026/05/20 17:09:01 awsdms.go:876: waiting for replication task to be ready
2026/05/20 17:10:00 awsdms.go:882: starting replication task
2026/05/20 17:10:00 awsdms.go:905: waiting for replication task to be running
2026/05/20 17:11:05 awsdms.go:859: creating replication task for test_table_large
2026/05/20 17:11:05 awsdms.go:876: waiting for replication task to be ready
2026/05/20 17:12:03 awsdms.go:882: starting replication task
2026/05/20 17:12:03 awsdms.go:905: waiting for replication task to be running
2026/05/20 17:13:01 awsdms.go:302: testing all data gets replicated
2026/05/20 17:13:01 awsdms.go:348: testing all subsequent updates get replicated
2026/05/20 17:13:01 awsdms.go:381: replication not up to date, retrying: expected row to be deleted, still found
(1) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.checkDMSReplicated.func2.func4
  | 	pkg/cmd/roachtest/tests/awsdms.go:357
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.func2
  | 	pkg/cmd/roachtest/tests/awsdms.go:377
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated
  | 	pkg/cmd/roachtest/tests/awsdms.go:384
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runAWSDMS
  | 	pkg/cmd/roachtest/tests/awsdms.go:286
  | main.(*testRunner).runTest.func2
  | 	pkg/cmd/roachtest/test_runner.go:1545
  | runtime.goexit
  | 	src/runtime/asm_arm64.s:1447
Wraps: (2) expected row to be deleted, still found
Error types: (1) *withstack.withStack (2) *errutil.leafError
2026/05/20 17:13:02 awsdms.go:381: replication not up to date, retrying: expected row to be deleted, still found
(1) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.checkDMSReplicated.func2.func4
  | 	pkg/cmd/roachtest/tests/awsdms.go:357
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.func2
  | 	pkg/cmd/roachtest/tests/awsdms.go:377
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated
  | 	pkg/cmd/roachtest/tests/awsdms.go:384
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runAWSDMS
  | 	pkg/cmd/roachtest/tests/awsdms.go:286
  | main.(*testRunner).runTest.func2
  | 	pkg/cmd/roachtest/test_runner.go:1545
  | runtime.goexit
  | 	src/runtime/asm_arm64.s:1447
Wraps: (2) expected row to be deleted, still found
Error types: (1) *withstack.withStack (2) *errutil.leafError
2026/05/20 17:13:02 awsdms.go:381: replication not up to date, retrying: expected row to be deleted, still found
(1) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.checkDMSReplicated.func2.func4
  | 	pkg/cmd/roachtest/tests/awsdms.go:357
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.func2
  | 	pkg/cmd/roachtest/tests/awsdms.go:377
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated
  | 	pkg/cmd/roachtest/tests/awsdms.go:384
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runAWSDMS
  | 	pkg/cmd/roachtest/tests/awsdms.go:286
  | main.(*testRunner).runTest.func2
  | 	pkg/cmd/roachtest/test_runner.go:1545
  | runtime.goexit
  | 	src/runtime/asm_arm64.s:1447
Wraps: (2) expected row to be deleted, still found
Error types: (1) *withstack.withStack (2) *errutil.leafError
2026/05/20 17:13:02 awsdms.go:381: replication not up to date, retrying: expected row to be deleted, still found
(1) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.checkDMSReplicated.func2.func4
  | 	pkg/cmd/roachtest/tests/awsdms.go:357
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.func2
  | 	pkg/cmd/roachtest/tests/awsdms.go:377
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated
  | 	pkg/cmd/roachtest/tests/awsdms.go:384
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runAWSDMS
  | 	pkg/cmd/roachtest/tests/awsdms.go:286
  | main.(*testRunner).runTest.func2
  | 	pkg/cmd/roachtest/test_runner.go:1545
  | runtime.goexit
  | 	src/runtime/asm_arm64.s:1447
Wraps: (2) expected row to be deleted, still found
Error types: (1) *withstack.withStack (2) *errutil.leafError
2026/05/20 17:13:02 awsdms.go:381: replication not up to date, retrying: expected row to be deleted, still found
(1) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.checkDMSReplicated.func2.func4
  | 	pkg/cmd/roachtest/tests/awsdms.go:357
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated.func2
  | 	pkg/cmd/roachtest/tests/awsdms.go:377
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.checkDMSReplicated
  | 	pkg/cmd/roachtest/tests/awsdms.go:384
  | github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runAWSDMS
  | 	pkg/cmd/roachtest/tests/awsdms.go:286
  | main.(*testRunner).runTest.func2
  | 	pkg/cmd/roachtest/test_runner.go:1545
  | runtime.goexit
  | 	src/runtime/asm_arm64.s:1447
Wraps: (2) expected row to be deleted, still found
Error types: (1) *withstack.withStack (2) *errutil.leafError
2026/05/20 17:13:03 awsdms.go:394: testing no pk table has a table error
2026/05/20 17:13:04 awsdms.go:407: table error was found
2026/05/20 17:13:04 awsdms.go:432: testing all rows from test_table_large replicate
2026/05/20 17:13:04 awsdms.go:472: test_table_large still replicating, rows: 2640000/200000000
2026/05/20 17:13:14 awsdms.go:472: test_table_large still replicating, rows: 5220000/200000000
2026/05/20 17:14:13 awsdms.go:472: test_table_large still replicating, rows: 10320000/200000000
2026/05/20 17:15:40 awsdms.go:472: test_table_large still replicating, rows: 16630000/200000000
2026/05/20 17:18:31 awsdms.go:472: test_table_large still replicating, rows: 30930000/200000000
2026/05/20 17:23:03 awsdms.go:472: test_table_large still replicating, rows: 55350000/200000000
2026/05/20 17:28:25 awsdms.go:472: test_table_large still replicating, rows: 88340000/200000000
2026/05/20 17:33:38 awsdms.go:472: test_table_large still replicating, rows: 119260000/200000000
2026/05/20 17:37:56 awsdms.go:472: test_table_large still replicating, rows: 146260000/200000000
2026/05/20 17:43:19 awsdms.go:472: test_table_large still replicating, rows: 179140000/200000000
2026/05/20 17:48:52 awsdms.go:458: test_table_large successfully replicated all rows
2026/05/20 17:48:52 awsdms.go:289: testing complete
2026/05/20 17:48:52 awsdms.go:273: attempting to cleanup instances
2026/05/20 17:48:52 awsdms.go:991: stopping DMS task roachtest-awsdms-dms-task-test-table-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:task:JXFVOIZJUNELBKNI6Z6KDWLOLY)
2026/05/20 17:48:52 awsdms.go:999: waiting for task to be stopped
2026/05/20 17:49:07 awsdms.go:1005: deleting DMS task roachtest-awsdms-dms-task-test-table-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:task:JXFVOIZJUNELBKNI6Z6KDWLOLY)
2026/05/20 17:49:08 awsdms.go:1010: waiting for task to be deleted
2026/05/20 17:50:43 awsdms.go:991: stopping DMS task roachtest-awsdms-dms-task-test-table-no-pk-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:task:US775I5CUVESPLVY7Y55FDKWYA)
2026/05/20 17:50:43 awsdms.go:999: waiting for task to be stopped
2026/05/20 17:51:27 awsdms.go:1005: deleting DMS task roachtest-awsdms-dms-task-test-table-no-pk-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:task:US775I5CUVESPLVY7Y55FDKWYA)
2026/05/20 17:51:27 awsdms.go:1010: waiting for task to be deleted
2026/05/20 17:52:19 awsdms.go:1005: deleting DMS task roachtest-awsdms-dms-task-test-table-large-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:task:P4PHVKCFJJFTFDMZA7ARDALUVM)
2026/05/20 17:52:19 awsdms.go:1010: waiting for task to be deleted
2026/05/20 17:52:50 awsdms.go:1039: deleting DMS endpoint roachtest-awsdms-rds-endpoint-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:endpoint:27RGSU26SBEXTL7HWRRI2LCUM4)
2026/05/20 17:52:50 awsdms.go:1039: deleting DMS endpoint roachtest-awsdms-crdb-endpoint-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:endpoint:ZQJDLWE36FHHFNE67RQT4C7Y6M)
2026/05/20 17:52:50 awsdms.go:1039: deleting DMS endpoint roachtest-awsdms-rds-endpoint-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:endpoint:27RGSU26SBEXTL7HWRRI2LCUM4)
2026/05/20 17:52:50 awsdms.go:1039: deleting DMS endpoint roachtest-awsdms-crdb-endpoint-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:endpoint:ZQJDLWE36FHHFNE67RQT4C7Y6M)
2026/05/20 17:52:51 awsdms.go:1039: deleting DMS endpoint roachtest-awsdms-large-rds-endpoint-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:endpoint:Z6RYSCYMQBADVCICPB2V46AOWY)
2026/05/20 17:52:51 awsdms.go:1039: deleting DMS endpoint roachtest-awsdms-crdb-endpoint-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:endpoint:ZQJDLWE36FHHFNE67RQT4C7Y6M)
2026/05/20 17:52:51 awsdms.go:1067: deleting DMS replication instance roachtest-awsdms-replication-instance-local-26-3-0 (arn: arn:aws:dms:us-east-1:541263489771:rep:RBGTOR3QZVBO5DF27WLJNMOLWE)
2026/05/20 17:52:51 awsdms.go:1076: waiting for all replication instances to be deleted
2026/05/20 17:52:51 awsdms.go:1096: attempting to delete instance roachtest-awsdms-rds-cluster-local-26-3-0-1
2026/05/20 17:52:52 awsdms.go:1108: waiting for all cluster db instances to be deleted
2026/05/20 18:03:10 awsdms.go:1124: attempting to delete cluster roachtest-awsdms-rds-cluster-local-26-3-0
2026/05/20 18:03:10 awsdms.go:1146: attempting to delete param group roachtest-awsdms-param-group-local-26-3-0
2026/05/20 18:03:10 awsdms.go:1169: expected error: failed to delete cluster param group, retrying: operation error RDS: DeleteDBClusterParameterGroup, https response error StatusCode: 400, RequestID: 379bd035-3f9d-4660-a5cb-5bab1fb25432, InvalidDBParameterGroupState: One or more database instances are still members of this parameter group roachtest-awsdms-param-group-local-26-3-0, so the group cannot be deleted
2026/05/20 18:03:37 awsdms.go:1169: expected error: failed to delete cluster param group, retrying: operation error RDS: DeleteDBClusterParameterGroup, https response error StatusCode: 400, RequestID: 1fc9345e-8b9e-4206-82fa-1fddd0aaa1d2, InvalidDBParameterGroupState: One or more database instances are still members of this parameter group roachtest-awsdms-param-group-local-26-3-0, so the group cannot be deleted
2026/05/20 18:04:31 test_runner.go:2698: terminating stray tasks
2026/05/20 18:04:31 test_runner.go:1566: test completed successfully
2026/05/20 18:04:35 test_runner.go:1603: running post test assertions (test-post-assertions.log)
2026/05/20 18:06:21 test_runner.go:1620: running test teardown (test-teardown.log)
2026/05/20 18:06:24 test_runner.go:1327: metrics: https://go.crdb.dev/roachtest-grafana/himanshushrivastava-1779296214/awsdms/1779296315201/1779300502767
2026/05/20 18:06:24 test_runner.go:1419: --- PASS: awsdms (4067.46s)
--- PASS: awsdms (4067.46s)
[w0] 2026/05/20 18:06:24 test_runner.go:1203: test passed: awsdms (run 1)
[w0] 2026/05/20 18:06:24 test_runner.go:860: No tests that can reuse cluster himanshushrivastava-1779296214-01-n1cpu4 [tag:] (1 nodes) found. Destroying.
[w0] 2026/05/20 18:06:24 test_runner.go:870: Releasing quota for 4 CPUs
[w0] 2026/05/20 18:06:24 test_runner.go:882: No work remaining; runWorker is bailing out...
No work remaining; runWorker is bailing out...
[w0] 2026/05/20 18:06:24 cluster.go:2085: destroying cluster himanshushrivastava-1779296214-01-n1cpu4 [tag:] (1 nodes)...
[w0] 2026/05/20 18:06:50 roachprod.go:1626: Destroying cluster himanshushrivastava-1779296214-01-n1cpu4 with 1 nodes
Destroying Prometheus configs
Destroying DNS entries
Destroying VMs
[w0] 2026/05/20 18:06:55 roachprod.go:1605: OK
[w0] 2026/05/20 18:06:55 cluster.go:2095: destroying cluster himanshushrivastava-1779296214-01-n1cpu4 [tag:] (1 nodes)... done
[w0] 2026/05/20 18:06:55 test_runner.go:781: Worker exiting; no cluster to destroy.
2026/05/20 18:06:55 test_runner.go:586: PASS
PASS
2026/05/20 18:07:10 run.go:230: runTests destroying all unsaved clusters
Find run artifacts in artifacts/62f4c9be2ab-dirty/125654
```

## Notes

Epic: none
Release note: none