### PR TITLE
sql: add support for EXPLAIN EXECUTE

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -401,6 +401,27 @@ func (ex *connExecutor) maybeReparsePrepStmt(
 	return nil
 }
 
+// resolveExecute looks up the prepared statement for an EXECUTE node, reparses
+// it if needed, and fills in placeholder values. It returns the prepared
+// statement and PlaceholderInfo, or an error.
+func (ex *connExecutor) resolveExecute(
+	ctx context.Context, e *tree.Execute,
+) (*prep.Statement, *tree.PlaceholderInfo, error) {
+	name := e.Name.String()
+	ps, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts.Get(name)
+	if !ok {
+		return nil, nil, newPreparedStmtDNEError(ex.sessionData(), name)
+	}
+	if err := ex.maybeReparsePrepStmt(ctx, ps, name); err != nil {
+		return nil, nil, err
+	}
+	pinfo, err := ex.planner.fillInPlaceholders(ctx, ps, name, e.Params)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ps, pinfo, nil
+}
+
 // execStmtInOpenState executes one statement in the context of the session's
 // current transaction.
 // It handles statements that affect the transaction state (BEGIN, COMMIT)
@@ -603,27 +624,33 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.ExpectedTypes = nil
 	}
 
+	// Special top-level handling for EXPLAIN wrapping EXECUTE. Resolve the
+	// prepared statement so the optimizer sees the actual statement instead of
+	// the EXECUTE node. Skip FINGERPRINT mode, which handles EXECUTE directly
+	// in the optbuilder without needing resolution.
+	if expl, ok := ast.(*tree.Explain); ok {
+		if e, ok := expl.Statement.(*tree.Execute); ok && expl.Mode != tree.ExplainFingerprint {
+			ps, pi, err := ex.resolveExecute(ctx, e)
+			if err != nil {
+				return makeErrEvent(err)
+			}
+			pinfo = pi
+			expl.Statement = ps.Statement.AST
+			stmt.Prepared = ps
+		}
+	}
+
 	// Special top-level handling for EXECUTE. This must happen after the handling
 	// for EXPLAIN ANALYZE (in order to support EXPLAIN ANALYZE EXECUTE) but
 	// before setting up the instrumentation helper.
 	if e, ok := ast.(*tree.Execute); ok {
 		// Replace the `EXECUTE foo` statement with the prepared statement, and
 		// continue execution.
-		name := e.Name.String()
-		ps, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts.Get(name)
-		if !ok {
-			return makeErrEvent(newPreparedStmtDNEError(ex.sessionData(), name))
-		}
-
-		if err := ex.maybeReparsePrepStmt(ctx, ps, name); err != nil {
-			return makeErrEvent(err)
-		}
-
-		var err error
-		pinfo, err = ex.planner.fillInPlaceholders(ctx, ps, name, e.Params)
+		ps, pi, err := ex.resolveExecute(ctx, e)
 		if err != nil {
 			return makeErrEvent(err)
 		}
+		pinfo = pi
 
 		// TODO(radu): what about .SQL, .NumAnnotations, .NumPlaceholders?
 		stmt.Statement = ps.Statement
@@ -1485,27 +1512,33 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		vars.stmt.ExpectedTypes = nil
 	}
 
+	// Special top-level handling for EXPLAIN wrapping EXECUTE. Resolve the
+	// prepared statement so the optimizer sees the actual statement instead of
+	// the EXECUTE node. Skip FINGERPRINT mode, which handles EXECUTE directly
+	// in the optbuilder without needing resolution.
+	if expl, ok := vars.ast.(*tree.Explain); ok {
+		if e, ok := expl.Statement.(*tree.Execute); ok && expl.Mode != tree.ExplainFingerprint {
+			ps, pi, err := ex.resolveExecute(ctx, e)
+			if err != nil {
+				return makeErrEvent(err)
+			}
+			pinfo = pi
+			expl.Statement = ps.Statement.AST
+			vars.stmt.Prepared = ps
+		}
+	}
+
 	// Special top-level handling for EXECUTE. This must happen after the handling
 	// for EXPLAIN ANALYZE (in order to support EXPLAIN ANALYZE EXECUTE) but
 	// before setting up the instrumentation helper.
 	if e, ok := vars.ast.(*tree.Execute); ok {
 		// Replace the `EXECUTE foo` statement with the prepared statement, and
 		// continue execution.
-		name := e.Name.String()
-		ps, ok := ex.extraTxnState.prepStmtsNamespace.prepStmts.Get(name)
-		if !ok {
-			return makeErrEvent(newPreparedStmtDNEError(ex.sessionData(), name))
-		}
-
-		if err := ex.maybeReparsePrepStmt(ctx, ps, name); err != nil {
-			return makeErrEvent(err)
-		}
-
-		var err error
-		pinfo, err = ex.planner.fillInPlaceholders(ctx, ps, name, e.Params)
+		ps, pi, err := ex.resolveExecute(ctx, e)
 		if err != nil {
 			return makeErrEvent(err)
 		}
+		pinfo = pi
 
 		// TODO(radu): what about .SQL, .NumAnnotations, .NumPlaceholders?
 		vars.stmt.Statement = ps.Statement

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2379,11 +2379,17 @@ distribution: local
 statement ok
 PREPARE prep AS SELECT $1 + 1
 
-statement error EXPLAIN EXECUTE is not supported
+query T
 EXPLAIN EXECUTE prep(1)
+----
+distribution: local
+·
+• values
+  size: 1 column, 1 row
 
-statement error EXPLAIN EXECUTE is not supported
-SELECT 1 FROM [ EXPLAIN EXECUTE prep(1) ]
+# EXPLAIN EXECUTE is not supported in a subquery context.
+statement error EXPLAIN EXECUTE cannot be used in a subquery
+SELECT count(*) FROM [ EXPLAIN EXECUTE prep(1) ]
 
 query T
 EXPLAIN ANALYZE EXECUTE prep(1)
@@ -2400,6 +2406,192 @@ regions: <hidden>
   execution time: 0µs
   actual row count: 1
   size: 1 column, 1 row
+
+# Test for #161889: EXPLAIN EXECUTE shows the query plan for a prepared
+# statement without executing it.
+
+statement ok
+CREATE TABLE t_ee (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  s STRING,
+  INDEX (a),
+  INDEX (s)
+)
+
+statement ok
+CREATE TABLE c_ee (
+  k INT PRIMARY KEY,
+  a INT,
+  INDEX (a)
+)
+
+statement ok
+INSERT INTO t_ee SELECT i, i % 10, i * 2, 'str' || i::STRING FROM generate_series(1, 100) AS g(i)
+
+statement ok
+INSERT INTO c_ee SELECT i, i % 5 FROM generate_series(1, 50) AS g(i)
+
+# Point lookup on primary key uses the primary index.
+statement ok
+PREPARE ee_point AS SELECT * FROM t_ee WHERE k = $1
+
+query T
+EXPLAIN EXECUTE ee_point(42)
+----
+distribution: local
+·
+• scan
+  missing stats
+  table: t_ee@t_ee_pkey
+  spans: [/42 - /42]
+
+# Lookup by secondary index column uses the index.
+statement ok
+PREPARE ee_idx AS SELECT k, a FROM t_ee WHERE a = $1
+
+query T
+EXPLAIN EXECUTE ee_idx(5)
+----
+distribution: local
+·
+• scan
+  missing stats
+  table: t_ee@t_ee_a_idx
+  spans: [/5 - /5]
+
+# Two-table join shows the join strategy.
+statement ok
+PREPARE ee_join AS SELECT t_ee.k, c_ee.k FROM t_ee JOIN c_ee ON t_ee.a = c_ee.a WHERE t_ee.a = $1
+
+query T
+EXPLAIN EXECUTE ee_join(3)
+----
+distribution: local
+·
+• merge join
+│ equality: (a) = (a)
+│
+├── • scan
+│     missing stats
+│     table: t_ee@t_ee_a_idx
+│     spans: [/3 - /3]
+│
+└── • scan
+      missing stats
+      table: c_ee@c_ee_a_idx
+      spans: [/3 - /3]
+
+# INSERT: shows the mutation plan without executing.
+statement ok
+PREPARE ee_ins AS INSERT INTO t_ee VALUES ($1, $2, $3, $4)
+
+query T
+EXPLAIN EXECUTE ee_ins(999, 1, 2, 'new')
+----
+distribution: local
+·
+• insert fast path
+  into: t_ee(k, a, b, s)
+  auto commit
+  size: 4 columns, 1 row
+
+# Verify the INSERT was NOT executed.
+query I
+SELECT count(*) FROM t_ee WHERE k = 999
+----
+0
+
+# UPDATE: shows the mutation plan without executing.
+statement ok
+PREPARE ee_upd AS UPDATE t_ee SET b = $2 WHERE k = $1
+
+query T
+EXPLAIN EXECUTE ee_upd(1, 100)
+----
+distribution: local
+·
+• update
+│ table: t_ee
+│ set: b
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: t_ee@t_ee_pkey
+          spans: [/1 - /1]
+          locking strength: for update
+
+# Verify the UPDATE was NOT executed.
+query I
+SELECT b FROM t_ee WHERE k = 1
+----
+2
+
+# DELETE: shows the mutation plan without executing.
+statement ok
+PREPARE ee_del AS DELETE FROM t_ee WHERE k = $1
+
+query T
+EXPLAIN EXECUTE ee_del(1)
+----
+distribution: local
+·
+• delete
+│ from: t_ee
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: t_ee@t_ee_pkey
+      spans: [/1 - /1]
+      locking strength: for update
+
+# Verify the DELETE was NOT executed.
+query I
+SELECT count(*) FROM t_ee WHERE k = 1
+----
+1
+
+# No parameters: prepared statement without placeholders.
+statement ok
+PREPARE ee_noparam AS SELECT count(*) FROM t_ee
+
+query T
+EXPLAIN EXECUTE ee_noparam
+----
+distribution: local
+·
+• group (scalar)
+│
+└── • scan
+      missing stats
+      table: t_ee@t_ee_a_idx
+      spans: FULL SCAN
+
+# Error: nonexistent prepared statement.
+statement error prepared statement \"nonexistent\" does not exist
+EXPLAIN EXECUTE nonexistent
+
+# Error: wrong number of parameters.
+statement error expected 1, got 2
+EXPLAIN EXECUTE ee_point(1, 2)
+
+statement error expected 1, got 0
+EXPLAIN EXECUTE ee_point
+
+# Cleanup.
+statement ok
+DEALLOCATE ALL
+
+statement ok
+DROP TABLE t_ee
+
+statement ok
+DROP TABLE c_ee
 
 # Tests for EXPLAIN (OPT, MEMO).
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_fingerprint
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_fingerprint
@@ -140,12 +140,6 @@ EXPLAIN (FINGERPRINT, TYPES) SELECT * FROM t
 statement error pq: at or near "EOF": syntax error: the JSON flag can only be used with DISTSQL
 EXPLAIN (FINGERPRINT, JSON) SELECT * FROM t
 
-# Test that regular EXPLAIN EXECUTE is still rejected while FINGERPRINT works
-statement error EXPLAIN EXECUTE is not supported; use EXPLAIN ANALYZE
-EXPLAIN EXECUTE stmt1
-
-# But EXPLAIN (FINGERPRINT) EXECUTE should work (already tested above)
-
 # Test with more complex queries
 query T
 EXPLAIN (FINGERPRINT)

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -17,13 +17,15 @@ import (
 )
 
 func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope *scope) {
-	if _, ok := explain.Statement.(*tree.Execute); ok {
-		// EXPLAIN (FINGERPRINT) EXECUTE is supported, but other modes are not.
-		if explain.Mode != tree.ExplainFingerprint {
-			panic(pgerror.New(
-				pgcode.FeatureNotSupported, "EXPLAIN EXECUTE is not supported; use EXPLAIN ANALYZE",
-			))
-		}
+	if _, ok := explain.Statement.(*tree.Execute); ok && explain.Mode != tree.ExplainFingerprint {
+		// EXPLAIN EXECUTE is resolved at the top level of the conn executor.
+		// If we reach here, it means the EXPLAIN EXECUTE was used in a
+		// subquery context (e.g., SELECT * FROM [EXPLAIN EXECUTE ...]) which
+		// is not supported.
+		panic(pgerror.New(
+			pgcode.FeatureNotSupported,
+			"EXPLAIN EXECUTE cannot be used in a subquery",
+		))
 	}
 
 	var stmtScope *scope


### PR DESCRIPTION
(The AI tools keep using EXPLAIN EXECUTE when debugging prepared stmt, making me feel that it might worth filling this gap)

This commit adds resolution of EXECUTE inside EXPLAIN at the conn_executor level (in both execStmtInOpenState and the pausable portal path), mirroring the existing EXPLAIN ANALYZE EXECUTE pattern. The prepared statement is looked up, placeholders are filled in, and the EXECUTE node is replaced with the resolved statement AST before the optimizer sees it. EXPLAIN (FINGERPRINT) EXECUTE is excluded since it already handles EXECUTE directly in the optbuilder.

Fixes: #161889

Release note (sql change): EXPLAIN EXECUTE is now supported. It shows the query plan for a prepared statement with the given parameters without actually executing it, matching the behavior of EXPLAIN for normal statements.