### PR TITLE
ts: strip histogram suffix in TenantServer TSDB query lookup

### DIFF
--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -134,8 +134,14 @@ func (t *TenantServer) Query(
 		// Tenant-scoped metrics get marked with the tenantID. This includes both
 		// app-level metrics (in tenantRegistry) and store-level tenant metrics
 		// (identified by isStoreTenantMetric).
-		metricName := strings.TrimPrefix(q.Name, "cr.store.")
-		if t.tenantRegistry.Contains(q.Name) || isStoreTenantMetric(metricName) {
+		//
+		// Histogram metrics are stored in TSDB under suffixed names (e.g.
+		// "cr.node.sql.service.latency-p99") but registered under the base name
+		// ("sql.service.latency"). Strip the suffix so both the registry lookup
+		// and the store metric check use the base metric name.
+		baseName := stripHistogramSuffix(q.Name)
+		storeMetricName := strings.TrimPrefix(baseName, "cr.store.")
+		if t.tenantRegistry.Contains(baseName) || isStoreTenantMetric(storeMetricName) {
 			req.Queries[i].TenantID = t.tenantID
 		}
 	}

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -824,6 +824,11 @@ func TestServerQueryTenant(t *testing.T) {
 	hostMetricName := "sys.rss"
 	// This is a store-level metric identified by isStoreTenantMetric.
 	storeMetricName := "cr.store.livebytes"
+	// Histogram metrics are stored in TSDB with quantile suffixes (e.g. "-p99")
+	// but registered under their base name. This tests that TenantServer.Query
+	// correctly strips the suffix before the registry lookup.
+	histogramBaseName := "sql.service.latency"
+	histogramSuffixedName := histogramBaseName + "-p99"
 
 	// Populate data directly. Aggregate sources ("1", "10") contain the sum
 	// of all tenants' data. Per-tenant sources ("1-2", "10-2") track tenant 2's
@@ -944,6 +949,36 @@ func TestServerQueryTenant(t *testing.T) {
 				{
 					TimestampNanos: 500 * 1e9,
 					Value:          20.0,
+				},
+			},
+		},
+		// Histogram metric with quantile suffix. Same aggregate/per-tenant
+		// pattern: aggregate "1" = 500, per-tenant "1-2" = 50.
+		{
+			Name:   histogramSuffixedName,
+			Source: "1",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{
+					TimestampNanos: 400 * 1e9,
+					Value:          500.0,
+				},
+				{
+					TimestampNanos: 500 * 1e9,
+					Value:          600.0,
+				},
+			},
+		},
+		{
+			Name:   histogramSuffixedName,
+			Source: "1-2",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				{
+					TimestampNanos: 400 * 1e9,
+					Value:          50.0,
+				},
+				{
+					TimestampNanos: 500 * 1e9,
+					Value:          60.0,
 				},
 			},
 		},
@@ -1273,6 +1308,41 @@ func TestServerQueryTenant(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, expectedTenantHostMetricsResponse, tenantResponse)
+
+	// We should get back the histogram data for the tenant.
+	expectedTenantHistogramResponse := &tspb.TimeSeriesQueryResponse{
+		Results: []tspb.TimeSeriesQueryResponse_Result{
+			{
+				Query: tspb.Query{
+					Name:     histogramSuffixedName,
+					Sources:  []string{"1"},
+					TenantID: tenantID,
+				},
+				Datapoints: []tspb.TimeSeriesDatapoint{
+					{
+						TimestampNanos: 400 * 1e9,
+						Value:          50.0,
+					},
+					{
+						TimestampNanos: 500 * 1e9,
+						Value:          60.0,
+					},
+				},
+			},
+		},
+	}
+	tenantHistogramResponse, err := tenantClient.Query(context.Background(), &tspb.TimeSeriesQueryRequest{
+		StartNanos: 400 * 1e9,
+		EndNanos:   500 * 1e9,
+		Queries: []tspb.Query{
+			{
+				Name:    histogramSuffixedName,
+				Sources: []string{"1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedTenantHistogramResponse, tenantHistogramResponse)
 }
 
 // TestServerQueryMemoryManagement verifies that queries succeed under


### PR DESCRIPTION
Previously, `TenantServer.Query()` used `tenantRegistry.Contains()` to determine whether a TSDB metric should be scoped to the requesting tenant. However, histogram metrics are stored in TSDB under suffixed names (e.g. `sql.service.latency-p99`) while the registry stores them under their base name (`sql.service.latency`). The lookup failed for all histogram quantile metrics, so `TenantID` was never set on the query.

This was a latent bug, but it became visible after #162048 changed `readAllSourcesFromDatabase` to filter out tenant-prefixed sources when no tenant ID is set. Before that change, the unfiltered query path returned all data (including the tenant's), masking the mismatch. After #162048, the unfiltered path returns only the system tenant's aggregate data, which is typically empty for SQL metrics since user workloads run on the virtual cluster.

The fix strips known histogram suffixes (via `stripHistogramSuffix`, which already existed in the same file) before calling `Contains`.

Resolves: #170687
Epic: none

Release note (bug fix): Fixed a bug where the DB Console on virtual clusters showed zero values for all histogram-based charts (such as Service Latency and SQL Execution Latency) even though the underlying metrics were being recorded correctly. The metrics were visible in Prometheus scrapes (`/_status/vars`) and Datadog but not in the DB Console, which reads from the internal time-series database. This affected CockroachDB v26.2 deployments using virtual clusters (including CockroachDB Cloud).