### PR TITLE
roachtest/sysbench: document MMA impact on tuning settings

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -388,6 +388,20 @@ func registerSysbench(r registry.Registry) {
 						`set cluster setting sql.metrics.statement_details.enabled = false`,
 						`set cluster setting kv.split_queue.enabled = false`,
 						`set cluster setting kv.transaction.write_buffering.enabled = true`,
+						// load_based_rebalancing_interval is still read by the
+						// MMA store rebalancer (mma_store_rebalancer.go) to drive
+						// its periodic loop, so this 10s override remains
+						// meaningful under MMA.
+						//
+						// store_cpu_rebalance_threshold (CPURebalanceThreshold)
+						// is a no-op under MMA: its only consumers are the
+						// legacy StoreRebalancer (disabled when MMA mode is on)
+						// and the LoadConvergence path in TransferLeaseTarget,
+						// which is only reached from that same legacy
+						// rebalancer. MMA uses its own internal overload
+						// classification (mmaprototype/load.go) and does not
+						// read this setting. Kept for now in case MMA is
+						// disabled again; revisit once MMA-default is locked in.
 						`set cluster setting kv.allocator.load_based_rebalancing_interval = '10s'`,
 						`set cluster setting kv.allocator.store_cpu_rebalance_threshold = 0.01`,
 					},


### PR DESCRIPTION
## Summary

The `sysbench-settings` variant explicitly tunes two `kv.allocator.*` cluster settings inherited from the legacy single-metric load-based rebalancer. Now that MMA is the default load-based rebalancer (#169430):

- `kv.allocator.load_based_rebalancing_interval = '10s'` is still read by the MMA store rebalancer (`mma_store_rebalancer.go`) to drive its periodic loop — override remains meaningful.
- `kv.allocator.store_cpu_rebalance_threshold = 0.01` is a **no-op** under MMA: only consumed by the legacy `StoreRebalancer` (disabled when MMA mode is on) and by the `LoadConvergence` path in `TransferLeaseTarget` (only reached from that same legacy code). MMA uses its own internal overload classification in `mmaprototype/load.go`.

Both settings are left in place in case the MMA default is reverted; this PR just adds a comment so the next reader doesn't have to re-derive the situation.

## Changepoint analysis

To check whether the MMA flip on 2026-05-06 caused a visible regression in this workload (or anywhere else), I converted `perf.js.gz` from roachperf into a DuckDB table (schema `cloud, benchmark, date, label, value, unit`) and ran a baseline-vs-post comparison (baseline = 30d before 2026-05-06; post = 2026-05-06 through 2026-05-12). For sysbench-settings/oltp_{read_only,read_write,write_only}/conc=64, all post means sit inside the baseline range and within ~1σ. Top movers elsewhere (cdc/rolling-restart, tpchbench Q3, etc.) decomposed into single-day outliers consistent with prior noise. No regression attributable to MMA.

Fixes #169441

## Test plan

- [x] N/A — comment-only change.

Release note: None
Epic: CRDB-56265