### PR TITLE
sql: allow GRANT, REVOKE, ALTER DEFAULT PRIVILEGES in stored procedures

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure_dcl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_dcl
@@ -1,0 +1,344 @@
+# LogicTest: !local-mixed-25.4 !local-mixed-26.1 !local-mixed-26.2
+
+statement ok
+CREATE ROLE r1;
+CREATE ROLE r2;
+
+statement ok
+CREATE TABLE t_dcl (a INT PRIMARY KEY, b TEXT);
+
+subtest dcl_blocked_in_functions
+
+statement error pgcode 0A000 unimplemented: GRANT usage inside a function definition
+CREATE FUNCTION f_grant() RETURNS VOID LANGUAGE PLpgSQL AS $$
+BEGIN
+  GRANT SELECT ON t_dcl TO r1;
+END
+$$;
+
+statement error pgcode 0A000 unimplemented: REVOKE usage inside a function definition
+CREATE FUNCTION f_revoke() RETURNS VOID LANGUAGE PLpgSQL AS $$
+BEGIN
+  REVOKE SELECT ON t_dcl FROM r1;
+END
+$$;
+
+statement error pgcode 0A000 unimplemented: ALTER DEFAULT PRIVILEGES usage inside a function definition
+CREATE FUNCTION f_adp() RETURNS VOID LANGUAGE PLpgSQL AS $$
+BEGIN
+  ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO r1;
+END
+$$;
+
+# VOLATILE does not unlock DCL in functions.
+statement error pgcode 0A000 unimplemented: GRANT usage inside a function definition
+CREATE FUNCTION f_grant_volatile() RETURNS VOID VOLATILE LANGUAGE PLpgSQL AS $$
+BEGIN
+  GRANT SELECT ON t_dcl TO r1;
+END
+$$;
+
+subtest end
+
+
+subtest dcl_blocked_in_do_blocks
+
+statement error pgcode 0A000 unimplemented: GRANT usage inside a function definition
+DO $$
+BEGIN
+  GRANT SELECT ON t_dcl TO r1;
+END
+$$;
+
+statement error pgcode 0A000 unimplemented: REVOKE usage inside a function definition
+DO $$
+BEGIN
+  REVOKE SELECT ON t_dcl FROM r1;
+END
+$$;
+
+statement error pgcode 0A000 unimplemented: ALTER DEFAULT PRIVILEGES usage inside a function definition
+DO $$
+BEGIN
+  ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO r1;
+END
+$$;
+
+subtest end
+
+
+subtest grant_in_procedure
+
+statement ok
+CREATE PROCEDURE p_grant() LANGUAGE PLpgSQL AS $$
+BEGIN
+  GRANT SELECT, INSERT ON t_dcl TO r1;
+END
+$$;
+
+statement ok
+CALL p_grant();
+
+query TTTTTB colnames,rowsort
+SHOW GRANTS ON t_dcl FOR r1
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r1       INSERT          false
+test           public       t_dcl       r1       SELECT          false
+
+statement ok
+DROP PROCEDURE p_grant;
+
+subtest end
+
+
+subtest revoke_in_procedure
+
+statement ok
+GRANT SELECT, UPDATE ON t_dcl TO r2;
+
+statement ok
+CREATE PROCEDURE p_revoke() LANGUAGE PLpgSQL AS $$
+BEGIN
+  REVOKE UPDATE ON t_dcl FROM r2;
+END
+$$;
+
+statement ok
+CALL p_revoke();
+
+query TTTTTB colnames,rowsort
+SHOW GRANTS ON t_dcl FOR r2
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r2       SELECT          false
+
+statement ok
+REVOKE ALL ON t_dcl FROM r2;
+
+statement ok
+DROP PROCEDURE p_revoke;
+
+subtest end
+
+
+subtest alter_default_privileges_in_procedure
+
+statement ok
+CREATE PROCEDURE p_alter_default() LANGUAGE PLpgSQL AS $$
+BEGIN
+  ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO r1;
+END
+$$;
+
+statement ok
+CALL p_alter_default();
+
+# A table created after the procedure runs should pick up the default grant.
+statement ok
+CREATE TABLE t_after_default (a INT);
+
+query TTTTTB colnames,rowsort
+SHOW GRANTS ON t_after_default FOR r1
+----
+database_name  schema_name  table_name       grantee  privilege_type  is_grantable
+test           public       t_after_default  r1       SELECT          false
+
+# Clean up: undo the default privilege (in a procedure too, to cover REVOKE
+# inside ALTER DEFAULT PRIVILEGES).
+statement ok
+CREATE PROCEDURE p_alter_default_revoke() LANGUAGE PLpgSQL AS $$
+BEGIN
+  ALTER DEFAULT PRIVILEGES REVOKE SELECT ON TABLES FROM r1;
+END
+$$;
+
+statement ok
+CALL p_alter_default_revoke();
+
+statement ok
+CREATE TABLE t_after_revoke (a INT);
+
+query TTTTTB colnames
+SHOW GRANTS ON t_after_revoke FOR r1
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+
+statement ok
+DROP TABLE t_after_default, t_after_revoke;
+
+statement ok
+DROP PROCEDURE p_alter_default;
+DROP PROCEDURE p_alter_default_revoke;
+
+subtest end
+
+
+subtest multiple_dcl_in_procedure
+
+statement ok
+GRANT SELECT, INSERT, UPDATE ON t_dcl TO r1;
+
+statement ok
+CREATE PROCEDURE p_multi_dcl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  REVOKE UPDATE ON t_dcl FROM r1;
+  GRANT DELETE ON t_dcl TO r2;
+  REVOKE INSERT ON t_dcl FROM r1;
+END
+$$;
+
+statement ok
+CALL p_multi_dcl();
+
+query TTTTTB colnames,rowsort
+SHOW GRANTS ON t_dcl FOR r1, r2
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r1       SELECT          false
+test           public       t_dcl       r2       DELETE          false
+
+statement ok
+REVOKE ALL ON t_dcl FROM r1, r2;
+
+statement ok
+DROP PROCEDURE p_multi_dcl;
+
+subtest end
+
+
+subtest mixed_ddl_and_dcl
+
+# DDL and DCL freely mix in the same procedure body, but DCL targets are
+# early-bound: a GRANT cannot reference a table created in the same body.
+# This procedure grants on a pre-existing table and then creates a new one.
+statement ok
+CREATE PROCEDURE p_mixed() LANGUAGE PLpgSQL AS $$
+BEGIN
+  GRANT SELECT ON t_dcl TO r1;
+  CREATE TABLE t_mixed (a INT PRIMARY KEY);
+END
+$$;
+
+statement ok
+CALL p_mixed();
+
+query TTTTTB colnames
+SHOW GRANTS ON t_dcl FOR r1
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r1       SELECT          false
+
+statement ok
+SELECT * FROM t_mixed;
+
+statement ok
+REVOKE SELECT ON t_dcl FROM r1;
+
+statement ok
+DROP TABLE t_mixed;
+
+statement ok
+DROP PROCEDURE p_mixed;
+
+subtest end
+
+
+subtest early_binding_limitations
+
+# GRANT targets are resolved when the procedure body is built (at CREATE
+# PROCEDURE time), not when CALL executes, so a GRANT cannot refer to a
+# table created earlier in the same body. This test pins the early-binding
+# behavior so a future late-binding change for stored procedures will
+# visibly flip it.
+statement error pgcode 42P01 relation "t_grant_target" does not exist
+CREATE PROCEDURE p_grant_on_new_table() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_grant_target (a INT PRIMARY KEY);
+  GRANT SELECT ON t_grant_target TO r1;
+END
+$$;
+
+subtest end
+
+
+subtest dcl_then_error_in_procedure
+
+# When a procedure errors after performing DCL, the entire transaction
+# (including the DCL) should be rolled back.
+statement ok
+GRANT SELECT ON t_dcl TO r1;
+
+query TTTTTB colnames
+SHOW GRANTS ON t_dcl FOR r1
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r1       SELECT          false
+
+statement ok
+CREATE PROCEDURE p_dcl_then_error() LANGUAGE PLpgSQL AS $$
+BEGIN
+  REVOKE SELECT ON t_dcl FROM r1;
+  SELECT 1 // 0;
+END
+$$;
+
+statement error division by zero
+CALL p_dcl_then_error();
+
+# The REVOKE should have been rolled back: r1 still has SELECT.
+query TTTTTB colnames
+SHOW GRANTS ON t_dcl FOR r1
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r1       SELECT          false
+
+statement ok
+REVOKE SELECT ON t_dcl FROM r1;
+
+statement ok
+DROP PROCEDURE p_dcl_then_error;
+
+subtest end
+
+
+subtest nested_procedure_dcl
+
+statement ok
+CREATE PROCEDURE p_inner_dcl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  GRANT SELECT ON t_dcl TO r1;
+END
+$$;
+
+statement ok
+CREATE PROCEDURE p_outer_dcl() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CALL p_inner_dcl();
+END
+$$;
+
+statement ok
+CALL p_outer_dcl();
+
+query TTTTTB colnames
+SHOW GRANTS ON t_dcl FOR r1
+----
+database_name  schema_name  table_name  grantee  privilege_type  is_grantable
+test           public       t_dcl       r1       SELECT          false
+
+statement ok
+REVOKE SELECT ON t_dcl FROM r1;
+
+statement ok
+DROP PROCEDURE p_outer_dcl;
+DROP PROCEDURE p_inner_dcl;
+
+subtest end
+
+
+# Cleanup.
+statement ok
+DROP TABLE t_dcl;
+DROP ROLE r1;
+DROP ROLE r2;

--- a/pkg/sql/logictest/tests/3node-tenant/generated_test.go
+++ b/pkg/sql/logictest/tests/3node-tenant/generated_test.go
@@ -1696,6 +1696,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1674,6 +1674,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1681,6 +1681,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1709,6 +1709,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1681,6 +1681,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-prepared/generated_test.go
+++ b/pkg/sql/logictest/tests/local-prepared/generated_test.go
@@ -1373,6 +1373,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-read-committed/generated_test.go
+++ b/pkg/sql/logictest/tests/local-read-committed/generated_test.go
@@ -1688,6 +1688,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-repeatable-read/generated_test.go
+++ b/pkg/sql/logictest/tests/local-repeatable-read/generated_test.go
@@ -1674,6 +1674,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1702,6 +1702,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2010,6 +2010,13 @@ func TestLogic_procedure_cte(
 	runLogicTest(t, "procedure_cte")
 }
 
+func TestLogic_procedure_dcl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_dcl")
+}
+
 func TestLogic_procedure_ddl(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -386,15 +386,16 @@ func (b *Builder) buildStmt(
 		case *tree.DoBlock:
 		case *tree.CreateTable, *tree.DropTable,
 			*tree.CreateSchema, *tree.DropSchema,
-			*tree.CreateRole, *tree.DropRole:
+			*tree.CreateRole, *tree.DropRole,
+			*tree.Grant, *tree.Revoke, *tree.AlterDefaultPrivileges:
 			if !b.insideProcDef {
 				panic(unimplemented.NewWithIssuef(110080,
 					"%s usage inside a function definition is not supported",
 					stmt.StatementTag(),
 				))
 			}
-			// DDL is allowed inside stored procedures when the cluster has
-			// been upgraded to v26.3.
+			// DDL and DCL are allowed inside stored procedures when the
+			// cluster has been upgraded to v26.3.
 			if !b.evalCtx.Settings.Version.IsActive(
 				b.ctx, clusterversion.V26_3,
 			) {


### PR DESCRIPTION
These DCL statements report StatementReturnType() == DDL and were rejected by the optbuilder's CanModifySchema check inside procedure bodies. Add them to the existing procedure allowlist alongside CREATE/DROP TABLE, SCHEMA, and ROLE, reusing the same insideProcDef gate and v26.3 cluster version gate. Functions and DO blocks remain blocked.

Closes #170017
Epic: CRDB-31256

Release note (sql change): Stored procedures now support GRANT, REVOKE, and ALTER DEFAULT PRIVILEGES. The statements remain unsupported inside user-defined functions and DO blocks.