### PR TITLE
jobutils: dump goroutines on WaitForJobToHaveStatus timeout

### DIFF
--- a/pkg/testutils/jobutils/BUILD.bazel
+++ b/pkg/testutils/jobutils/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/security/username",
         "//pkg/sql/catalog/lease",
+        "//pkg/testutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util/protoutil",
         "//pkg/util/retry",

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -99,7 +100,9 @@ func WaitForJobToHaveStatus(
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("condition failed to evaluate within %s: %s", duration, err)
+		dumpFile := testutils.WriteGoroutineDump()
+		t.Fatalf("condition failed to evaluate within %s: %s\n\ngoroutine dump: %s",
+			duration, err, dumpFile)
 	}
 }
 


### PR DESCRIPTION
When WaitForJobToHaveStatus times out, write a goroutine dump to a file and include the path in the failure message. This makes it easier to debug stuck jobs.

Informs: #170260