### PR TITLE
release: fix two more prod release-workflow auth bugs

### DIFF
--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -84,7 +84,7 @@ env:
   # writes to dev GCS / Artifact Registry.
   RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
   RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
-  RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-signing@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
 
 jobs:

--- a/build/github/release-sign-ibm.sh
+++ b/build/github/release-sign-ibm.sh
@@ -60,8 +60,8 @@ for platform in linux-amd64 linux-amd64-fips linux-arm64 linux-s390x; do
   tarball=${cockroach_archive_prefix}-${version}.${platform}.tgz
 
   echo "Downloading $tarball..."
-  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$tarball" "$tarball"
-  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$tarball.sha256sum" "$tarball.sha256sum"
+  gcloud storage cp "gs://$gcs_staged_bucket/$tarball" "$tarball"
+  gcloud storage cp "gs://$gcs_staged_bucket/$tarball.sha256sum" "$tarball.sha256sum"
 
   echo "Verifying checksum..."
   shasum --algorithm 256 --check "$tarball.sha256sum"
@@ -73,6 +73,6 @@ for platform in linux-amd64 linux-amd64-fips linux-arm64 linux-s390x; do
   gpg --homedir "$secrets_dir" --verify "$tarball.asc" "$tarball"
 
   echo "Uploading $tarball.asc..."
-  gsutil -o 'GSUtil:num_retries=5' cp "$tarball.asc" "gs://$gcs_staged_bucket/$tarball.asc"
+  gcloud storage cp "$tarball.asc" "gs://$gcs_staged_bucket/$tarball.asc"
 done
 echo "IBM GPG signing complete."

--- a/build/github/release-sign-macos.sh
+++ b/build/github/release-sign-macos.sh
@@ -60,8 +60,8 @@ for product in cockroach cockroach-sql; do
     target=${base}.tgz
 
     echo "Downloading unsigned archive: $unsigned_file"
-    gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$unsigned_file" "$unsigned_file"
-    gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$unsigned_file.sha256sum" "$unsigned_file.sha256sum"
+    gcloud storage cp "gs://$gcs_staged_bucket/$unsigned_file" "$unsigned_file"
+    gcloud storage cp "gs://$gcs_staged_bucket/$unsigned_file.sha256sum" "$unsigned_file.sha256sum"
 
     echo "Verifying checksum..."
     shasum --algorithm 256 --check "$unsigned_file.sha256sum"
@@ -87,8 +87,8 @@ for product in cockroach cockroach-sql; do
 
     echo "Uploading signed archive: $target"
     shasum --algorithm 256 "$target" > "$target.sha256sum"
-    gsutil -o 'GSUtil:num_retries=5' cp "$target" "gs://$gcs_staged_bucket/$target"
-    gsutil -o 'GSUtil:num_retries=5' cp "$target.sha256sum" "gs://$gcs_staged_bucket/$target.sha256sum"
+    gcloud storage cp "$target" "gs://$gcs_staged_bucket/$target"
+    gcloud storage cp "$target.sha256sum" "gs://$gcs_staged_bucket/$target.sha256sum"
 
   done
 done

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -139,8 +139,8 @@ for product in cockroach cockroach-sql; do
           archive_suffix=zip
       fi
       archive="$product-$version.$platform.$archive_suffix"
-      gsutil cp "gs://$gcs_staged_bucket/$archive" "gs://$gcs_bucket/$archive"
-      gsutil cp "gs://$gcs_staged_bucket/$archive.sha256sum" "gs://$gcs_bucket/$archive.sha256sum"
+      gcloud storage cp "gs://$gcs_staged_bucket/$archive" "gs://$gcs_bucket/$archive"
+      gcloud storage cp "gs://$gcs_staged_bucket/$archive.sha256sum" "gs://$gcs_bucket/$archive.sha256sum"
   done
 done
 tc_end_block "Copy binaries"
@@ -221,8 +221,8 @@ if [[ -n "${PUBLISH_LATEST}" && $prerelease == false ]]; then
         fi
         from="$product-$version.$platform.$archive_suffix"
         to="$product-latest.$platform.$archive_suffix"
-        gsutil cp "gs://$gcs_bucket/$from" "gs://$gcs_bucket/$to"
-        gsutil cp "gs://$gcs_bucket/$from.sha256sum" "gs://$gcs_bucket/$to.sha256sum"
+        gcloud storage cp "gs://$gcs_bucket/$from" "gs://$gcs_bucket/$to"
+        gcloud storage cp "gs://$gcs_bucket/$from.sha256sum" "gs://$gcs_bucket/$to.sha256sum"
     done
   done
 else

--- a/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
@@ -60,7 +60,7 @@ cp build/deploy/Dockerfile "$context/Dockerfile"
 for platform in linux-amd64 linux-arm64 linux-s390x; do
   arch="${platform#linux-}"
   archive="${cockroach_archive_prefix}-${version}.${platform}.tgz"
-  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_bucket/$archive" "$tmpdir/$archive"
+  gcloud storage cp "gs://$gcs_bucket/$archive" "$tmpdir/$archive"
   # Extract into a staging directory, then copy the files the Dockerfile needs
   # into the ${arch}/ subdirectory of the build context.
   staging="$tmpdir/staging-${platform}"
@@ -84,7 +84,7 @@ fips_context="$tmpdir/fips-context"
 mkdir -p "$fips_context/amd64"
 cp build/deploy/Dockerfile "$fips_context/Dockerfile"
 fips_archive="${cockroach_archive_prefix}-${version}.linux-amd64-fips.tgz"
-gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_bucket/$fips_archive" "$tmpdir/$fips_archive"
+gcloud storage cp "gs://$gcs_bucket/$fips_archive" "$tmpdir/$fips_archive"
 fips_staging="$tmpdir/staging-linux-amd64-fips"
 mkdir -p "$fips_staging"
 tar \


### PR DESCRIPTION
Two more independent auth failures in the prod release pipeline.

1. macOS signing impersonated a service account that does not exist. RELEASE_SIGNING_SERVICE_ACCOUNT in release-build-and-sign.yml pointed at release-signing@releases-prod, whose Gaia ID does not resolve. Fetching Apple signing secrets from Secret Manager failed with 404 ("Gaia id not found"). Point the prod arm at gha-releases@releases-prod.iam.gserviceaccount.com, the consolidated prod identity already used by the other release workflows.

2. The IBM docker build fetched cockroach tarballs from GCS using gsutil, which does not honor the WIF credentials file that google-github-actions/auth writes. gsutil fell back to the runner VM's metadata service account and got a 403 from the release-staged bucket. Switch the two gs:// downloads in build-cockroach-release-docker.sh to 'gcloud storage cp', which reads CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE / GOOGLE_APPLICATION_CREDENTIALS and uses the impersonated identity as intended.

Epic: none
Release note: None