### PR TITLE
roachprod: bump local Prometheus version to 2.53.5

### DIFF
--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -19,7 +19,7 @@ const (
 	GrafanaEnterpriseVersion = "9.2.3"
 	// PrometheusVersion is the version of Prometheus installed during the
 	// grafana-start command.
-	PrometheusVersion = "2.27.1"
+	PrometheusVersion = "2.53.5"
 	// NodeExporterVersion is the version of NodeExporter installed on each node
 	// in the startup script and during the grafana-start command.
 	NodeExporterVersion = "1.10.2"


### PR DESCRIPTION
The local Prometheus version (2.27.1)  is over 4 years old and has been observed crashing in CI (e.g. #169503 on s390x). This commit bumps it to 2.53.5, the latest patch in the 2.53 LTS series.

We choose to stay on 2.x instead of upgrading to 3.x to avoid any breaking changes. The 2.x bump is sufficient to address the stability issue mentioned above and will act as an drop-in replacement before we move away from Prometheus entirely (VictoriaMetrics).

The 2.53.5 tarballs have been uploaded to
gs://cockroach-test-artifacts/prometheus/ for amd64, arm64, and s390x. No testdata regeneration was required because PrometheusVersion is not embedded in any cloud-provider startup script.

## Validation

Manually triggered `admission-control/intent-resolution` against this branch via TeamCity:

https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel?branch=170676&buildTypeTab=overview&mode=builds

Resolves: #169559
See also: #169503

Release note: None