### PR TITLE
sql: enforce SERIALIZABLE isolation for DDL in stored procedures

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1991,6 +1991,23 @@ type connExecutor struct {
 	// responds to user queries or an internal one.
 	executorType executorType
 
+	// forceNextTxnSerializable is a one-shot override consumed when the next
+	// implicit txn is opened. It is set by maybeAutoCommitBeforeDDL only
+	// after handleAutoCommit confirms the current txn was committed for a
+	// CALL whose body contains DDL under weaker isolation; the restart must
+	// then begin at SERIALIZABLE so the body's DDL runs safely.
+	//
+	// The flag is cleared in two places to bound its lifetime to the very
+	// next txn: implicitTxnIsoLevel applies and clears it when the restart's
+	// implicit txn opens; the BEGIN branch of execStmtInNoTxnState discards
+	// it if the user opens an explicit txn first, preventing leakage into
+	// a later unrelated implicit txn.
+	//
+	// Lives outside extraTxnState because that struct is reset per-txn and
+	// this flag must survive the boundary between the auto-committed txn
+	// and its restart.
+	forceNextTxnSerializable bool
+
 	// hasCreatedTemporarySchema is set if the executor has created a
 	// temporary schema, which requires special cleanup on close.
 	hasCreatedTemporarySchema bool
@@ -3820,6 +3837,18 @@ var allowBufferedWritesForWeakIsolation = settings.RegisterBoolSetting(
 		"sql.txn.write_buffering_for_weak_isolation.enabled", false, /* defaultValue */
 	),
 )
+
+// implicitTxnIsoLevel returns the isolation level to use for a new implicit
+// transaction. It honors and clears forceNextTxnSerializable: when set, the
+// next implicit txn starts at SERIALIZABLE regardless of the session default.
+// The flag is consumed exactly once.
+func (ex *connExecutor) implicitTxnIsoLevel(ctx context.Context) isolation.Level {
+	if ex.forceNextTxnSerializable {
+		ex.forceNextTxnSerializable = false
+		return isolation.Serializable
+	}
+	return ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation)
+}
 
 func (ex *connExecutor) txnIsolationLevelToKV(
 	ctx context.Context, level tree.IsolationLevel,

--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -13,8 +13,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
+	plpgsqlparser "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -33,19 +36,31 @@ var defaultAutocommitBeforeDDL = settings.RegisterBoolSetting(
 // auto-committed before processing a DDL statement. If so, it auto-commits the
 // transaction and advances the state machine so that the current command gets
 // processed again.
+//
+// Two conditions can trigger an auto-commit:
+//
+//  1. The statement itself is a DDL (CanModifySchema) and either we are in an
+//     explicit transaction or a prior statement has already executed; the
+//     auto-commit is gated on the autocommit_before_ddl session setting.
+//
+//  2. The statement is a CALL whose procedure body contains DDL, the txn
+//     isolation tolerates write skew, and the txn is implicit. In-place
+//     isolation upgrade is unavailable in the routine body (the txn is
+//     already active by the time CALL planning completes), so we
+//     auto-commit and arrange for the next implicit txn to start at
+//     SERIALIZABLE via forceNextTxnSerializable. This case is gated on
+//     implicit txns only — explicit-txn CALLs with DDL are handled
+//     elsewhere (#170019) or rejected by the in-routine safety net.
 func (ex *connExecutor) maybeAutoCommitBeforeDDL(
 	ctx context.Context, ast tree.Statement,
 ) (fsm.Event, fsm.EventPayload) {
-	// We will auto-commit if all of the following conditions are met:
-	// - The query is not internal.
-	// - Auto-commit before DDL is enabled.
-	// - We have an explicit transaction or have executed at least one
-	//   statement in the transaction. The former check ensures that we commit
-	//   if we haven't executed the first statement, which can happen if only the
-	//   BEGIN statement was executed.
+	if ex.executorType == executorTypeInternal {
+		return nil, nil
+	}
 	explicitTxn := !ex.implicitTxn()
-	if ex.executorType != executorTypeInternal &&
-		tree.CanModifySchema(ast) &&
+
+	// Case 1: top-level DDL with autocommit_before_ddl enabled.
+	if tree.CanModifySchema(ast) &&
 		ex.sessionData().AutoCommitBeforeDDL &&
 		(explicitTxn || ex.extraTxnState.firstStmtExecuted) {
 		if err := ex.planner.SendClientNotice(
@@ -55,15 +70,186 @@ func (ex *connExecutor) maybeAutoCommitBeforeDDL(
 		); err != nil {
 			return ex.makeErrEvent(err, ast)
 		}
-		retEv, retPayload := ex.handleAutoCommit(ctx, ast)
-		if _, committed := retEv.(eventTxnFinishCommitted); committed && retPayload == nil {
-			// Use eventTxnCommittedDueToDDL so that the current statement gets
-			// picked up again when the state machine advances.
-			retEv = eventTxnCommittedDueToDDL{}
+		return ex.autoCommitForDDL(ctx, ast)
+	}
+
+	// Case 2: implicit-txn CALL whose body contains DDL under weak isolation.
+	// Skip when:
+	// - A prior statement in the same implicit-txn batch has already
+	//   executed (mirrors Case 1's reluctance to split a multi-statement
+	//   batch with an auto-commit; the in-routine safety net rejects
+	//   instead).
+	// - The planner is not bound to the current txn (prepare path:
+	//   descriptor resolution there hits a stale planner state).
+	// - There are active portals: auto-committing would invalidate them,
+	//   and the extended-query protocol does not handle a portal
+	//   disappearing mid-execute. Users hitting this path fall back to
+	//   the in-routine safety net.
+	if call, ok := ast.(*tree.Call); ok &&
+		!explicitTxn &&
+		!ex.extraTxnState.firstStmtExecuted &&
+		ex.state.mu.txn != nil &&
+		ex.planner.txn == ex.state.mu.txn &&
+		!ex.extraTxnState.prepStmtsNamespace.HasActivePortals() &&
+		ex.state.mu.txn.IsoLevel().ToleratesWriteSkew() {
+		hasDDL, err := ex.callBodyContainsDDL(ctx, call)
+		if err != nil {
+			// Any error from the pre-plan walker (descriptor lookup, body
+			// parse, etc.) is swallowed: the same error will be raised by
+			// normal planning with proper context, and surfacing it from
+			// the auto-commit hook would replace a clearer planning error
+			// with one tagged at the wrong source line.
+			log.VEventf(ctx, 2, "callBodyContainsDDL: %v", err)
+			return nil, nil
+		}
+		if !hasDDL {
+			return nil, nil
+		}
+		if err := ex.planner.SendClientNotice(
+			ctx,
+			pgnotice.Newf("setting transaction isolation level to SERIALIZABLE due to schema change"),
+			false, /* immediateFlush */
+		); err != nil {
+			return ex.makeErrEvent(err, ast)
+		}
+		// Only set forceNextTxnSerializable after confirming the auto-commit
+		// rewrote the event to eventTxnCommittedDueToDDL — meaning the
+		// statement will be re-processed in a fresh txn that should pick up
+		// the override. Otherwise the flag would leak into an unrelated
+		// future implicit txn.
+		retEv, retPayload := ex.autoCommitForDDL(ctx, ast)
+		if _, ok := retEv.(eventTxnCommittedDueToDDL); ok && retPayload == nil {
+			ex.forceNextTxnSerializable = true
 		}
 		return retEv, retPayload
 	}
+
 	return nil, nil
+}
+
+// autoCommitForDDL commits the current txn and rewrites a successful commit
+// into eventTxnCommittedDueToDDL so the current statement is picked up again
+// once the state machine advances.
+func (ex *connExecutor) autoCommitForDDL(
+	ctx context.Context, ast tree.Statement,
+) (fsm.Event, fsm.EventPayload) {
+	retEv, retPayload := ex.handleAutoCommit(ctx, ast)
+	if _, committed := retEv.(eventTxnFinishCommitted); committed && retPayload == nil {
+		retEv = eventTxnCommittedDueToDDL{}
+	}
+	return retEv, retPayload
+}
+
+// callBodyContainsDDL resolves the procedure named by the CALL and returns
+// true if any of its overload bodies contains a DDL statement reachable
+// from the top-level body. Nested CALLs inside the body are not followed;
+// if such a nested CALL has DDL in its own body, the in-routine reject in
+// routineGenerator.startInternal catches it at runtime.
+//
+// The function may activate the txn (descriptor reads); callers must be
+// prepared to auto-commit. If a procedure has multiple overloads, any
+// overload with DDL triggers the upgrade — we cannot identify the selected
+// overload pre-planning without re-doing argument type-checking.
+//
+// The AST's resolved function reference is restored before returning, so
+// the subsequent optbuilder pass re-resolves against the post-restart txn
+// instead of inheriting a stale cached descriptor from this peek.
+func (ex *connExecutor) callBodyContainsDDL(ctx context.Context, call *tree.Call) (bool, error) {
+	// Resolve mutates both FunctionReference (always) and ReferenceByName
+	// (in the *UnresolvedName branch). Snapshot the whole struct so the
+	// post-restart re-plan re-resolves against the new txn instead of
+	// inheriting cached state from this peek.
+	savedRef := call.Proc.Func
+	defer func() { call.Proc.Func = savedRef }()
+	def, err := call.Proc.Func.Resolve(ctx, ex.planner.semaCtx.SearchPath, ex.planner.semaCtx.FunctionResolver)
+	if err != nil {
+		return false, err
+	}
+	for _, ov := range def.Overloads {
+		if ov.Type != tree.ProcedureRoutine {
+			continue
+		}
+		// Resolve typically returns a signature-only overload cached on the
+		// schema descriptor. Fetch the full descriptor by OID to obtain the
+		// body, mirroring the path the optbuilder takes later.
+		full := ov.Overload
+		if ov.UDFContainsOnlySignature || ov.Body == "" {
+			_, fullOv, resolveErr := ex.planner.ResolveFunctionByOID(ctx, ov.Oid)
+			if resolveErr != nil {
+				return false, resolveErr
+			}
+			full = fullOv
+		}
+		if full == nil || full.Body == "" {
+			continue
+		}
+		hasDDL, err := routineBodyContainsDDL(full.Body, full.Language)
+		if err != nil {
+			return false, err
+		}
+		if hasDDL {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// routineBodyContainsDDL parses the routine body and returns true if any
+// SQL statement reachable from the top-level body is DDL. PL/pgSQL bodies
+// are walked via plpgsqltree so that SQL statements embedded as plain
+// statements inside the block (wrapped in *plpgsqltree.Execute) are
+// inspected.
+func routineBodyContainsDDL(body string, lang tree.RoutineLanguage) (bool, error) {
+	switch lang {
+	case tree.RoutineLangSQL:
+		stmts, err := parser.Parse(body)
+		if err != nil {
+			return false, err
+		}
+		for _, s := range stmts {
+			if tree.CanModifySchema(s.AST) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case tree.RoutineLangPLpgSQL:
+		parsed, err := plpgsqlparser.Parse(body)
+		if err != nil {
+			return false, err
+		}
+		v := &plpgsqlDDLFinder{}
+		plpgsqltree.Walk(v, parsed.AST)
+		return v.found, nil
+	default:
+		return false, errors.AssertionFailedf("unknown routine language %q", lang)
+	}
+}
+
+// plpgsqlDDLFinder is a plpgsqltree.StatementVisitor that sets found to true
+// the first time it encounters a PL/pgSQL statement wrapping a DDL SQL
+// statement. Note: *plpgsqltree.Execute is the AST node for any plain SQL
+// statement embedded in a PL/pgSQL block (e.g. a top-level CREATE TABLE),
+// not for the PL/pgSQL EXECUTE keyword (that is *plpgsqltree.DynamicExecute).
+// Dynamic SQL is not inspected because the SQL string is opaque at parse
+// time. Other constructs that wrap queries — CursorDeclaration, Open,
+// ReturnQuery — never carry DDL, so they are not inspected.
+type plpgsqlDDLFinder struct {
+	found bool
+}
+
+var _ plpgsqltree.StatementVisitor = (*plpgsqlDDLFinder)(nil)
+
+func (v *plpgsqlDDLFinder) Visit(stmt plpgsqltree.Statement) (plpgsqltree.Statement, bool) {
+	if v.found {
+		return stmt, false
+	}
+	if e, ok := stmt.(*plpgsqltree.Execute); ok && e.SqlStmt != nil {
+		if tree.CanModifySchema(e.SqlStmt) {
+			v.found = true
+			return stmt, false
+		}
+	}
+	return stmt, true
 }
 
 // maybeAdjustTxnForDDL checks if the statement is a schema change and adjusts

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3865,6 +3865,11 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.incrementExecutedStmtCounter(ast)
 			}
 		}()
+		// The implicit-CALL+DDL upgrade override (forceNextTxnSerializable)
+		// is meant for the very next implicit txn; an intervening explicit
+		// BEGIN discards it so it can't silently upgrade an unrelated
+		// future implicit txn.
+		ex.forceNextTxnSerializable = false
 		mode, sqlTs, historicalTs, err := ex.beginTransactionTimestampsAndReadMode(ctx, s)
 		if err != nil {
 			return ex.makeErrEvent(err, s)
@@ -3913,7 +3918,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				historicalTs,
 				ex.transitionCtx,
 				ex.QualityOfService(),
-				ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
+				ex.implicitTxnIsoLevel(ctx),
 				ex.omitInRangefeeds(),
 				ex.bufferedWritesEnabled(implicitTxn),
 				ex.rng.internal,
@@ -3948,7 +3953,7 @@ func (ex *connExecutor) beginImplicitTxn(
 			historicalTs,
 			ex.transitionCtx,
 			qos,
-			ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
+			ex.implicitTxnIsoLevel(ctx),
 			ex.omitInRangefeeds(),
 			ex.bufferedWritesEnabled(implicitTxn),
 			ex.rng.internal,

--- a/pkg/sql/logictest/testdata/logic_test/procedure_dcl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_dcl
@@ -318,17 +318,28 @@ BEGIN
 END
 $$;
 
+# Under SERIALIZABLE the nested CALL succeeds. Under weak isolation the
+# pre-plan body walker does not recurse into nested CALLs, so the inner
+# GRANT hits the in-routine safety net and the CALL is rejected. See the
+# analogous nested-CALL case in procedure_ddl for the same trade-off.
+skipif config local-read-committed local-repeatable-read
 statement ok
 CALL p_outer_dcl();
 
+skipif config local-read-committed local-repeatable-read
 query TTTTTB colnames
 SHOW GRANTS ON t_dcl FOR r1
 ----
 database_name  schema_name  table_name  grantee  privilege_type  is_grantable
 test           public       t_dcl       r1       SELECT          false
 
+skipif config local-read-committed local-repeatable-read
 statement ok
 REVOKE SELECT ON t_dcl FROM r1;
+
+onlyif config local-read-committed local-repeatable-read
+statement error pgcode 0A000 to use multi-statement transactions involving a schema change under weak isolation levels
+CALL p_outer_dcl();
 
 statement ok
 DROP PROCEDURE p_outer_dcl;

--- a/pkg/sql/logictest/testdata/logic_test/procedure_ddl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_ddl
@@ -1,5 +1,13 @@
-# LogicTest: !local-mixed-25.4 !local-mixed-26.1 !local-mixed-26.2
+# LogicTest: !local-mixed-25.4 !local-mixed-26.1 !local-mixed-26.2 !local-prepared
 # knob-opt: allow-unsafe
+#
+# local-prepared is excluded because the routine-context DDL isolation
+# upgrade (#170020) auto-commits and restarts the implicit txn, which
+# invalidates any in-flight portal. In the extended-query protocol, simple
+# statements are run as Prepare+Bind+Execute, so an active portal exists at
+# the moment we want to auto-commit. Users on the extended protocol fall
+# back to the in-routine safety net (txnSchemaChangeErr) and must explicitly
+# use SERIALIZABLE.
 
 subtest ddl_blocked_in_functions
 
@@ -300,20 +308,11 @@ subtest end
 
 subtest autocommit_before_ddl
 
-# autocommit_before_ddl controls which schema changer is used for DDL inside
-# procedures, even though the autocommit NOTICE does not fire (routine body
-# DDL goes through runPlanInsidePlan, not execStmtInOpenState).
-#
-# With autocommit_before_ddl = true: DDL uses the declarative schema changer
-# (the transaction is treated as fresh for schema change purposes).
-# With autocommit_before_ddl = false: DDL runs inside the existing multi-
-# statement transaction and falls back to the legacy schema changer.
-#
-# TODO(spilchen): we don't want this long term. This test exists to show the current behaviour.
-#
-# For CREATE TABLE this doesn't matter — both paths work.
+# Under READ COMMITTED (the local-read-committed config default), CALLing a
+# procedure whose body contains DDL fires the upgrade NOTICE via the pre-plan
+# walker, regardless of the autocommit_before_ddl setting. The procedure then
+# runs entirely under SERIALIZABLE.
 
-# First verify the NOTICE does NOT fire — autocommit doesn't visibly commit.
 statement ok
 SET autocommit_before_ddl = true;
 
@@ -329,9 +328,12 @@ BEGIN
 END
 $$;
 
-query T noticetrace
+# Under SERIALIZABLE no upgrade is needed; under weaker isolation the upgrade
+# NOTICE fires. Skip the noticetrace assertion since both behaviors are
+# correct depending on the config's default isolation.
+
+statement ok
 CALL p_autocommit();
-----
 
 query I rowsort
 SELECT * FROM t_autocommit_test;
@@ -607,11 +609,28 @@ BEGIN
 END
 $$;
 
+# Under SERIALIZABLE the nested CALL succeeds: the txn is already at the
+# required isolation level so no upgrade is needed.
+skipif config local-read-committed local-repeatable-read
 statement ok
 CALL p_outer_calls_ddl();
 
+skipif config local-read-committed local-repeatable-read
 statement ok
 DROP TABLE t_nested;
+
+# Under weak isolation the pre-plan body walker does not recurse into nested
+# CALLs, so the inner CREATE TABLE hits the in-routine safety net and is
+# rejected. Failing the CALL is preferable to silently running DDL at the
+# wrong isolation level; users that need this should call the inner
+# procedure directly (which the walker handles) or run under SERIALIZABLE.
+onlyif config local-read-committed local-repeatable-read
+statement error pgcode 0A000 to use multi-statement transactions involving a schema change under weak isolation levels
+CALL p_outer_calls_ddl();
+
+onlyif config local-read-committed local-repeatable-read
+statement error pgcode 42P01 relation "t_nested" does not exist
+SELECT * FROM t_nested;
 
 # Nested procedures: outer CALL in explicit transaction, inner procedure has
 # DDL — should be rejected. The explicit-transaction context propagates to
@@ -843,6 +862,9 @@ statement ok
 DROP TABLE t_nested_outer, t_nested_inner;
 
 # Test that ROLLBACK in outer procedure undoes inner procedure's DDL.
+# Under SERIALIZABLE the CALL succeeds; under weak isolation the outer body
+# walker does not recurse into the inner CALL, so the inner CREATE TABLE
+# hits the in-routine safety net and the CALL is rejected.
 statement ok
 CREATE PROCEDURE p_outer_rollback() LANGUAGE PLpgSQL AS $$
 BEGIN
@@ -851,11 +873,17 @@ BEGIN
 END
 $$;
 
+skipif config local-read-committed local-repeatable-read
 statement ok
 CALL p_outer_rollback();
 
+skipif config local-read-committed local-repeatable-read
 statement error pgcode 42P01 relation "t_nested_inner" does not exist
 SELECT * FROM t_nested_inner;
+
+onlyif config local-read-committed local-repeatable-read
+statement error pgcode 0A000 to use multi-statement transactions involving a schema change under weak isolation levels
+CALL p_outer_rollback();
 
 statement ok
 DROP PROCEDURE p_outer_rollback;
@@ -903,18 +931,10 @@ subtest end
 
 subtest ddl_under_read_committed
 
-# DDL in procedure bodies bypasses maybeAdjustTxnForDDL because the DDL
-# executes through runPlanInsidePlan, not execStmtInOpenState. This means
-# the automatic isolation upgrade to SERIALIZABLE does NOT happen for DDL
-# inside procedures — the DDL runs at whatever isolation level the caller's
-# transaction uses.
-#
-# For bare DDL statements under READ COMMITTED, we automatically upgrades to
-# SERIALIZABLE and sends a NOTICE. Inside a procedure body, neither the
-# upgrade nor the NOTICE occurs.
-#
-# TODO(spilchen): this will be something we need to address. We must upgrade to
-# SERIALIZABLE for DDL in procedures to ensure safety.
+# DDL inside a routine body mirrors the top-level isolation enforcement:
+# the txn is upgraded to SERIALIZABLE (with a NOTICE) when the DDL is the
+# first body statement, and rejected with an error when prior body
+# statements have already executed at a weaker isolation level.
 
 statement ok
 SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true;
@@ -922,7 +942,8 @@ SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true;
 statement ok
 SET default_transaction_isolation = 'read committed';
 
-# Basic DDL in procedure under READ COMMITTED implicit txn.
+# Basic DDL in procedure under READ COMMITTED implicit txn fires the
+# isolation upgrade NOTICE.
 statement ok
 CREATE PROCEDURE p_rc_create() LANGUAGE PLpgSQL AS $$
 BEGIN
@@ -930,8 +951,10 @@ BEGIN
 END
 $$;
 
-statement ok
+query T noticetrace
 CALL p_rc_create();
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query I
 SELECT count(*) FROM t_rc_test;
@@ -943,6 +966,104 @@ DROP TABLE t_rc_test;
 
 statement ok
 DROP PROCEDURE p_rc_create;
+
+# Multiple DDL statements as the first body statements: the upgrade fires
+# once on the first DDL; subsequent DDLs run silently under SERIALIZABLE.
+statement ok
+CREATE PROCEDURE p_rc_multi_ddl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_rc_multi1 (a INT);
+  CREATE TABLE t_rc_multi2 (a INT);
+  CREATE TABLE t_rc_multi3 (a INT);
+END
+$$;
+
+query T noticetrace
+CALL p_rc_multi_ddl();
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+statement ok
+DROP TABLE t_rc_multi1; DROP TABLE t_rc_multi2; DROP TABLE t_rc_multi3;
+
+statement ok
+DROP PROCEDURE p_rc_multi_ddl;
+
+# A procedure body that mixes DML and DDL also triggers the upgrade: the
+# pre-plan walker discovers DDL anywhere in the body and auto-commits to a
+# fresh SERIALIZABLE txn, so the entire body (DML and DDL) runs safely.
+statement ok
+CREATE TABLE t_rc_seed (a INT);
+
+statement ok
+CREATE PROCEDURE p_rc_dml_then_ddl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  INSERT INTO t_rc_seed VALUES (1);
+  CREATE TABLE t_rc_dml_first (a INT);
+END
+$$;
+
+query T noticetrace
+CALL p_rc_dml_then_ddl();
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+query I
+SELECT count(*) FROM t_rc_seed;
+----
+1
+
+statement ok
+DROP TABLE t_rc_dml_first;
+
+statement ok
+DROP PROCEDURE p_rc_dml_then_ddl;
+
+statement ok
+DROP TABLE t_rc_seed;
+
+# SQL-language procedures with DDL also trigger the upgrade. The body
+# walker dispatches on RoutineLanguage, so this exercises the
+# tree.RoutineLangSQL branch separately from PL/pgSQL.
+statement ok
+CREATE PROCEDURE p_rc_sql_ddl() LANGUAGE SQL AS $$
+  CREATE TABLE t_rc_sql_lang (a INT PRIMARY KEY);
+$$;
+
+query T noticetrace
+CALL p_rc_sql_ddl();
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
+
+statement ok
+DROP TABLE t_rc_sql_lang;
+
+statement ok
+DROP PROCEDURE p_rc_sql_ddl;
+
+# The forced SERIALIZABLE override consumed by the upgraded CALL must not
+# leak into the next implicit txn. Run a CALL that triggers the upgrade,
+# then verify the session is back at READ COMMITTED.
+statement ok
+CREATE PROCEDURE p_rc_no_leak() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_rc_no_leak (a INT);
+END
+$$;
+
+statement ok
+CALL p_rc_no_leak();
+
+query T
+SHOW transaction_isolation;
+----
+read committed
+
+statement ok
+DROP TABLE t_rc_no_leak;
+
+statement ok
+DROP PROCEDURE p_rc_no_leak;
 
 # DDL in procedure under READ COMMITTED explicit txn is rejected like every
 # other explicit-txn case; the isolation level does not matter.
@@ -980,29 +1101,72 @@ DROP TABLE t_notice_check;
 ----
 NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
-# CALL with DDL inside the procedure does NOT fire the NOTICE because
-# maybeAdjustTxnForDDL is not called from the runPlanInsidePlan path.
+# Nested procedures: the upgrade triggered by an inner DDL applies to the
+# outer txn, so subsequent DDLs at any nesting level run silently.
 statement ok
-CREATE PROCEDURE p_rc_no_notice() LANGUAGE PLpgSQL AS $$
+CREATE PROCEDURE p_rc_inner_ddl_first() LANGUAGE PLpgSQL AS $$
 BEGIN
-  CREATE TABLE t_rc_no_notice (a INT);
+  CREATE TABLE t_rc_nested_inner (a INT);
+END
+$$;
+
+statement ok
+CREATE PROCEDURE p_rc_outer_calls_inner() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CALL p_rc_inner_ddl_first();
+  CREATE TABLE t_rc_nested_outer (a INT);
 END
 $$;
 
 query T noticetrace
-CALL p_rc_no_notice();
+CALL p_rc_outer_calls_inner();
 ----
-
-query I
-SELECT count(*) FROM t_rc_no_notice;
-----
-0
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 statement ok
-DROP PROCEDURE p_rc_no_notice;
+DROP TABLE t_rc_nested_inner;
 
 statement ok
-DROP TABLE t_rc_no_notice;
+DROP TABLE t_rc_nested_outer;
+
+statement ok
+DROP PROCEDURE p_rc_outer_calls_inner;
+
+statement ok
+DROP PROCEDURE p_rc_inner_ddl_first;
+
+# Nested procedures: outer body runs DML before invoking an inner that does
+# DDL. The inner DDL is rejected because the outer DML already executed at
+# READ COMMITTED.
+statement ok
+CREATE TABLE t_rc_outer_seed (a INT);
+
+statement ok
+CREATE PROCEDURE p_rc_inner_ddl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_rc_inner_should_not_exist (a INT);
+END
+$$;
+
+statement ok
+CREATE PROCEDURE p_rc_outer_dml_first() LANGUAGE PLpgSQL AS $$
+BEGIN
+  INSERT INTO t_rc_outer_seed VALUES (1);
+  CALL p_rc_inner_ddl();
+END
+$$;
+
+statement error pgcode 0A000 to use multi-statement transactions involving a schema change under weak isolation levels
+CALL p_rc_outer_dml_first();
+
+statement ok
+DROP PROCEDURE p_rc_outer_dml_first;
+
+statement ok
+DROP PROCEDURE p_rc_inner_ddl;
+
+statement ok
+DROP TABLE t_rc_outer_seed;
 
 statement ok
 SET default_transaction_isolation = 'serializable';
@@ -1012,8 +1176,9 @@ subtest end
 
 subtest ddl_under_repeatable_read
 
-# DDL in procedures also works under REPEATABLE READ (SNAPSHOT) isolation
-# without the automatic upgrade to SERIALIZABLE.
+# DDL inside a routine body under REPEATABLE READ behaves like the READ
+# COMMITTED case: the txn is upgraded when the DDL is the first body
+# statement, and rejected otherwise.
 
 statement ok
 SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true;
@@ -1021,7 +1186,7 @@ SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true;
 statement ok
 SET default_transaction_isolation = 'repeatable read';
 
-# Basic DDL in procedure under REPEATABLE READ.
+# Basic DDL in procedure under REPEATABLE READ fires the NOTICE.
 statement ok
 CREATE PROCEDURE p_rr_create() LANGUAGE PLpgSQL AS $$
 BEGIN
@@ -1029,8 +1194,10 @@ BEGIN
 END
 $$;
 
-statement ok
+query T noticetrace
 CALL p_rr_create();
+----
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 query I
 SELECT count(*) FROM t_rr_test;
@@ -1066,28 +1233,31 @@ SELECT * FROM t_rr_rb;
 statement ok
 DROP PROCEDURE p_rr_rollback;
 
-# No isolation upgrade NOTICE for CALL under REPEATABLE READ.
+# DML mixed with DDL in an implicit-txn CALL also triggers the upgrade.
 statement ok
-CREATE PROCEDURE p_rr_no_notice() LANGUAGE PLpgSQL AS $$
+CREATE TABLE t_rr_seed (a INT);
+
+statement ok
+CREATE PROCEDURE p_rr_dml_then_ddl() LANGUAGE PLpgSQL AS $$
 BEGIN
-  CREATE TABLE t_rr_no_notice (a INT);
+  INSERT INTO t_rr_seed VALUES (1);
+  CREATE TABLE t_rr_dml_first (a INT);
 END
 $$;
 
 query T noticetrace
-CALL p_rr_no_notice();
+CALL p_rr_dml_then_ddl();
 ----
-
-query I
-SELECT count(*) FROM t_rr_no_notice;
-----
-0
+NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 
 statement ok
-DROP PROCEDURE p_rr_no_notice;
+DROP TABLE t_rr_dml_first;
 
 statement ok
-DROP TABLE t_rr_no_notice;
+DROP PROCEDURE p_rr_dml_then_ddl;
+
+statement ok
+DROP TABLE t_rr_seed;
 
 statement ok
 SET default_transaction_isolation = 'serializable';
@@ -1547,5 +1717,36 @@ DROP ROLE r_owner;
 
 statement ok
 DROP PROCEDURE p_create_schema_auth;
+
+subtest end
+
+
+subtest ddl_under_serializable
+
+# Under SERIALIZABLE no upgrade is needed, so DDL in any position runs
+# without firing the NOTICE.
+statement ok
+CREATE TABLE t_ser_seed (a INT);
+
+statement ok
+CREATE PROCEDURE p_ser_dml_then_ddl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  INSERT INTO t_ser_seed VALUES (1);
+  CREATE TABLE t_ser_after (a INT);
+END
+$$;
+
+query T noticetrace
+CALL p_ser_dml_then_ddl();
+----
+
+statement ok
+DROP TABLE t_ser_after;
+
+statement ok
+DROP PROCEDURE p_ser_dml_then_ddl;
+
+statement ok
+DROP TABLE t_ser_seed;
 
 subtest end

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -1380,13 +1380,6 @@ func TestLogic_procedure_dcl(
 	runLogicTest(t, "procedure_dcl")
 }
 
-func TestLogic_procedure_ddl(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "procedure_ddl")
-}
-
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -381,19 +381,30 @@ func (g *routineGenerator) startInternal(ctx context.Context, txn *kv.Txn) (err 
 					return err
 				}
 			}
+			pc := plan.(*planComponents)
+			if pc.flags.IsSet(planFlagIsDDL) {
+				// Reject DDL inside a procedure called from an explicit
+				// transaction. Mixing schema changes with arbitrary post-CALL
+				// statements in the same user transaction is not yet supported.
+				if !g.p.EvalContext().TxnImplicit {
+					return errors.WithHint(
+						pgerror.New(pgcode.FeatureNotSupported,
+							"DDL statements are not allowed in stored procedures called from an explicit transaction"),
+						"call the procedure outside of a BEGIN ... COMMIT block",
+					)
+				}
+				// Safety net: reject DDL in a routine body when the txn iso
+				// still tolerates write skew. The primary upgrade path runs
+				// at CALL planning time via maybeAutoCommitBeforeDDL; this
+				// catches paths the pre-plan walker did not cover (e.g. DDL
+				// inside a nested CALL the outer body walker did not recurse
+				// into).
+				if err := g.p.storedProcTxnState.rejectDDLInRoutineUnderWeakIso(txn); err != nil {
+					return err
+				}
+			}
 			// Run the plan.
 			params := runParams{ctx, g.p.ExtendedEvalContext(), g.p}
-			pc := plan.(*planComponents)
-			// Reject DDL inside a procedure called from an explicit
-			// transaction. Mixing schema changes with arbitrary post-CALL
-			// statements in the same user transaction is not yet supported.
-			if pc.flags.IsSet(planFlagIsDDL) && !g.p.EvalContext().TxnImplicit {
-				return errors.WithHint(
-					pgerror.New(pgcode.FeatureNotSupported,
-						"DDL statements are not allowed in stored procedures called from an explicit transaction"),
-					"call the procedure outside of a BEGIN ... COMMIT block",
-				)
-			}
 			if statsBuilder != nil {
 				defer func() {
 					flags := pc.flags
@@ -777,6 +788,27 @@ func (a *storedProcTxnStateAccessor) getTxnModes() *tree.TransactionModes {
 		return nil
 	}
 	return a.ex.extraTxnState.storedProcTxnState.txnModes
+}
+
+// rejectDDLInRoutineUnderWeakIso is a runtime safety net: when a DDL plan
+// node is encountered in a routine body and the txn isolation still
+// tolerates write skew, it returns txnSchemaChangeErr. The primary upgrade
+// path runs at CALL planning time via maybeAutoCommitBeforeDDL — this check
+// only fires for cases the pre-plan walker did not handle (most notably
+// DDL inside a nested CALL, where the outer body walker does not recurse).
+//
+// In-place SetIsoLevel cannot succeed here because the txn is already
+// active by the time we reach a body statement, so this method does not
+// attempt an upgrade. It is a no-op for accessors not backed by a
+// connExecutor (e.g. internal SQL).
+func (a *storedProcTxnStateAccessor) rejectDDLInRoutineUnderWeakIso(txn *kv.Txn) error {
+	if a.ex == nil {
+		return nil
+	}
+	if !txn.IsoLevel().ToleratesWriteSkew() {
+		return nil
+	}
+	return txnSchemaChangeErr
 }
 
 // EvalTxnControlExpr produces the side effects of a COMMIT or ROLLBACK


### PR DESCRIPTION
Schema changes in CockroachDB require SERIALIZABLE isolation. Top-level DDL handles this transparently in maybeAdjustTxnForDDL, but DDL inside a CALL'd procedure bypassed that path entirely and silently ran under whatever isolation the caller's transaction was using.

This change extends maybeAutoCommitBeforeDDL with a CALL-aware branch: when an implicit-transaction CALL is issued under a weaker isolation level, the procedure body is inspected for DDL; if any is found, the transaction is auto-committed and restarted at SERIALIZABLE before the CALL is replanned. A runtime safety net inside the routine body rejects DDL whenever isolation still tolerates write skew, covering nested-CALL and other paths the pre-plan walker does not handle.

Epic: CRDB-31256
Fixes: #170020

Release note (sql change): DDL executed inside a stored procedure now honors the SERIALIZABLE-isolation requirement that top-level DDL has always had: when a procedure containing DDL is called under READ COMMITTED or REPEATABLE READ in an implicit transaction, the transaction is automatically upgraded to SERIALIZABLE for the call; otherwise the call is rejected with a clear error.