### PR TITLE
roachtest: re-enable perturbation/full tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -419,7 +419,6 @@ func register(r registry.Registry, p perturbation, skipReason string) {
 
 func RegisterTests(r registry.Registry) {
 	const notSkipped = ""
-	const skippedByBankruptcy = "#149662"
 
 	register(r, restart{}, notSkipped)
 	addLong(r, restart{})
@@ -431,17 +430,13 @@ func RegisterTests(r registry.Registry) {
 	for _, asleep := range []bool{true, false} {
 		register(r, splits{asleep: asleep}, notSkipped)
 	}
-
-	// TODO(ssd): We skipped the majority of these tests so that we can focus on
-	// one at a time. These are vaguely ordered by their previous pass rate
-	// (highest first).
-	register(r, intents{}, skippedByBankruptcy)
-	register(r, decommission{}, skippedByBankruptcy)
-	register(r, elasticWorkload{}, skippedByBankruptcy)
-	register(r, partition{}, skippedByBankruptcy)
+	register(r, intents{}, notSkipped)
+	register(r, decommission{}, notSkipped)
+	register(r, elasticWorkload{}, notSkipped)
+	register(r, partition{}, notSkipped)
 	register(r, backfill{}, notSkipped)
-	register(r, &slowDisk{}, skippedByBankruptcy)
-	register(r, addNode{}, skippedByBankruptcy)
+	register(r, &slowDisk{}, notSkipped)
+	register(r, addNode{}, notSkipped)
 }
 
 func (v variations) makeClusterSpec() spec.ClusterSpec {

--- a/pkg/cmd/roachtest/tests/perturbation/network_partition.go
+++ b/pkg/cmd/roachtest/tests/perturbation/network_partition.go
@@ -31,7 +31,13 @@ var _ perturbation = partition{}
 
 func (p partition) setup() variations {
 	p.partitionSite = true
-	v := setup(p, defaultThresholds())
+	// The partition test isolates an entire region (4 of 12 nodes), removing
+	// 1/3 of leaseholders. Foreground throughput naturally drops sharply
+	// while the partition is in effect, and the meaningful pass/fail signal
+	// is whether the cluster returns to baseline once the partition heals.
+	// Skip the perturbation-interval gate; keep the default recovery gate.
+	v := setup(p, noImpactThresholds())
+	v.recoveryImpact = defaultThresholds()
 	v.leaseType = registry.ExpirationLeases
 	// TODO(baptist): Remove this setting once #120073 is fixed.
 	v.clusterSettings["kv.lease.reject_on_leader_unknown.enabled"] = "true"

--- a/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
+++ b/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
@@ -32,6 +32,15 @@ var _ perturbation = &slowDisk{}
 func (s *slowDisk) setup() variations {
 	s.slowLiveness = true
 	s.walFailover = true
+	// With walFailover=true and 2 disks per node (the default for the full
+	// variant), raft log writes fail over to the non-throttled store, so
+	// foreground throughput is expected to stay close to baseline even
+	// while the staller is active. Default thresholds apply to both
+	// intervals; we keep the 1.25x floor (rather than tightening) only to
+	// avoid flakes from the slowLiveness leg, which routes liveness
+	// heartbeats through the slow disk. The metamorphic variant exercises
+	// configurations where walFailover is off and throughput can drop
+	// substantially -- those should override impact independently.
 	return setup(s, defaultThresholds())
 }
 


### PR DESCRIPTION
## Context

The `perturbation/full/*` tests measure the throughput/latency impact of various perturbations (network partition, node restart, decommission, slow disk, etc.) on a CockroachDB cluster. They were valuable for catching latency regressions, but were also persistently flaky.

In July 2025 (#149662), most of them were skipped on a "stabilize one at a time" basis. As of master, only `restart`, `backup`, and `backfill` are running; the rest (`intents`, `decommission`, `elasticWorkload`, `partition`, `slowDisk`, `addNode`) are skipped.

## What this PR does

This PR re-enables all six skipped tests and tunes their pass/fail thresholds.

## Threshold history

At the time of the skip, each test had its own latency-impact threshold (single float, ratio of post-perturbation latency to baseline):

| Test | Pre-skip threshold |
|------|-------------------|
| partition | `Inf` (no gate) |
| slowDisk | `Inf` (no gate) |
| restart | `Inf` (no gate) |
| backfill | `Inf` (no gate) |
| intents | `40x` latency |
| decommission | `5x` latency |
| addNode | `5x` latency |
| backup | `5x` latency |

The pattern: perturbations that intentionally break the cluster (partition, slow disk, restart, backfill) weren't gated at all. Perturbations with expected mild impact had 5x-40x latency thresholds.

## What changed in the harness

Since the skip, the perturbation framework has been substantially rewritten:

- **Throughput-based scoring** (#167696): impact is now measured as a throughput ratio (p5 of per-second throughput vs baseline) rather than blended latency. p99/p50 latency gates exist but are off by default — too noisy at current sample sizes.
- **Default lenient threshold** (#169659): all tests now share `defaultThresholds()` with `maxThroughputImpact: 1.25` (fail if throughput drops below 80% of baseline).
- **Separate perturbation vs recovery thresholds** (#170090): tests can now gate the perturbation interval and the recovery interval independently via `recoveryImpact`. Some perturbations are *expected* to crush foreground throughput while they run; the meaningful pass/fail signal is whether the cluster returns to baseline afterwards.

## Per-test thresholds in this PR

For each test, why we picked what we picked:

| Test | Perturbation | Recovery | Rationale |
|------|-------------|----------|-----------|
| **partition** | `Inf` | `1.25x` | Isolating an entire region removes 1/3 of leaseholders. Foreground throughput drops sharply during the partition (observed ~50% drop, ratio ~2x). The meaningful signal is whether the cluster recovers once the partition heals. Matches historical "never gated during perturbation". |
| **slowDisk** | `1.25x` | `1.25x` | With `walFailover=true` and 2 disks per node (the full variant's default), raft log writes fail over to the non-throttled store, so foreground throughput stays close to baseline. The 1.25x floor mainly absorbs noise from the `slowLiveness` leg, which routes liveness heartbeats through the slow disk. |
| **restart** | `1.25x` | `1.25x` | Clean restart (`cleanRestart=true`, SIGTERM) gracefully drains leases off the target node before stopping. Cluster spends the 10-minute downtime serving traffic from the other nodes with no missing leases. Throughput should stay near baseline. |
| **backfill** | `1.25x` | `1.25x` | Index backfill writes a lot but uses elastic admission control; foreground throughput shouldn't drop meaningfully. |
| **intents** | `1.25x` | `1.25x` | Builds up a large intent backlog then rolls back. Some cluster pressure during cleanup, but not enough to crush throughput. |
| **decommission** | `1.25x` | `1.25x` | Graceful, AC-aware data movement. Doesn't crush throughput. |
| **addNode** | `1.25x` | `1.25x` | Triggers rebalancing; doesn't crush throughput. |
| **backup** | `1.25x` | `1.25x` | Uses elastic priority via AC. |
| **elasticWorkload** | `1.25x` | `1.25x` | The perturbation IS an elastic workload — AC keeps foreground unaffected. |

Only `partition` needs the asymmetric thresholds; the rest use `defaultThresholds()` for both intervals.

## Validation

See the run table in the comment thread for results from running each test on TeamCity. With `USE_SPOT=never` (now the trigger script default per #171008), all six previously-skipped tests pass under the chosen thresholds.

Resolves: #149662
Epic: none

Release note: None