### PR TITLE
release-26.1: ci/release: remove pinned gce zones in release qualification ci

### DIFF
--- a/build/teamcity/internal/release/process/roachtest-release-qualification.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification.sh
@@ -57,14 +57,9 @@ EOF
 # We'd love to see a stack trace though, so after 7800 minutes,
 # kill with SIGINT which will allow roachtest to fail tests and
 # cleanup.
-#
-# NB(2): We specify --zones below so that nodes are created in us-central1-b
-# by default. This reserves us-east1-b (the roachprod default zone) for use
-# by manually created clusters.
 timeout -s INT $((7800*60)) bin/roachtest run \
   --suite release_qualification \
   --cluster-id "${TC_BUILD_ID}" \
-  --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --cockroach "$PWD/cockroach" \
   --roachprod "$PWD/bin/roachprod" \
   --workload "$PWD/bin/workload" \


### PR DESCRIPTION
Backport 1/1 commits from #170675 on behalf of @williamchoe3.

----

This PR removes the explicit --zones override from the roachtest release qualification TeamCity script to enable new roachtest smart cluster creation retries added in #170222

Epic: None

----

Release justification: ci only change