### PR TITLE
release-26.2.1-rc: release/sentry: use 'gcloud storage cp' to download artifact

### DIFF
--- a/pkg/cmd/release/sentry/main.go
+++ b/pkg/cmd/release/sentry/main.go
@@ -225,10 +225,16 @@ func main() {
 	}
 	artifactName := fmt.Sprintf("cockroach-%s.%s.tgz", version, platform)
 	log.Printf("Downloading artifact: %s", artifactName)
-	gsutilCmd := exec.Command("gsutil", "cp",
+	// Use `gcloud storage cp` rather than `gsutil cp`: under Workload
+	// Identity Federation, gsutil does not honor the credentials file
+	// google-github-actions/auth writes and silently falls back to the
+	// runner VM's metadata service account.
+	downloadCmd := exec.Command("gcloud", "storage", "cp",
 		fmt.Sprintf("gs://cockroach-release-artifacts-staged-prod/%s", artifactName),
 		"./")
-	if err := gsutilCmd.Run(); err != nil {
+	downloadCmd.Stdout = os.Stdout
+	downloadCmd.Stderr = os.Stderr
+	if err := downloadCmd.Run(); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Downloaded artifact: %s", artifactName)


### PR DESCRIPTION
Backport 1/1 commits from #170690 on behalf of @rail.

----

The sentry-panic helper shelled out to 'gsutil cp' to fetch the linux-amd64 release tarball. Under Workload Identity Federation, gsutil does not honor the credentials file google-github-actions/auth writes and silently falls back to the runner VM's metadata service account, which does not have access to the release-staged bucket. The download failed with a bare 'exit status 1' because the command's stderr was discarded.

Switch to 'gcloud storage cp', which reads the WIF credentials, and wire the subcommand's stdout/stderr through to the parent so future failures surface real diagnostics instead of an empty exit code.

Epic: none
Release note: None

----

Release justification: release automation changes