### PR TITLE
server: disable GC assist by default

### DIFF
--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -47,9 +47,8 @@ var gcAssistEnabled = settings.RegisterBoolSetting(
 	settings.SystemVisible,
 	"server.gc_assist.enabled",
 	"set to false to dynamically disable GC assist in the Go runtime "+
-		"(requires CockroachDB's forked Go runtime; no-op otherwise); "+
-		"picks up the GODEBUG gcnoassist flag as its default",
-	gcassist.Enabled(), // default reflects GODEBUG=gcnoassist at startup
+		"(requires CockroachDB's forked Go runtime; no-op otherwise)",
+	false, // disabled by default to reduce tail latencies
 )
 
 var gcPressureWarningThreshold = settings.RegisterFloatSetting(


### PR DESCRIPTION
Changes the default value of the server.gc_assist.enabled cluster
setting from true to false. This disables the Go runtime's GC assist
mechanism by default.

Evidence from production workloads shows that the GC assist mechanism
can drive up tail latencies in certain scenarios. Additionally,
CockroachDB workloads have never been observed in practice to actually
require the GC assist mechanism, which aims to prevent runaway memory
usage by having application goroutines participate in garbage collection
when the heap is growing too quickly.

Users who wish to re-enable GC assist can do so by setting
server.gc_assist.enabled to true.

Epic: none

Release note (performance improvement): The server.gc_assist.enabled
cluster setting now defaults to false, disabling the Go runtime's GC
assist mechanism. Production evidence shows that GC assist can increase
tail latencies in certain scenarios while CockroachDB workloads have
not been observed to require it in practice. Users who wish to
re-enable GC assist can set server.gc_assist.enabled to true.