### PR TITLE
codeowners: route SQL Foundations review assignment via -prs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@
 /pkg/sql/create_stats*       @cockroachdb/sql-queries-prs
 /pkg/sql/distsql*.go         @cockroachdb/sql-queries-prs
 /pkg/sql/execinfra/          @cockroachdb/sql-queries-prs
-/pkg/sql/execinfra/merge_metrics.go @cockroachdb/sql-foundations
+/pkg/sql/execinfra/merge_metrics.go @cockroachdb/sql-foundations-prs
 /pkg/sql/execinfrapb/        @cockroachdb/sql-queries-prs
 /pkg/sql/execstats/          @cockroachdb/sql-queries-prs
 /pkg/sql/execinfrapb/processors_bulk_io.proto     @cockroachdb/disaster-recovery
@@ -95,58 +95,58 @@
 /pkg/sql/tablemetadatacache/  @cockroachdb/obs-prs
 /pkg/ccl/testccl/sqlstatsccl/ @cockroachdb/obs-prs
 
-/pkg/sql/crdb_internal.go    @cockroachdb/sql-foundations
-/pkg/sql/pg_catalog.go       @cockroachdb/sql-foundations
-/pkg/sql/show_create*.go     @cockroachdb/sql-foundations
-/pkg/sql/lex/                @cockroachdb/sql-foundations
+/pkg/sql/crdb_internal.go    @cockroachdb/sql-foundations-prs
+/pkg/sql/pg_catalog.go       @cockroachdb/sql-foundations-prs
+/pkg/sql/show_create*.go     @cockroachdb/sql-foundations-prs
+/pkg/sql/lex/                @cockroachdb/sql-foundations-prs
 /pkg/sql/partitioning/       @cockroachdb/sql-queries-prs
-/pkg/sql/pgwire/             @cockroachdb/sql-foundations
-/pkg/sql/pgwire/auth.go      @cockroachdb/sql-foundations @cockroachdb/security-engineering @cockroachdb/product-security
-/pkg/sql/pgwire/identmap/    @cockroachdb/sql-foundations @cockroachdb/product-security
-/pkg/sql/sem/builtins/       @cockroachdb/sql-foundations
-/pkg/sql/sem/plpgsqltree/    @cockroachdb/sql-foundations
-/pkg/sql/vtable/             @cockroachdb/sql-foundations
+/pkg/sql/pgwire/             @cockroachdb/sql-foundations-prs
+/pkg/sql/pgwire/auth.go      @cockroachdb/sql-foundations-prs @cockroachdb/security-engineering @cockroachdb/product-security
+/pkg/sql/pgwire/identmap/    @cockroachdb/sql-foundations-prs @cockroachdb/product-security
+/pkg/sql/sem/builtins/       @cockroachdb/sql-foundations-prs
+/pkg/sql/sem/plpgsqltree/    @cockroachdb/sql-foundations-prs
+/pkg/sql/vtable/             @cockroachdb/sql-foundations-prs
 
-/pkg/sql/sessiondata/        @cockroachdb/sql-foundations
-/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-foundations
+/pkg/sql/sessiondata/        @cockroachdb/sql-foundations-prs
+/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-foundations-prs
 /pkg/sql/ttl                 @cockroachdb/sql-queries-prs
-/pkg/sql/spanutils/          @cockroachdb/sql-foundations
+/pkg/sql/spanutils/          @cockroachdb/sql-foundations-prs
 /pkg/sql/inspect/            @cockroachdb/sql-queries-prs
-/pkg/sql/copy/               @cockroachdb/sql-foundations
-/pkg/sql/copy_*.go           @cockroachdb/sql-foundations
-/pkg/sql/plpgsql/            @cockroachdb/sql-foundations
-/pkg/sql/routine.go          @cockroachdb/sql-foundations
-/pkg/sql/function_references.go @cockroachdb/sql-foundations
-/pkg/sql/show_trigger.go     @cockroachdb/sql-foundations
+/pkg/sql/copy/               @cockroachdb/sql-foundations-prs
+/pkg/sql/copy_*.go           @cockroachdb/sql-foundations-prs
+/pkg/sql/plpgsql/            @cockroachdb/sql-foundations-prs
+/pkg/sql/routine.go          @cockroachdb/sql-foundations-prs
+/pkg/sql/function_references.go @cockroachdb/sql-foundations-prs
+/pkg/sql/show_trigger.go     @cockroachdb/sql-foundations-prs
 
-/pkg/sql/syntheticprivilege/      @cockroachdb/sql-foundations
-/pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations
+/pkg/sql/syntheticprivilege/      @cockroachdb/sql-foundations-prs
+/pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations-prs
 
-/pkg/ccl/schemachangerccl/   @cockroachdb/sql-foundations
-/pkg/sql/bulkmerge/          @cockroachdb/sql-foundations
-/pkg/sql/bulksst/            @cockroachdb/sql-foundations
-/pkg/sql/bulkutil/           @cockroachdb/sql-foundations
-/pkg/sql/catalog/            @cockroachdb/sql-foundations
+/pkg/ccl/schemachangerccl/   @cockroachdb/sql-foundations-prs
+/pkg/sql/bulkmerge/          @cockroachdb/sql-foundations-prs
+/pkg/sql/bulksst/            @cockroachdb/sql-foundations-prs
+/pkg/sql/bulkutil/           @cockroachdb/sql-foundations-prs
+/pkg/sql/catalog/            @cockroachdb/sql-foundations-prs
 /pkg/sql/catalog/multiregion @cockroachdb/sql-queries-prs
-/pkg/sql/doctor/             @cockroachdb/sql-foundations
-/pkg/sql/gcjob/              @cockroachdb/sql-foundations
-/pkg/sql/gcjob_test/         @cockroachdb/sql-foundations
-/pkg/sql/importer/           @cockroachdb/sql-foundations
-/pkg/sql/privilege/          @cockroachdb/sql-foundations
-/pkg/sql/schemachange/       @cockroachdb/sql-foundations
-/pkg/sql/schemachanger/      @cockroachdb/sql-foundations
-/pkg/sql/alter*.go           @cockroachdb/sql-foundations
-/pkg/sql/backfill*.go        @cockroachdb/sql-foundations
-/pkg/sql/create*.go          @cockroachdb/sql-foundations
-/pkg/sql/database*.go        @cockroachdb/sql-foundations
-/pkg/sql/drop*.go            @cockroachdb/sql-foundations
-/pkg/sql/grant*.go           @cockroachdb/sql-foundations
-/pkg/sql/multitenant_admin_function_test.go @cockroachdb/sql-foundations
-/pkg/sql/rename*.go          @cockroachdb/sql-foundations
-/pkg/sql/revoke*.go          @cockroachdb/sql-foundations
-/pkg/sql/schema*.go          @cockroachdb/sql-foundations
-/pkg/sql/zone*.go            @cockroachdb/sql-foundations
-/pkg/cmd/sql-bootstrap-data/ @cockroachdb/sql-foundations
+/pkg/sql/doctor/             @cockroachdb/sql-foundations-prs
+/pkg/sql/gcjob/              @cockroachdb/sql-foundations-prs
+/pkg/sql/gcjob_test/         @cockroachdb/sql-foundations-prs
+/pkg/sql/importer/           @cockroachdb/sql-foundations-prs
+/pkg/sql/privilege/          @cockroachdb/sql-foundations-prs
+/pkg/sql/schemachange/       @cockroachdb/sql-foundations-prs
+/pkg/sql/schemachanger/      @cockroachdb/sql-foundations-prs
+/pkg/sql/alter*.go           @cockroachdb/sql-foundations-prs
+/pkg/sql/backfill*.go        @cockroachdb/sql-foundations-prs
+/pkg/sql/create*.go          @cockroachdb/sql-foundations-prs
+/pkg/sql/database*.go        @cockroachdb/sql-foundations-prs
+/pkg/sql/drop*.go            @cockroachdb/sql-foundations-prs
+/pkg/sql/grant*.go           @cockroachdb/sql-foundations-prs
+/pkg/sql/multitenant_admin_function_test.go @cockroachdb/sql-foundations-prs
+/pkg/sql/rename*.go          @cockroachdb/sql-foundations-prs
+/pkg/sql/revoke*.go          @cockroachdb/sql-foundations-prs
+/pkg/sql/schema*.go          @cockroachdb/sql-foundations-prs
+/pkg/sql/zone*.go            @cockroachdb/sql-foundations-prs
+/pkg/cmd/sql-bootstrap-data/ @cockroachdb/sql-foundations-prs
 
 #!/pkg/sql/logictest/tests/cockroach-go-testserver-*/*.go @cockroachdb/sql-foundations-noreview
 #!/pkg/sql/logictest/tests/local-mixed-*/*.go             @cockroachdb/sql-foundations-noreview
@@ -161,23 +161,23 @@
 /pkg/cli/cli.go              @cockroachdb/cli-prs
 /pkg/cli/cli_debug*.go       @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/cli_test.go         @cockroachdb/cli-prs
-/pkg/cli/clientflags/        @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cli/clienturl/          @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cli/clisqlcfg/          @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cli/clisqlclient/       @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cli/clisqlexec/         @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cli/clisqlshell/        @cockroachdb/sql-foundations @cockroachdb/cli-prs
+/pkg/cli/clientflags/        @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
+/pkg/cli/clienturl/          @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
+/pkg/cli/clisqlcfg/          @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
+/pkg/cli/clisqlclient/       @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
+/pkg/cli/clisqlexec/         @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
+/pkg/cli/clisqlshell/        @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
 /pkg/cli/context.go          @cockroachdb/cli-prs
-/pkg/cli/convert_url*        @cockroachdb/sql-foundations   @cockroachdb/cli-prs
+/pkg/cli/convert_url*        @cockroachdb/sql-foundations-prs   @cockroachdb/cli-prs
 /pkg/cli/debug*.go           @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/debug_job_trace*.go @cockroachdb/jobs-prs       @cockroachdb/disaster-recovery
 /pkg/cli/debug_logconfig.go  @cockroachdb/obs-prs    @cockroachdb/cli-prs @cockroachdb/obs-india-prs
 /pkg/cli/debug_merge_logs*.go @cockroachdb/obs-prs    @cockroachdb/cli-prs @cockroachdb/obs-india-prs
-/pkg/cli/declarative_*       @cockroachdb/sql-foundations
+/pkg/cli/declarative_*       @cockroachdb/sql-foundations-prs
 /pkg/cli/decode*.go          @cockroachdb/kv-prs         @cockroachdb/cli-prs
-/pkg/cli/demo*.go            @cockroachdb/sql-foundations   @cockroachdb/server-prs @cockroachdb/cli-prs
-/pkg/cli/democluster/        @cockroachdb/sql-foundations   @cockroachdb/server-prs @cockroachdb/cli-prs
-/pkg/cli/doctor*.go          @cockroachdb/sql-foundations     @cockroachdb/cli-prs
+/pkg/cli/demo*.go            @cockroachdb/sql-foundations-prs   @cockroachdb/server-prs @cockroachdb/cli-prs
+/pkg/cli/democluster/        @cockroachdb/sql-foundations-prs   @cockroachdb/server-prs @cockroachdb/cli-prs
+/pkg/cli/doctor*.go          @cockroachdb/sql-foundations-prs     @cockroachdb/cli-prs
 /pkg/cli/flags*.go           @cockroachdb/cli-prs
 /pkg/cli/init.go             @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/log*.go             @cockroachdb/obs-prs    @cockroachdb/cli-prs @cockroachdb/obs-india-prs
@@ -188,7 +188,7 @@
 /pkg/cli/nodelocal*.go       @cockroachdb/disaster-recovery
 /pkg/cli/node*.go            @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/rpc*.go             @cockroachdb/kv-prs         @cockroachdb/cli-prs
-/pkg/cli/sql*.go             @cockroachdb/sql-foundations   @cockroachdb/cli-prs
+/pkg/cli/sql*.go             @cockroachdb/sql-foundations-prs   @cockroachdb/cli-prs
 /pkg/cli/start*.go           @cockroachdb/server-prs     @cockroachdb/cli-prs
 /pkg/cli/statement*.go       @cockroachdb/obs-prs @cockroachdb/cli-prs
 /pkg/cli/syncbench/          @cockroachdb/storage @cockroachdb/kv-prs
@@ -213,7 +213,7 @@
 /pkg/server/critical_nodes*.go           @cockroachdb/obs-prs
 /pkg/server/debug/                       @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/decommission*.go             @cockroachdb/kv-prs
-/pkg/server/drain*.go                    @cockroachdb/kv-prs @cockroachdb/sql-foundations
+/pkg/server/drain*.go                    @cockroachdb/kv-prs @cockroachdb/sql-foundations-prs
 /pkg/server/dumpstore/                   @cockroachdb/obs-prs
 /pkg/server/external_storage*.go         @cockroachdb/disaster-recovery
 /pkg/server/fanout*.go                   @cockroachdb/obs-prs
@@ -223,22 +223,22 @@
 /pkg/server/index_usage*.go              @cockroachdb/obs-prs
 /pkg/server/init*.go                     @cockroachdb/kv-prs      @cockroachdb/server-prs
 /pkg/server/key_vis*                     @cockroachdb/obs-prs
-/pkg/server/license/                     @cockroachdb/sql-foundations
+/pkg/server/license/                     @cockroachdb/sql-foundations-prs
 /pkg/server/load_endpoint*               @cockroachdb/obs-prs @cockroachdb/server-prs
 /pkg/server/loss_of_quorum*.go           @cockroachdb/kv-prs
-/pkg/server/migration*                   @cockroachdb/sql-foundations
+/pkg/server/migration*                   @cockroachdb/sql-foundations-prs
 /pkg/server/multi_store*                 @cockroachdb/kv-prs      @cockroachdb/storage
 /pkg/server/node*                        @cockroachdb/kv-prs
 /pkg/server/node_http*.go                @cockroachdb/obs-prs
 /pkg/server/node_tenant*go               @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/pgurl/                       @cockroachdb/sql-foundations @cockroachdb/cli-prs
+/pkg/server/pgurl/                       @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
 /pkg/server/pagination*                  @cockroachdb/obs-prs
 /pkg/server/problem_ranges*.go           @cockroachdb/obs-prs
 /pkg/server/profiler/                    @cockroachdb/obs-prs @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/server/purge_auth_*                 @cockroachdb/obs-prs
 /pkg/server/server_controller_*.go       @cockroachdb/server-prs
 /pkg/server/server_controller_http.go    @cockroachdb/obs-prs @cockroachdb/server-prs
-/pkg/server/server_controller_sql.go     @cockroachdb/sql-foundations @cockroachdb/server-prs
+/pkg/server/server_controller_sql.go     @cockroachdb/sql-foundations-prs @cockroachdb/server-prs
 /pkg/server/server_drpc_test.go          @cockroachdb/server-prs
 # DB Server will eventually competely own server_http*
 /pkg/server/server_http*.go              @cockroachdb/obs-prs @cockroachdb/server-prs
@@ -387,10 +387,10 @@
 #!/pkg/gen/*.bzl               @cockroachdb/dev-inf-noreview
 /pkg/gen/gen.bzl             @cockroachdb/dev-inf
 
-/pkg/acceptance/             @cockroachdb/sql-foundations
+/pkg/acceptance/             @cockroachdb/sql-foundations-prs
 /pkg/base/                   @cockroachdb/kv-prs @cockroachdb/server-prs
 #!/pkg/bench/                  @cockroachdb/sql-queries-noreview
-/pkg/bench/rttanalysis       @cockroachdb/sql-foundations
+/pkg/bench/rttanalysis       @cockroachdb/sql-foundations-prs
 /pkg/blobs/                  @cockroachdb/disaster-recovery
 /pkg/build/                  @cockroachdb/dev-inf
 /pkg/ccl/multiregionccl/     @cockroachdb/sql-queries-prs
@@ -406,30 +406,30 @@
 
 /pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries-prs
-/pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-foundations
+/pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-foundations-prs
 #!/pkg/ccl/testutilsccl/     @cockroachdb/test-eng-noreview
-/pkg/ccl/testutilsccl/alter_* @cockroachdb/sql-foundations
+/pkg/ccl/testutilsccl/alter_* @cockroachdb/sql-foundations-prs
 #!/pkg/clusterversion/       @cockroachdb/kv-prs-noreview @cockroachdb/dev-inf-noreview @cockroachdb/test-eng-noreview
 /pkg/clusterversion/cockroach_versions.go @cockroachdb/release-eng-prs @cockroachdb/upgrade-prs
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf
 /pkg/cmd/cmdutil/            @cockroachdb/dev-inf
-/pkg/cmd/cmp-protocol/       @cockroachdb/sql-foundations
-/pkg/cmd/cmp-sql/            @cockroachdb/sql-foundations
-/pkg/cmd/cmpconn/            @cockroachdb/sql-foundations
+/pkg/cmd/cmp-protocol/       @cockroachdb/sql-foundations-prs
+/pkg/cmd/cmp-sql/            @cockroachdb/sql-foundations-prs
+/pkg/cmd/cmpconn/            @cockroachdb/sql-foundations-prs
 /pkg/cmd/cockroach/          @cockroachdb/dev-inf @cockroachdb/cli-prs
 /pkg/cmd/cockroach-short/    @cockroachdb/dev-inf @cockroachdb/cli-prs
-/pkg/cmd/cockroach-sql/      @cockroachdb/sql-foundations @cockroachdb/cli-prs
-/pkg/cmd/cr2pg/              @cockroachdb/sql-foundations
+/pkg/cmd/cockroach-sql/      @cockroachdb/sql-foundations-prs @cockroachdb/cli-prs
+/pkg/cmd/cr2pg/              @cockroachdb/sql-foundations-prs
 /pkg/cmd/dev/                @cockroachdb/dev-inf
 #!/pkg/cmd/docgen/             @cockroachdb/docs-infra-prs
 /pkg/cmd/drt*                @cockroachdb/test-eng
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
-/pkg/cmd/generate-binary/    @cockroachdb/sql-foundations
+/pkg/cmd/generate-binary/    @cockroachdb/sql-foundations-prs
 /pkg/cmd/generate-distdir/ @cockroachdb/dev-inf
 /pkg/cmd/generate-logictest/       @cockroachdb/dev-inf
 /pkg/cmd/generate-acceptance-tests/       @cockroachdb/dev-inf
-/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-foundations
+/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-foundations-prs
 /pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/spatial
 /pkg/cmd/generate-bazel-extra/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
@@ -464,7 +464,7 @@
 /pkg/cmd/roachtest/spec/              @cockroachdb/test-eng
 /pkg/cmd/roachtest/test/              @cockroachdb/test-eng
 /pkg/cmd/roachtest/testdata/          @cockroachdb/test-eng
-/pkg/cmd/roachtest/testdata/pg_regress @cockroachdb/sql-foundations
+/pkg/cmd/roachtest/testdata/pg_regress @cockroachdb/sql-foundations-prs
 /pkg/cmd/roachtest/testselector/      @cockroachdb/test-eng
 # This isn't quite right, each file should ideally be owned
 # by a team (or at least most of them), namely the team that
@@ -472,23 +472,23 @@
 # two concepts of ownership we don't want to ping test-eng
 # on each test change.
 #!/pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
-/pkg/cmd/roachtest/tests/activerecord.go  @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/asyncpg.go       @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/activerecord.go  @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/asyncpg.go       @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
 /pkg/cmd/roachtest/tests/cdc*.go          @cockroachdb/cdc-prs
-/pkg/cmd/roachtest/tests/django.go        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/gopg.go	        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/gorm.go	        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/hibernate.go	    @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/knex.go	        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/libpq.go	        @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/npgsql.go	      @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/pgjdbc.go	      @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/pgx.go	          @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/ruby_pg.go	      @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/sequelize.go	    @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/typeorm.go	      @cockroachdb/sql-foundations @cockroachdb/docs-infra-prs
-/pkg/cmd/roachtest/tests/copy.go                         @cockroachdb/sql-foundations
-/pkg/cmd/roachtest/tests/copyfrom.go                     @cockroachdb/sql-foundations
+/pkg/cmd/roachtest/tests/django.go        @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/gopg.go	        @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/gorm.go	        @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/hibernate.go	    @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/knex.go	        @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/libpq.go	        @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/npgsql.go	      @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/pgjdbc.go	      @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/pgx.go	          @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/ruby_pg.go	      @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/sequelize.go	    @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/typeorm.go	      @cockroachdb/sql-foundations-prs @cockroachdb/docs-infra-prs
+/pkg/cmd/roachtest/tests/copy.go                         @cockroachdb/sql-foundations-prs
+/pkg/cmd/roachtest/tests/copyfrom.go                     @cockroachdb/sql-foundations-prs
 /pkg/cmd/roachtest/tests/inspect_throughput.go           @cockroachdb/sql-queries-prs
 /pkg/cmd/roachtest/tests/ttl_restart.go                  @cockroachdb/sql-queries-prs
 /pkg/cmd/roachtest/tests/multi_region_system_database.go @cockroachdb/sql-queries-prs
@@ -496,7 +496,7 @@
 /pkg/cmd/roachtest/tests/super_region_failover.go        @cockroachdb/sql-queries-prs
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng
-/pkg/cmd/skiperrs/           @cockroachdb/sql-foundations
+/pkg/cmd/skiperrs/           @cockroachdb/sql-foundations-prs
 /pkg/cmd/skipped-tests/      @cockroachdb/test-eng
 /pkg/cmd/smith/              @cockroachdb/sql-queries-prs
 /pkg/cmd/smithcmp/           @cockroachdb/sql-queries-prs
@@ -509,7 +509,7 @@
 #!/pkg/cmd/wraprules/          @cockroachdb/obs-prs-noreview
 #!/pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries-prs
-/pkg/compose/                @cockroachdb/sql-foundations
+/pkg/compose/                @cockroachdb/sql-foundations-prs
 /pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
 # TODO(nickvigilante): add the cockroach repo to the docs-infra-prs team so that
 # Github stops complaining. Then remove the #! prefix here and on the other lines
@@ -563,7 +563,7 @@
 /pkg/security/tls_ciphersuites.go @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/security/tls_test.go    @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/security/x509.go        @cockroachdb/security-engineering @cockroachdb/product-security
-/pkg/security/clientsecopts/ @cockroachdb/sql-foundations @cockroachdb/security-engineering @cockroachdb/product-security
+/pkg/security/clientsecopts/ @cockroachdb/sql-foundations-prs @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/security/distinguishedname/ @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/security/gssapiauth/    @cockroachdb/product-security
 /pkg/security/jwtauth/       @cockroachdb/cloud-identity @cockroachdb/product-security
@@ -574,21 +574,21 @@
 /pkg/security/provisioning/  @cockroachdb/security-engineering @cockroachdb/product-security
 /pkg/security/username/      @cockroachdb/security-engineering @cockroachdb/product-security
 #!/pkg/settings/             @cockroachdb/unowned
-/pkg/spanconfig/                         @cockroachdb/kv-prs @cockroachdb/sql-foundations @cockroachdb/kv-distribution
-/pkg/spanconfig/spanconfigbounds/        @cockroachdb/sql-foundations
-/pkg/spanconfig/spanconfigjob/           @cockroachdb/sql-foundations
+/pkg/spanconfig/                         @cockroachdb/kv-prs @cockroachdb/sql-foundations-prs @cockroachdb/kv-distribution
+/pkg/spanconfig/spanconfigbounds/        @cockroachdb/sql-foundations-prs
+/pkg/spanconfig/spanconfigjob/           @cockroachdb/sql-foundations-prs
 /pkg/spanconfig/spanconfigkvaccessor/    @cockroachdb/kv-prs @cockroachdb/kv-distribution
 /pkg/spanconfig/spanconfigkvsubscriber/  @cockroachdb/kv-prs @cockroachdb/kv-distribution
-/pkg/spanconfig/spanconfiglimiter/       @cockroachdb/sql-foundations
-/pkg/spanconfig/spanconfigmanager/       @cockroachdb/sql-foundations
+/pkg/spanconfig/spanconfiglimiter/       @cockroachdb/sql-foundations-prs
+/pkg/spanconfig/spanconfigmanager/       @cockroachdb/sql-foundations-prs
 /pkg/spanconfig/spanconfigptsreader/     @cockroachdb/kv-prs @cockroachdb/kv-distribution
 /pkg/spanconfig/spanconfigreconciler/    @cockroachdb/kv-prs @cockroachdb/kv-distribution
 /pkg/spanconfig/spanconfigreporter/      @cockroachdb/kv-prs @cockroachdb/kv-distribution
-/pkg/spanconfig/spanconfigsplitter/      @cockroachdb/sql-foundations
-/pkg/spanconfig/spanconfigsqltranslator/ @cockroachdb/sql-foundations
-/pkg/spanconfig/spanconfigsqlwatcher/    @cockroachdb/sql-foundations
+/pkg/spanconfig/spanconfigsplitter/      @cockroachdb/sql-foundations-prs
+/pkg/spanconfig/spanconfigsqltranslator/ @cockroachdb/sql-foundations-prs
+/pkg/spanconfig/spanconfigsqlwatcher/    @cockroachdb/sql-foundations-prs
 /pkg/spanconfig/spanconfigstore/         @cockroachdb/kv-prs @cockroachdb/kv-distribution
-/pkg/spanconfig/spanconfigtestutils/     @cockroachdb/kv-prs @cockroachdb/sql-foundations @cockroachdb/kv-distribution
+/pkg/spanconfig/spanconfigtestutils/     @cockroachdb/kv-prs @cockroachdb/sql-foundations-prs @cockroachdb/kv-distribution
 /pkg/repstream/              @cockroachdb/disaster-recovery
 #!/pkg/testutils/              @cockroachdb/test-eng-noreview
 /pkg/testutils/sqlutils/     @cockroachdb/sql-queries-prs

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -8,6 +8,7 @@ cockroachdb/docs:
 cockroachdb/sql-foundations:
   aliases:
     cockroachdb/sql-api-prs: other
+    cockroachdb/sql-foundations-prs: other
   label: T-sql-foundations
 cockroachdb/sqlproxy-prs:
   label: T-cloud-platform


### PR DESCRIPTION
Register cockroachdb/sql-foundations-prs as an alias of the parent sql-foundations team and point CODEOWNERS at it. GitHub now round-robins PR review assignment across -prs members, while issue routing, labels, and metric ownership continue to resolve to the canonical sql-foundations team.

Epic: none
Release note: None