### PR TITLE
release-26.2: release: follow-ups to the pick-sha + cloud-rollout flow

### DIFF
--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -720,6 +720,15 @@ jobs:
         with:
           name: cloud-only-metadata
 
+      # rafa-production's update_versions.sh invokes `go run main.go ...`,
+      # so Go has to be on PATH for the rollout script to succeed. The
+      # version is pinned to match go.mod's toolchain so the rafa tool
+      # builds the same way it would locally.
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.2'
+
       # Fetch the GitHub PAT via the official Google action so it's
       # auto-registered with ::add-mask:: and never has to flow through `echo`
       # in our scripts.

--- a/pkg/cmd/release/pick_sha.go
+++ b/pkg/cmd/release/pick_sha.go
@@ -41,6 +41,16 @@ const pickSHAJQLDryRun = `issueType="CRDB Release" and ` +
 // "Pick SHA" subtask on a release ticket.
 const pickSHASubtaskMatch = "Pick SHA"
 
+// pickSHA success notifications go to the release-ops channels — a
+// RelEng-only audience. This deliberately differs from the wider
+// #db-release-status / #db-release-test channels that branch-cut uses,
+// because the "build-and-sign triggered" announcement is operational
+// noise that doesn't need to reach the broader release audience.
+const (
+	pickSHASlackChannel        = "#release-ops"
+	pickSHASlackStagingChannel = "#release-ops-staging"
+)
+
 // defaultBuildWorkflow is the workflow file dispatched by `pick-sha`. It
 // must accept `dry_run` and `sha` workflow_dispatch inputs.
 const defaultBuildWorkflow = "release-build-and-sign.yml"
@@ -85,8 +95,8 @@ func init() {
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.repo, "repo", defaultRepo(),
 		"target GitHub repository in owner/name form (defaults to $GITHUB_REPOSITORY when set)")
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.channel, "slack-channel", "",
-		"Slack channel for success notifications (default: "+releaseChannel+
-			" when "+envIsProductionRepo+"=true, "+nonProdChannel+" otherwise)")
+		"Slack channel for success notifications (default: "+pickSHASlackChannel+
+			" when "+envIsProductionRepo+"=true, "+pickSHASlackStagingChannel+" otherwise)")
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.opsChannel, "ops-channel", opsChannel,
 		"Slack channel for failure notifications")
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.buildWorkflow, "build-workflow", defaultBuildWorkflow,
@@ -130,13 +140,13 @@ func runPickSHA(_ *cobra.Command, _ []string) error {
 	sl := newSlackClient(slackToken)
 
 	// Repo identity (not --dry-run) decides which channel to post to: a fork
-	// rehearsal must not echo into #db-release-status. Explicit
-	// --slack-channel always wins.
+	// rehearsal must not echo into #release-ops. Explicit --slack-channel
+	// always wins.
 	channel := pickSHAFlags.channel
 	if channel == "" {
-		channel = nonProdChannel
+		channel = pickSHASlackStagingChannel
 		if isProductionRepo() {
-			channel = releaseChannel
+			channel = pickSHASlackChannel
 		}
 	}
 	r := &pickSHARunner{
@@ -301,36 +311,53 @@ func (r *pickSHARunner) processCandidate(ctx context.Context, c jiraIssue) error
 		log.Printf("[DRY RUN] would set SHA field on %s to %s", c.Key, sha)
 	}
 
-	msg := buildPickSHASlackMessage(details, r.dryRun)
+	// Trigger the docs release-notes draft before composing the Slack
+	// message so we can include the generated PR's URL inline (operators
+	// linked to it from the old Superblocks notification). It's safe to
+	// call here because the Pick SHA subtask was transitioned to Done
+	// above: the gate at the top of processCandidate skips this entire
+	// path on retry, so a transient slack/jira failure below can't
+	// re-fire the API and produce a duplicate docs draft. API failures
+	// remain non-fatal — see notifyReleaseNotes.
+	releaseNotesPRURL := r.notifyReleaseNotes(c.Key, full, sha)
+	// Log the PR URL eagerly so the docs draft link survives in the GHA
+	// run log even if PostMessage/AddComment below fail — the
+	// idempotency gate at the top of processCandidate prevents the
+	// retry from re-posting, so the log is the only durable record.
+	if releaseNotesPRURL != "" {
+		log.Printf("ticket %s: release-notes PR created: %s", c.Key, releaseNotesPRURL)
+	}
+
+	msg := buildPickSHASlackMessage(details, releaseNotesPRURL, r.dryRun)
 	link, err := r.slack.PostMessage(r.channel, msg)
 	if err != nil {
 		return errors.Wrap(err, "posting Slack message")
 	}
 	if !r.dryRun {
-		if err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link)); err != nil {
+		if err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link, releaseNotesPRURL)); err != nil {
 			return errors.Wrap(err, "adding Jira comment")
 		}
 	} else {
 		log.Printf("[DRY RUN] would add Jira comment on %s with Slack link %q", c.Key, link)
 	}
 
-	// Notify the docs release-notes API last, after every other side effect
-	// has succeeded. Failures here are non-fatal: we already dispatched
-	// build-and-sign and updated Jira/Slack, so failing the candidate would
-	// re-fire those (expensive) side effects on the next cron. A Slack
-	// warning to #release-ops gives operators a chance to re-trigger
-	// generation manually.
-	r.notifyReleaseNotes(c.Key, full, sha)
-
 	log.Printf("ticket %s: dispatched %s on %s at %s", c.Key, r.buildWorkflow, ref, sha)
 	return nil
 }
 
 // notifyReleaseNotes builds the release-notes API payload from the Jira
-// issue and POSTs it. Skipped (with a log line) under --dry-run, since the
-// API has no non-prod endpoint and a dry-run call would create real docs
-// drafts. Errors are swallowed after a warning is posted to #release-ops:
-// see the call site for why.
+// issue and POSTs it. Returns the generated docs PR URL on success, or
+// "" on dry-run, idempotency skip, or any error (after warning to
+// #release-ops). The caller surfaces the URL in the success Slack and
+// Jira messages; it isn't load-bearing for correctness.
+//
+// Skipped (with a log line) under --dry-run, since the API has no
+// non-prod endpoint and a dry-run call would create real docs drafts.
+// Errors are swallowed after a warning is posted to #release-ops:
+// failing the candidate would re-fire the (expensive) build-and-sign
+// dispatch on the next cron run, which is too costly to risk over a
+// non-critical docs draft. Operators can re-trigger generation
+// manually from the warning.
 //
 // Idempotency: the call is also skipped when the docs subtask is already
 // marked Done, because that means the docs team has already opened (and
@@ -339,14 +366,14 @@ func (r *pickSHARunner) processCandidate(ctx context.Context, c jiraIssue) error
 // processCandidate normally prevents re-entry on the same ticket, but a
 // transition failure between DispatchWorkflow and the subtask transition
 // could re-fire the rest of the chain — this gate covers that window.
-func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha string) {
+func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha string) string {
 	if r.dryRun {
 		log.Printf("[DRY RUN] would call release-notes API for %s", key)
-		return
+		return ""
 	}
 	if _, docsDone := findSubtask(full, docsSubtaskMatch); docsDone {
 		log.Printf("ticket %s: docs subtask already Done, skipping release-notes API call", key)
-		return
+		return ""
 	}
 	payload, err := buildReleaseNotesPayload(full, sha)
 	if err != nil {
@@ -355,12 +382,15 @@ func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha stri
 		// ticket key in the headline.
 		log.Printf("ticket %s: building release-notes payload failed: %v", key, err)
 		r.warnReleaseNotes(key, releaseNotesPayload{}, err)
-		return
+		return ""
 	}
-	if err := postReleaseNotes(releaseNotesAPIURL, r.releaseNotesAPIKey, payload); err != nil {
+	resp, err := postReleaseNotes(releaseNotesAPIURL, r.releaseNotesAPIKey, payload)
+	if err != nil {
 		log.Printf("ticket %s: release-notes API call failed: %v", key, err)
 		r.warnReleaseNotes(key, payload, err)
+		return ""
 	}
+	return resp.PullRequestURL
 }
 
 func (r *pickSHARunner) warnReleaseNotes(key string, payload releaseNotesPayload, err error) {
@@ -526,8 +556,11 @@ func buildPickSHADetails(
 }
 
 // buildPickSHASlackMessage renders the announcement that goes to
-// #db-release-status (or the non-prod channel for fork rehearsals).
-func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
+// #release-ops (or the staging channel for fork rehearsals).
+// releaseNotesPRURL is the docs PR opened by the release-notes API and
+// is rendered as an extra bullet when non-empty; an empty value (dry-run,
+// API failure, or idempotency skip) just omits the bullet.
+func buildPickSHASlackMessage(d pickSHADetails, releaseNotesPRURL string, dryRun bool) string {
 	body := fmt.Sprintf("SHA picked for `%s` — build-and-sign triggered:\n"+
 		"• Picked SHA: <%s|%s>\n"+
 		"• Build run: <%s|view in Actions>\n"+
@@ -538,6 +571,9 @@ func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
 		d.BuildRunListURL,
 		d.CloudReleaseNotesDate,
 		d.PublishBinaryDate)
+	if releaseNotesPRURL != "" {
+		body += fmt.Sprintf("\n• *Release notes PR:* <%s|%s>", releaseNotesPRURL, releaseNotesPRURL)
+	}
 	if dryRun {
 		return "[DRY RUN] " + body
 	}
@@ -547,11 +583,39 @@ func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
 // buildPickSHAJiraComment returns an ADF doc that mirrors the Slack message
 // using native Jira marks (strong, code, link) so the comment doesn't show
 // literal `*` and backticks. The Slack permalink, when non-empty, is
-// rendered as the first paragraph for traceability.
-func buildPickSHAJiraComment(d pickSHADetails, slackLink string) map[string]interface{} {
+// rendered as the first paragraph for traceability. The release-notes PR
+// URL, when non-empty, becomes an extra bullet — symmetric with the Slack
+// message.
+func buildPickSHAJiraComment(
+	d pickSHADetails, slackLink, releaseNotesPRURL string,
+) map[string]interface{} {
 	var blocks []interface{}
 	if slackLink != "" {
 		blocks = append(blocks, adfPara(adfMarked(slackLink, adfLink(slackLink))))
+	}
+	bullets := [][]interface{}{
+		{
+			adfMarked("Picked SHA: ", adfStrong()),
+			adfMarked(d.PickedSHA, adfLink(d.PickedCommitURL), adfCode()),
+		},
+		{
+			adfMarked("Build run: ", adfStrong()),
+			adfMarked("view in Actions", adfLink(d.BuildRunListURL)),
+		},
+		{
+			adfMarked("Cloud Release Notes Date: ", adfStrong()),
+			adfMarked(d.CloudReleaseNotesDate, adfCode()),
+		},
+		{
+			adfMarked("Publish Binaries Date: ", adfStrong()),
+			adfMarked(d.PublishBinaryDate, adfCode()),
+		},
+	}
+	if releaseNotesPRURL != "" {
+		bullets = append(bullets, []interface{}{
+			adfMarked("Release notes PR: ", adfStrong()),
+			adfMarked(releaseNotesPRURL, adfLink(releaseNotesPRURL)),
+		})
 	}
 	blocks = append(blocks,
 		adfPara(
@@ -559,24 +623,7 @@ func buildPickSHAJiraComment(d pickSHADetails, slackLink string) map[string]inte
 			adfMarked(d.StagingBranch, adfCode()),
 			adfText(" — build-and-sign triggered:"),
 		),
-		adfBullet(
-			[]interface{}{
-				adfMarked("Picked SHA: ", adfStrong()),
-				adfMarked(d.PickedSHA, adfLink(d.PickedCommitURL), adfCode()),
-			},
-			[]interface{}{
-				adfMarked("Build run: ", adfStrong()),
-				adfMarked("view in Actions", adfLink(d.BuildRunListURL)),
-			},
-			[]interface{}{
-				adfMarked("Cloud Release Notes Date: ", adfStrong()),
-				adfMarked(d.CloudReleaseNotesDate, adfCode()),
-			},
-			[]interface{}{
-				adfMarked("Publish Binaries Date: ", adfStrong()),
-				adfMarked(d.PublishBinaryDate, adfCode()),
-			},
-		),
+		adfBullet(bullets...),
 	)
 	return adfDoc(blocks...)
 }

--- a/pkg/cmd/release/pick_sha_test.go
+++ b/pkg/cmd/release/pick_sha_test.go
@@ -82,7 +82,7 @@ func TestBuildPickSHASlackMessage(t *testing.T) {
 	}
 
 	t.Run("regular message", func(t *testing.T) {
-		msg := buildPickSHASlackMessage(d, false)
+		msg := buildPickSHASlackMessage(d, "", false)
 		require.Contains(t, msg, "SHA picked for `release-25.4.3-rc`")
 		require.Contains(t, msg, "<https://github.com/example-org/example-repo/commit/deadbeef|deadbeef>")
 		require.Contains(t, msg,
@@ -90,10 +90,17 @@ func TestBuildPickSHASlackMessage(t *testing.T) {
 		require.Contains(t, msg, "*Cloud Release Notes Date:* `Thursday, 04/23`")
 		require.Contains(t, msg, "*Publish Binaries Date:* `Friday, 04/24`")
 		require.False(t, strings.HasPrefix(msg, "[DRY RUN] "))
+		require.NotContains(t, msg, "Release notes PR")
+	})
+
+	t.Run("with release-notes PR", func(t *testing.T) {
+		const prURL = "https://github.com/cockroachdb/docs/pull/23375"
+		msg := buildPickSHASlackMessage(d, prURL, false)
+		require.Contains(t, msg, "*Release notes PR:* <"+prURL+"|"+prURL+">")
 	})
 
 	t.Run("dry-run prefix", func(t *testing.T) {
-		require.True(t, strings.HasPrefix(buildPickSHASlackMessage(d, true), "[DRY RUN] "))
+		require.True(t, strings.HasPrefix(buildPickSHASlackMessage(d, "", true), "[DRY RUN] "))
 	})
 }
 
@@ -108,7 +115,7 @@ func TestBuildPickSHAJiraComment(t *testing.T) {
 	}
 	const slackLink = "https://example.slack.com/archives/C123/p456"
 
-	doc := buildPickSHAJiraComment(d, slackLink)
+	doc := buildPickSHAJiraComment(d, slackLink, "")
 	require.Equal(t, "doc", doc["type"])
 	require.Equal(t, 1, doc["version"])
 	content, ok := doc["content"].([]interface{})
@@ -144,7 +151,7 @@ func TestBuildPickSHAJiraCommentNoSlackLink(t *testing.T) {
 		CloudReleaseNotesDate: "TBD",
 		PublishBinaryDate:     "TBD",
 	}
-	doc := buildPickSHAJiraComment(d, "")
+	doc := buildPickSHAJiraComment(d, "", "")
 	content, ok := doc["content"].([]interface{})
 	require.True(t, ok)
 	// No Slack-link paragraph: just intro paragraph + bullet list.
@@ -360,7 +367,7 @@ func TestPostReleaseNotes(t *testing.T) {
 		DocsTicket:     "DOC-42",
 	}
 
-	t.Run("posts payload with X-API-Key header on success", func(t *testing.T) {
+	t.Run("posts payload and decodes pull_request_url on success", func(t *testing.T) {
 		var gotMethod, gotKey, gotContentType string
 		var gotBody []byte
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -369,13 +376,16 @@ func TestPostReleaseNotes(t *testing.T) {
 			gotContentType = r.Header.Get("Content-Type")
 			gotBody, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"pull_request_url":"https://github.com/cockroachdb/docs/pull/123"}`))
 		}))
 		defer srv.Close()
 
-		require.NoError(t, postReleaseNotes(srv.URL, "secret-key", payload))
+		resp, err := postReleaseNotes(srv.URL, "secret-key", payload)
+		require.NoError(t, err)
 		require.Equal(t, http.MethodPost, gotMethod)
 		require.Equal(t, "secret-key", gotKey)
 		require.Equal(t, "application/json", gotContentType)
+		require.Equal(t, "https://github.com/cockroachdb/docs/pull/123", resp.PullRequestURL)
 
 		// The docs API expects the payload fields at the top level of the
 		// request body; an envelope causes 400s on the required-field
@@ -385,6 +395,17 @@ func TestPostReleaseNotes(t *testing.T) {
 		require.Equal(t, payload, got)
 	})
 
+	t.Run("empty body yields zero-value response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		resp, err := postReleaseNotes(srv.URL, "k", payload)
+		require.NoError(t, err)
+		require.Empty(t, resp.PullRequestURL)
+	})
+
 	t.Run("non-2xx returns error including status and body", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -392,7 +413,7 @@ func TestPostReleaseNotes(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		err := postReleaseNotes(srv.URL, "k", payload)
+		_, err := postReleaseNotes(srv.URL, "k", payload)
 		require.ErrorContains(t, err, "500")
 		require.ErrorContains(t, err, "boom")
 	})

--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -46,20 +46,30 @@ type releaseNotesPayload struct {
 	DocsTicket     string `json:"docs_ticket"`
 }
 
-// postReleaseNotes POSTs payload to url with the X-API-Key header. Returns
-// nil on a 2xx response, otherwise an error containing the response status
-// and (truncated) body. Caller is expected to treat failures as a warning,
-// not a fatal error: the rest of pick-sha has already succeeded and the
-// docs team can re-trigger manually. URL is injected (rather than reading
-// the constant directly) so tests can point at an httptest server.
-func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
+// releaseNotesResponse is the JSON body the docs API returns on success.
+// PullRequestURL points at the cockroachdb/docs PR that holds the
+// generated release-notes draft. Other fields the API may return are
+// intentionally not modelled — callers only need the PR link today.
+type releaseNotesResponse struct {
+	PullRequestURL string `json:"pull_request_url"`
+}
+
+// postReleaseNotes POSTs payload to url with the X-API-Key header. On a 2xx
+// response it returns the parsed body (which may have an empty
+// PullRequestURL if the API omits it); on non-2xx it returns an error
+// containing the response status and (truncated) body. Caller is expected
+// to treat failures as a warning, not a fatal error: the rest of pick-sha
+// has already succeeded and the docs team can re-trigger manually. URL is
+// injected (rather than reading the constant directly) so tests can point
+// at an httptest server.
+func postReleaseNotes(url, apiKey string, p releaseNotesPayload) (releaseNotesResponse, error) {
 	body, err := json.Marshal(p)
 	if err != nil {
-		return errors.Wrap(err, "marshalling payload")
+		return releaseNotesResponse{}, errors.Wrap(err, "marshalling payload")
 	}
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return errors.Wrap(err, "building request")
+		return releaseNotesResponse{}, errors.Wrap(err, "building request")
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", apiKey)
@@ -69,12 +79,27 @@ func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
 	client := httputil.NewClientWithTimeout(2 * time.Minute)
 	resp, err := client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "posting to release-notes API")
+		return releaseNotesResponse{}, errors.Wrap(err, "posting to release-notes API")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
+		// The body is diagnostic-only on top of an already-known error;
+		// a read failure here doesn't change the outcome, so the error
+		// is intentionally dropped.
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return errors.Newf("release-notes API returned %s: %s", resp.Status, respBody)
+		return releaseNotesResponse{}, errors.Newf("release-notes API returned %s: %s", resp.Status, respBody)
 	}
-	return nil
+	// Bound the read so a runaway response can't exhaust memory. 16 KiB
+	// is well above the small JSON the API actually returns.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
+	if err != nil {
+		return releaseNotesResponse{}, errors.Wrap(err, "reading release-notes response")
+	}
+	var out releaseNotesResponse
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &out); err != nil {
+			return releaseNotesResponse{}, errors.Wrap(err, "decoding release-notes response")
+		}
+	}
+	return out, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #170754 on behalf of @rail.

----

Three independent follow-ups, all surfaced by operating the new GHA release pipeline on release-26.2.1-rc.

1. cloud-rollout job needs Go on PATH. rafa-production's update_versions.sh shells out to `go run main.go update-versions ...`. The cockroach GHA runner doesn't ship Go, so the job died with `go: command not found` (exit 127). Add an actions/setup-go step pinned to go.mod's 1.26.2 so the rafa tool builds. The symmetric update-versions-master job in release-publish.yml doesn't need this — it runs inside the bazel container via run_bazel, which already has Go.

2. Narrow the pick-sha success Slack audience to RelEng. The 'SHA picked / build-and-sign triggered' announcement was posting to #db-release-status (or #db-release-test for fork rehearsals), but only RelEng acts on it. Route it to #release-ops (or #release-ops-staging) via two new pick-sha-specific channel constants. Branch-cut deliberately keeps the wider channels — its notification is genuinely useful to the broader release audience.

3. Inline the generated release-notes PR in the success message. The docs release-notes API now returns the PR URL; operators previously had to dig it out of the docs ticket. postReleaseNotes now parses the response into a releaseNotesResponse, and the call is reordered to happen between the Jira SHA update and the Slack post so the PR URL can be rendered as an extra bullet in the announcement (and in the mirrored Jira comment). The reorder is safe because the Pick SHA subtask is already transitioned to Done before this point, so the idempotency gate at the top of processCandidate prevents any retry from re-firing the API and producing a duplicate docs draft.

Epic: none
Release note: None

----

Release justification: release automation changes