### PR TITLE
release-26.1: sql: fix savepoint rollback assertion failure with extended protocol

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -977,76 +977,20 @@ func (ex *connExecutor) execStmtInOpenState(
 	// set / RETURNING can be used instead. However this is not relevant
 	// here.)
 
-	// We first ensure stepping mode is enabled.
-	//
-	// This ought to be done just once when a txn gets initialized;
-	// unfortunately, there are too many places where the txn object
-	// is re-configured, re-set etc without using NewTxnWithSteppingEnabled().
-	//
-	// Manually hunting them down and calling ConfigureStepping() each
-	// time would be error prone (and increase the chance that a future
-	// change would forget to add the call).
-	//
-	// TODO(andrei): really the code should be rearchitected to ensure
-	// that all uses of SQL execution initialize the kv.Txn using a
-	// single/common function. That would be where the stepping mode
-	// gets enabled once for all SQL statements executed "underneath".
-	prevSteppingMode := ex.state.mu.txn.ConfigureStepping(ctx, kv.SteppingEnabled)
-	prevSeqNum := ex.state.mu.txn.GetReadSeqNum()
-	delegatedUnderOuterTxn := ex.executorType == executorTypeInternal && ex.extraTxnState.underOuterTxn
-	var origTs hlc.Timestamp
-	defer func() {
-		_ = ex.state.mu.txn.ConfigureStepping(ctx, prevSteppingMode)
-
-		// If this is an internal executor that is running on behalf of an outer
-		// txn, then we need to step back the txn so that the outer executor uses
-		// the proper sequence number.
-		if delegatedUnderOuterTxn {
-			if err := ex.state.mu.txn.SetReadSeqNum(prevSeqNum); err != nil {
-				retEv, retPayload, retErr = makeErrEvent(err)
-			}
-		}
-	}()
-
-	// Then we create a sequencing point.
-	//
-	// This is not the only place where a sequencing point is placed. There are
-	// also sequencing point after every stage of constraint checks and cascading
-	// actions at the _end_ of a statement's execution.
-	//
-	// If this is an internal executor running on behalf of an outer txn, then we
-	// also need to make sure the external read timestamp is not bumped. Normally,
-	// that happens whenever a READ COMMITTED txn is stepped.
-	//
-	// Under test builds, we add a few extra assertions to ensure that the
-	// external read timestamp does not change if it shouldn't, and that we use
-	// the correct isolation level for internal operations.
-	if buildutil.CrdbTestBuild {
-		if delegatedUnderOuterTxn {
-			origTs = ex.state.mu.txn.ReadTimestamp()
-		} else if ex.executorType == executorTypeInternal {
-			if level := ex.state.mu.txn.IsoLevel(); level != isolation.Serializable {
-				return nil, nil, errors.AssertionFailedf(
-					"internal operation is not using SERIALIZABLE isolation; found=%s",
-					level,
-				)
-			}
-		}
-	}
-	if err := ex.state.mu.txn.Step(ctx, !delegatedUnderOuterTxn /* allowReadTimestampStep */); err != nil {
+	// Create a sequencing point on the txn so this statement reads a
+	// consistent snapshot of writes done by prior statements. This is not
+	// the only place where a sequencing point is placed; there are also
+	// sequencing points after every stage of constraint checks and
+	// cascading actions at the _end_ of a statement's execution.
+	cleanup, err := ex.stepReadSequenceWithRestore(ctx)
+	if err != nil {
 		return makeErrEvent(err)
 	}
-	if buildutil.CrdbTestBuild && delegatedUnderOuterTxn {
-		newTs := ex.state.mu.txn.ReadTimestamp()
-		if newTs != origTs {
-			// This should never happen. If it does, it means that the internal
-			// executor incorrectly moved the txn's read timestamp forward.
-			return nil, nil, errors.AssertionFailedf(
-				"internal executor advanced the txn read timestamp. origTs=%s, newTs=%s",
-				origTs, newTs,
-			)
+	defer func() {
+		if err := cleanup(); err != nil {
+			retEv, retPayload, retErr = makeErrEvent(err)
 		}
-	}
+	}()
 
 	// Auto-commit is disallowed during statement execution if we previously
 	// executed any DDL. This is because may potentially create jobs and do other
@@ -1972,76 +1916,20 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	// set / RETURNING can be used instead. However this is not relevant
 	// here.)
 
-	// We first ensure stepping mode is enabled.
-	//
-	// This ought to be done just once when a txn gets initialized;
-	// unfortunately, there are too many places where the txn object
-	// is re-configured, re-set etc without using NewTxnWithSteppingEnabled().
-	//
-	// Manually hunting them down and calling ConfigureStepping() each
-	// time would be error prone (and increase the chance that a future
-	// change would forget to add the call).
-	//
-	// TODO(andrei): really the code should be rearchitected to ensure
-	// that all uses of SQL execution initialize the kv.Txn using a
-	// single/common function. That would be where the stepping mode
-	// gets enabled once for all SQL statements executed "underneath".
-	prevSteppingMode := ex.state.mu.txn.ConfigureStepping(ctx, kv.SteppingEnabled)
-	prevSeqNum := ex.state.mu.txn.GetReadSeqNum()
-	delegatedUnderOuterTxn := ex.executorType == executorTypeInternal && ex.extraTxnState.underOuterTxn
-	var origTs hlc.Timestamp
-	defer func() {
-		_ = ex.state.mu.txn.ConfigureStepping(ctx, prevSteppingMode)
-
-		// If this is an internal executor that is running on behalf of an outer
-		// txn, then we need to step back the txn so that the outer executor uses
-		// the proper sequence number.
-		if delegatedUnderOuterTxn {
-			if err := ex.state.mu.txn.SetReadSeqNum(prevSeqNum); err != nil {
-				retEv, retPayload, retErr = makeErrEvent(err)
-			}
-		}
-	}()
-
-	// Then we create a sequencing point.
-	//
-	// This is not the only place where a sequencing point is placed. There are
-	// also sequencing point after every stage of constraint checks and cascading
-	// actions at the _end_ of a statement's execution.
-	//
-	// If this is an internal executor running on behalf of an outer txn, then we
-	// also need to make sure the external read timestamp is not bumped. Normally,
-	// that happens whenever a READ COMMITTED txn is stepped.
-	//
-	// Under test builds, we add a few extra assertions to ensure that the
-	// external read timestamp does not change if it shouldn't, and that we use
-	// the correct isolation level for internal operations.
-	if buildutil.CrdbTestBuild {
-		if delegatedUnderOuterTxn {
-			origTs = ex.state.mu.txn.ReadTimestamp()
-		} else if ex.executorType == executorTypeInternal {
-			if level := ex.state.mu.txn.IsoLevel(); level != isolation.Serializable {
-				return nil, nil, errors.AssertionFailedf(
-					"internal operation is not using SERIALIZABLE isolation; found=%s",
-					level,
-				)
-			}
-		}
-	}
-	if err := ex.state.mu.txn.Step(ctx, !delegatedUnderOuterTxn /* allowReadTimestampStep */); err != nil {
+	// Create a sequencing point on the txn so this statement reads a
+	// consistent snapshot of writes done by prior statements. This is not
+	// the only place where a sequencing point is placed; there are also
+	// sequencing points after every stage of constraint checks and
+	// cascading actions at the _end_ of a statement's execution.
+	cleanup, err := ex.stepReadSequenceWithRestore(ctx)
+	if err != nil {
 		return makeErrEvent(err)
 	}
-	if buildutil.CrdbTestBuild && delegatedUnderOuterTxn {
-		newTs := ex.state.mu.txn.ReadTimestamp()
-		if newTs != origTs {
-			// This should never happen. If it does, it means that the internal
-			// executor incorrectly moved the txn's read timestamp forward.
-			return nil, nil, errors.AssertionFailedf(
-				"internal executor advanced the txn read timestamp. origTs=%s, newTs=%s",
-				origTs, newTs,
-			)
+	defer func() {
+		if err := cleanup(); err != nil {
+			retEv, retPayload, retErr = makeErrEvent(err)
 		}
-	}
+	}()
 
 	if portal.isPausable() {
 		p.pausablePortal = portal
@@ -2180,6 +2068,74 @@ func (ex *connExecutor) stepReadSequence(ctx context.Context) error {
 		ex.state.mu.txn.ConfigureStepping(ctx, prevSteppingMode)
 	}
 	return nil
+}
+
+// stepReadSequenceWithRestore creates a sequencing point on the current txn,
+// returning a cleanup function the caller MUST defer.
+//
+// The cleanup always restores the prior stepping mode. If this connExecutor is
+// an internal executor running under an outer user txn, the cleanup also
+// restores the read sequence number so that outer executor uses the proper
+// sequence number. The Step itself is also instructed not to advance the read
+// timestamp in that case — the parent owns timestamp advancement.
+//
+// When the connExecutor is not in stateOpen the call is a no-op and the
+// returned cleanup does nothing.
+//
+// The cleanup may itself return an error from restoring the read sequence
+// number.
+func (ex *connExecutor) stepReadSequenceWithRestore(ctx context.Context) (func() error, error) {
+	if _, isOpen := ex.machine.CurState().(stateOpen); !isOpen {
+		return func() error { return nil }, nil
+	}
+
+	prevSteppingMode := ex.state.mu.txn.ConfigureStepping(ctx, kv.SteppingEnabled)
+	prevSeqNum := ex.state.mu.txn.GetReadSeqNum()
+	delegatedUnderOuterTxn := ex.executorType == executorTypeInternal && ex.extraTxnState.underOuterTxn
+	cleanup := func() error {
+		_ = ex.state.mu.txn.ConfigureStepping(ctx, prevSteppingMode)
+		if delegatedUnderOuterTxn {
+			return ex.state.mu.txn.SetReadSeqNum(prevSeqNum)
+		}
+		return nil
+	}
+
+	// Under test builds, assert that an internal executor running
+	// under an outer txn does not advance the read timestamp and
+	// that any other internal operation runs at SERIALIZABLE
+	// isolation.
+	var origTs hlc.Timestamp
+	if buildutil.CrdbTestBuild {
+		if delegatedUnderOuterTxn {
+			origTs = ex.state.mu.txn.ReadTimestamp()
+		} else if ex.executorType == executorTypeInternal {
+			if level := ex.state.mu.txn.IsoLevel(); level != isolation.Serializable {
+				_ = cleanup()
+				return nil, errors.AssertionFailedf(
+					"internal operation is not using SERIALIZABLE isolation; found=%s",
+					level,
+				)
+			}
+		}
+	}
+
+	if err := ex.state.mu.txn.Step(ctx, !delegatedUnderOuterTxn /* allowReadTimestampStep */); err != nil {
+		_ = cleanup()
+		return nil, err
+	}
+
+	if buildutil.CrdbTestBuild && delegatedUnderOuterTxn {
+		newTs := ex.state.mu.txn.ReadTimestamp()
+		if newTs != origTs {
+			_ = cleanup()
+			return nil, errors.AssertionFailedf(
+				"internal executor advanced the txn read timestamp. origTs=%s, newTs=%s",
+				origTs, newTs,
+			)
+		}
+	}
+
+	return cleanup, nil
 }
 
 // handleAOST gets the AsOfSystemTime clause from the statement, and sets

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -29,7 +29,7 @@ import (
 
 func (ex *connExecutor) execPrepare(
 	ctx context.Context, parseCmd PrepareStmt,
-) (fsm.Event, fsm.EventPayload) {
+) (retEv fsm.Event, retPayload fsm.EventPayload) {
 	retErr := func(err error) (fsm.Event, fsm.EventPayload) {
 		return ex.makeErrEvent(err, parseCmd.AST)
 	}
@@ -82,15 +82,21 @@ func (ex *connExecutor) execPrepare(
 		tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(ex.server.cfg.SV())),
 		statementHintsCache,
 	)
-	// Step the read sequence so that any KV reads during Prepare (e.g.
-	// descriptor resolution) use a sequence number past ignored ranges
-	// from a prior savepoint rollback.
-	if _, isOpen := ex.machine.CurState().(stateOpen); isOpen {
-		if err := ex.stepReadSequence(ctx); err != nil {
-			return retErr(err)
-		}
+	// Create a sequencing point so KV reads issued during prepare (e.g.
+	// descriptor resolution) observe a valid read snapshot, including
+	// after a prior ROLLBACK TO SAVEPOINT. For an internal executor
+	// running under an outer txn, the deferred cleanup undoes the step
+	// so the parent's read snapshot is left untouched.
+	cleanup, err := ex.stepReadSequenceWithRestore(ctx)
+	if err != nil {
+		return retErr(err)
 	}
-	_, err := ex.addPreparedStmt(
+	defer func() {
+		if err := cleanup(); err != nil {
+			retEv, retPayload = retErr(err)
+		}
+	}()
+	_, err = ex.addPreparedStmt(
 		ctx,
 		parseCmd.Name,
 		stmt,
@@ -342,7 +348,7 @@ func (ex *connExecutor) populatePrepared(
 
 func (ex *connExecutor) execBind(
 	ctx context.Context, bindCmd BindStmt,
-) (fsm.Event, fsm.EventPayload) {
+) (retEv fsm.Event, retPayload fsm.EventPayload) {
 	var ps *prep.Statement
 	retErr := func(err error) (fsm.Event, fsm.EventPayload) {
 		if bindCmd.PreparedStatementName != "" {
@@ -405,15 +411,21 @@ func (ex *connExecutor) execBind(
 
 	numQArgs := uint16(len(ps.InferredTypes))
 
-	// Step the read sequence so that any KV reads during Bind (e.g.
+	// Create a sequencing point so KV reads issued during bind (e.g.
 	// ResolveTypeByOID for enum parameters, descriptor staleness checks)
-	// use a sequence number past ignored ranges from a prior savepoint
-	// rollback.
-	if _, isOpen := ex.machine.CurState().(stateOpen); isOpen {
-		if err := ex.stepReadSequence(ctx); err != nil {
-			return retErr(err)
-		}
+	// observe a valid read snapshot, including after a prior ROLLBACK TO
+	// SAVEPOINT. For an internal executor running under an outer txn,
+	// the deferred cleanup undoes the step so the parent's read snapshot
+	// is left untouched.
+	cleanup, err := ex.stepReadSequenceWithRestore(ctx)
+	if err != nil {
+		return retErr(err)
 	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			retEv, retPayload = retErr(err)
+		}
+	}()
 
 	// Decode the arguments, except for internal queries for which we just verify
 	// that the arguments match what's expected.

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -405,6 +405,16 @@ func (ex *connExecutor) execBind(
 
 	numQArgs := uint16(len(ps.InferredTypes))
 
+	// Step the read sequence so that any KV reads during Bind (e.g.
+	// ResolveTypeByOID for enum parameters, descriptor staleness checks)
+	// use a sequence number past ignored ranges from a prior savepoint
+	// rollback.
+	if _, isOpen := ex.machine.CurState().(stateOpen); isOpen {
+		if err := ex.stepReadSequence(ctx); err != nil {
+			return retErr(err)
+		}
+	}
+
 	// Decode the arguments, except for internal queries for which we just verify
 	// that the arguments match what's expected.
 	qargs := make(tree.QueryArguments, numQArgs)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -82,6 +82,14 @@ func (ex *connExecutor) execPrepare(
 		tree.FmtFlags(tree.QueryFormattingForFingerprintsMask.Get(ex.server.cfg.SV())),
 		statementHintsCache,
 	)
+	// Step the read sequence so that any KV reads during Prepare (e.g.
+	// descriptor resolution) use a sequence number past ignored ranges
+	// from a prior savepoint rollback.
+	if _, isOpen := ex.machine.CurState().(stateOpen); isOpen {
+		if err := ex.stepReadSequence(ctx); err != nil {
+			return retErr(err)
+		}
+	}
 	_, err := ex.addPreparedStmt(
 		ctx,
 		parseCmd.Name,

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -2578,3 +2578,87 @@ func TestPrepareAfterSavepointRollback(t *testing.T) {
 	_, err = p.Until(false /* keepErrMsg */, until...)
 	require.NoError(t, err)
 }
+
+// TestBindAfterSavepointRollback reproduces the same class of bug as
+// TestPrepareAfterSavepointRollback but through the Bind (pgwire Bind)
+// entry point instead of Parse. It uses an enum-typed parameter to
+// trigger ResolveTypeByOID inside execBind's resolve() closure — the
+// exact code path that runs BEFORE stepReadSequence in the unfixed code.
+//
+// The test disables descriptor leasing so that the enum type resolution
+// falls through to storage, issuing real KV reads through the user's
+// transaction.
+func TestBindAfterSavepointRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Insecure: true,
+	})
+	defer s.Stopper().Stop(ctx)
+	defer lease.TestingDisableTableLeases()()
+
+	p, err := pgtest.NewPGTest(ctx, s.SQLAddr(), username.RootUser)
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	until := pgtest.ParseMessages("ReadyForQuery")
+
+	// Create an enum type and a table that uses it, plus a plain table
+	// for the INSERT inside the savepoint.
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_insert (id INT PRIMARY KEY)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TYPE te AS ENUM ('a', 'b')"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_bind (id INT, val te)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// Parse OUTSIDE the transaction. The autocommit descriptor collection
+	// used during Parse is discarded, so the enum type will not be cached
+	// in the new transaction's collection created at BEGIN.
+	require.NoError(t, p.SendOneLine(`Parse {"Query": "INSERT INTO t_for_bind VALUES ($1, $2)"}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+	_, err = p.Until(false /* keepErrMsg */, pgtest.ParseMessages("ParseComplete\nReadyForQuery")...)
+	require.NoError(t, err)
+
+	// BEGIN → SAVEPOINT → INSERT → ROLLBACK TO SAVEPOINT.
+	require.NoError(t, p.SendOneLine(`Query {"String": "BEGIN"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "INSERT INTO t_for_insert VALUES (1)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "ROLLBACK TO SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// Bind with enum-typed parameters. resolve() calls ResolveTypeByOID
+	// for the enum OID — the enum is not in this txn's descriptor
+	// collection (Parse used a different collection), so it falls through
+	// to storage (leases disabled) and issues a KV read on the user's txn.
+	// Without the fix, readSeq=0 is inside the ignored range [0, 1].
+	require.NoError(t, p.SendOneLine(`Bind {"ParameterFormatCodes": [0, 0], "Parameters": [{"text":"1"}, {"text":"a"}]}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+
+	_, err = p.Until(
+		true, /* keepErrMsg */
+		pgtest.ParseMessages("BindComplete\nReadyForQuery")...)
+	require.NoError(t, err,
+		"Bind after ROLLBACK TO SAVEPOINT hit readSeq-in-ignored-range assertion; see #169720")
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "COMMIT"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+}

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -384,30 +384,37 @@ func TestHalloweenProblemAvoidance(t *testing.T) {
 		`SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true;`,
 		`CREATE DATABASE t;`,
 		`CREATE TABLE t.test (x FLOAT);`,
+		`CREATE USER halloween_user;`,
 	} {
 		if _, err := db.Exec(s); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	for _, isoLevel := range []tree.IsolationLevel{
-		tree.ReadCommittedIsolation,
-		tree.RepeatableReadIsolation,
-		tree.SerializableIsolation,
-	} {
-		t.Run(isoLevel.String(), func(t *testing.T) {
-			if _, err := db.Exec("DELETE FROM t.test"); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := db.Exec(
-				`INSERT INTO t.test(x) SELECT generate_series(1, $1)::FLOAT`,
-				numRows); err != nil {
-				t.Fatal(err)
-			}
-			// Now slightly modify the values in duplicate rows.
-			// We choose a float +0.1 to ensure that none of the derived
-			// values become duplicate of already-present values.
-			q := fmt.Sprintf(`
+	// Run as both a system user and a regular user: name resolution and
+	// privilege checks routinely take different paths for the two, and
+	// only the regular-user path forces has_table_privilege to invoke
+	// the internal executor here.
+	for _, privUser := range []string{"root", "halloween_user"} {
+		t.Run(privUser, func(t *testing.T) {
+			for _, isoLevel := range []tree.IsolationLevel{
+				tree.ReadCommittedIsolation,
+				tree.RepeatableReadIsolation,
+				tree.SerializableIsolation,
+			} {
+				t.Run(isoLevel.String(), func(t *testing.T) {
+					if _, err := db.Exec("DELETE FROM t.test"); err != nil {
+						t.Fatal(err)
+					}
+					if _, err := db.Exec(
+						`INSERT INTO t.test(x) SELECT generate_series(1, $1)::FLOAT`,
+						numRows); err != nil {
+						t.Fatal(err)
+					}
+					// Now slightly modify the values in duplicate rows.
+					// We choose a float +0.1 to ensure that none of the derived
+					// values become duplicate of already-present values.
+					q := fmt.Sprintf(`
 BEGIN TRANSACTION ISOLATION LEVEL %s;
 INSERT INTO t.test(x)
     -- the if ensures that no row is processed two times.
@@ -418,21 +425,23 @@ SELECT IF(x::INT::FLOAT = x,
        + 0.1
   FROM t.test
   -- the function used here is implemented by using the internal executor.
-  WHERE has_table_privilege('root', ((x+.1)/(x+1) + 1)::int::oid, 'INSERT') IS NULL;
-COMMIT;`, isoLevel.String())
-			if _, err := db.Exec(q); err != nil {
-				t.Fatal(err)
-			}
+  WHERE has_table_privilege('%s', ((x+.1)/(x+1) + 1)::int::oid, 'INSERT') IS NULL;
+COMMIT;`, isoLevel.String(), privUser)
+					if _, err := db.Exec(q); err != nil {
+						t.Fatal(err)
+					}
 
-			// Finally verify that no rows has been operated on more than once.
-			row := db.QueryRow(`SELECT count(DISTINCT x) FROM t.test`)
-			var cnt int
-			if err := row.Scan(&cnt); err != nil {
-				t.Fatal(err)
-			}
+					// Finally verify that no rows has been operated on more than once.
+					row := db.QueryRow(`SELECT count(DISTINCT x) FROM t.test`)
+					var cnt int
+					if err := row.Scan(&cnt); err != nil {
+						t.Fatal(err)
+					}
 
-			if cnt != 2*numRows {
-				t.Fatalf("expected %d rows in final table, got %d", 2*numRows, cnt)
+					if cnt != 2*numRows {
+						t.Fatalf("expected %d rows in final table, got %d", 2*numRows, cnt)
+					}
+				})
 			}
 		})
 	}

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -2500,4 +2501,80 @@ func TestInternalAppNamePrefix(t *testing.T) {
 		finalUserMetrics = sqlServer.Metrics.ExecutedStatementCounters.InsertCount.Count()
 		require.Greater(t, finalUserMetrics, initialUserMetrics)
 	})
+}
+
+// TestPrepareAfterSavepointRollback reproduces #169720: after ROLLBACK TO
+// SAVEPOINT, the transaction's read sequence number can remain in the ignored
+// range because execPrepare (pgwire Parse) does not call Step() to advance it.
+// Any KV read during the Prepare then hits the assertion in
+// checkReadSeqNotIgnoredLocked.
+//
+// The test disables descriptor leasing so that descriptor lookups fall
+// through to storage, issuing real KV reads through the user's transaction.
+// A second table (t_for_parse) is used as the Parse target — it has never
+// been accessed in this transaction, so the descriptor collection has no
+// cached entry and must resolve it from storage.
+func TestPrepareAfterSavepointRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Insecure: true,
+	})
+	defer s.Stopper().Stop(ctx)
+	defer lease.TestingDisableTableLeases()()
+
+	p, err := pgtest.NewPGTest(ctx, s.SQLAddr(), username.RootUser)
+	require.NoError(t, err)
+	defer func() { _ = p.Close() }()
+
+	until := pgtest.ParseMessages("ReadyForQuery")
+
+	// Two tables: t_for_insert is the INSERT target (cached in the txn's
+	// descriptor collection after the INSERT), t_for_parse is the Parse
+	// target (never accessed in this txn, forcing a storage lookup).
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_insert (id INT PRIMARY KEY)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "CREATE TABLE t_for_parse (id INT PRIMARY KEY)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// BEGIN → SAVEPOINT → INSERT → ROLLBACK TO SAVEPOINT.
+	// After the rollback the ignored seqnum range is [0, 1] and readSeq
+	// remains 0 (stepping mode does not auto-advance it).
+	require.NoError(t, p.SendOneLine(`Query {"String": "BEGIN"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "INSERT INTO t_for_insert VALUES (1)"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "ROLLBACK TO SAVEPOINT sp1"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
+
+	// Parse "SELECT * FROM t_for_parse" — descriptor lookup for t_for_parse
+	// goes to storage (leases disabled, not in collection cache) and issues
+	// a KV read on the user's txn. Without the fix, readSeq=0 is inside the
+	// ignored range [0, 1], triggering the assertion.
+	require.NoError(t, p.SendOneLine(`Parse {"Query": "SELECT * FROM t_for_parse"}`))
+	require.NoError(t, p.SendOneLine(`Sync`))
+
+	_, err = p.Until(
+		true, /* keepErrMsg */
+		pgtest.ParseMessages("ParseComplete\nReadyForQuery")...)
+	require.NoError(t, err,
+		"Parse after ROLLBACK TO SAVEPOINT hit readSeq-in-ignored-range assertion; see #169720")
+
+	require.NoError(t, p.SendOneLine(`Query {"String": "COMMIT"}`))
+	_, err = p.Until(false /* keepErrMsg */, until...)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Backport:
  * 2/2 commits from "sql: step read sequence in execPrepare after savepoint rollback" (#169970)
  * 1/1 commits from "sql: don't step the user txn read sequence from internal executor Parse/Bind" (#170325)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Fix bug that results in assertion failures for transactions using the extended protocol.