### PR TITLE
roachtest: skip revision history in OR recovery test

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -1032,6 +1032,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 		"online-restore-recovery",
 		bspec, bspec,
 		true /* internalSystemsJobs */, false, /* isMultitenant */
+		WithSkipRevisionHistory(),
 		scopes[rand.Intn(len(scopes))],
 	)
 	t.L().Printf("building backup collection")


### PR DESCRIPTION
The OR recovery roachtest would fail if revision history backups were
taken, as the link phase would ingest the SSTs instead of linking them.
Since #170148 moved deleting the SSTs to before the link phase, the link
phase would then fail due to being unable to find the SSTs. This patch
updates the test to avoid taking revision history backups.

Fixes: #170617

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>