### PR TITLE
schemachanger: implement `ALTER DOMAIN ... DEFAULT` for domains

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -148,6 +148,13 @@ func TestBackupRollbacks_base_alter_database_configure_zone_multiple(t *testing.
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -166,6 +173,13 @@ func TestBackupRollbacks_base_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacks_base_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1093,6 +1107,13 @@ func TestBackupRollbacksMixedVersion_base_alter_database_configure_zone_multiple
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacksMixedVersion_base_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacksMixedVersion_base_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1111,6 +1132,13 @@ func TestBackupRollbacksMixedVersion_base_alter_domain_rename_collision(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2038,6 +2066,13 @@ func TestBackupSuccess_base_alter_database_configure_zone_multiple(t *testing.T)
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2056,6 +2091,13 @@ func TestBackupSuccess_base_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccess_base_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2983,6 +3025,13 @@ func TestBackupSuccessMixedVersion_base_alter_database_configure_zone_multiple(t
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccessMixedVersion_base_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccessMixedVersion_base_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3001,6 +3050,13 @@ func TestBackupSuccessMixedVersion_base_alter_domain_rename_collision(t *testing
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_domain
+++ b/pkg/sql/logictest/testdata/logic_test/alter_domain
@@ -8,18 +8,97 @@ CREATE DOMAIN d AS INT DEFAULT 0 NOT NULL CHECK (VALUE > 0)
 
 subtest set_default
 
-statement error pgcode 0A000 ALTER DOMAIN SET DEFAULT is not supported
-ALTER DOMAIN d SET DEFAULT 42
+# Use a domain without NOT NULL to allow NULL default testing.
+statement ok
+CREATE DOMAIN d_def AS INT DEFAULT 0
 
-statement error pgcode 0A000 ALTER DOMAIN SET DEFAULT is not supported
-ALTER DOMAIN d SET DEFAULT 1 + 2
+statement ok
+ALTER DOMAIN d_def SET DEFAULT 42
+
+# Verify the default was applied by creating a table and inserting.
+statement ok
+CREATE TABLE t_set_def (c d_def);
+INSERT INTO t_set_def (c) VALUES (DEFAULT)
+
+query T
+SELECT c FROM t_set_def
+----
+42
+
+# Replace the default with an expression.
+statement ok
+ALTER DOMAIN d_def SET DEFAULT 1 + 2
+
+statement ok
+TRUNCATE t_set_def;
+INSERT INTO t_set_def (c) VALUES (DEFAULT)
+
+query T
+SELECT c FROM t_set_def
+----
+3
+
+# Setting the default to NULL clears it.
+statement ok
+ALTER DOMAIN d_def SET DEFAULT NULL
+
+statement ok
+TRUNCATE t_set_def;
+INSERT INTO t_set_def (c) VALUES (DEFAULT)
+
+query T
+SELECT c FROM t_set_def
+----
+NULL
+
+# SET DEFAULT is idempotent (setting when already absent).
+statement ok
+ALTER DOMAIN d_def SET DEFAULT 10
+
+statement ok
+TRUNCATE t_set_def;
+INSERT INTO t_set_def (c) VALUES (DEFAULT)
+
+query T
+SELECT c FROM t_set_def
+----
+10
+
+# Type mismatch should be caught.
+statement error could not parse "not an int" as type int
+ALTER DOMAIN d_def SET DEFAULT 'not an int'
+
+statement ok
+DROP TABLE t_set_def
 
 subtest end
 
 subtest drop_default
 
-statement error pgcode 0A000 ALTER DOMAIN DROP DEFAULT is not supported
-ALTER DOMAIN d DROP DEFAULT
+statement ok
+ALTER DOMAIN d_def DROP DEFAULT
+
+# Verify the default is gone.
+statement ok
+CREATE TABLE t_drop_def (c d_def);
+INSERT INTO t_drop_def (c) VALUES (DEFAULT)
+
+query T
+SELECT c FROM t_drop_def
+----
+NULL
+
+# DROP DEFAULT is idempotent.
+statement ok
+ALTER DOMAIN d_def DROP DEFAULT
+
+# Restore the original default for subsequent tests.
+statement ok
+ALTER DOMAIN d_def SET DEFAULT 0
+
+statement ok
+DROP TABLE t_drop_def;
+DROP DOMAIN d_def
 
 subtest end
 
@@ -657,7 +736,7 @@ CREATE SCHEMA s
 statement ok
 CREATE DOMAIN s.d_qual AS INT
 
-statement error pgcode 0A000 ALTER DOMAIN SET DEFAULT is not supported
+statement ok
 ALTER DOMAIN s.d_qual SET DEFAULT 1
 
 subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_domain.go
@@ -11,11 +11,13 @@ import (
 	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/errors"
 )
@@ -112,13 +114,47 @@ func AlterDomain(b BuildCtx, n *tree.AlterDomain) {
 func alterDomainSetDefault(
 	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainSetDefault,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN SET DEFAULT is not supported"))
+	typeID := domainType.TypeID
+	domainElts := b.QueryByID(typeID)
+	if oldDefault := domainElts.FilterDomainDefault().NotToAbsent().MustGetZeroOrOneElement(); oldDefault != nil {
+		b.Drop(oldDefault)
+	}
+
+	if t.Default == nil || t.Default == tree.DNull {
+		return
+	}
+
+	typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
+		b, t.Default, domainType.BaseTypeT.Type,
+		tree.ColumnDefaultExprInSetDefault,
+		b.SemaCtx(), volatility.Volatile, false, /* allowAssignmentCast */
+	)
+	if err != nil {
+		panic(pgerror.WithCandidateCode(err, pgcode.DatatypeMismatch))
+	}
+
+	typedExpr, err = schemaexpr.MaybeReplaceUDFNameWithOIDReferenceInTypedExpr(typedExpr)
+	if err != nil {
+		panic(err)
+	}
+
+	b.Add(&scpb.DomainDefault{
+		TypeID:     typeID,
+		Expression: *b.WrapExpression(typeID, typedExpr),
+	})
 }
 
 func alterDomainDropDefault(
 	b BuildCtx, tn *tree.TypeName, domainType *scpb.DomainType, t *tree.AlterDomainDropDefault,
 ) {
-	panic(pgerror.Newf(pgcode.FeatureNotSupported, "ALTER DOMAIN DROP DEFAULT is not supported"))
+	typeID := domainType.TypeID
+	domainElts := b.QueryByID(typeID)
+
+	existingDefault := domainElts.FilterDomainDefault().NotToAbsent().MustGetZeroOrOneElement()
+	if existingDefault == nil {
+		return
+	}
+	b.Drop(existingDefault)
 }
 
 func alterDomainSetNotNull(
@@ -157,13 +193,14 @@ func alterDomainDropNotNull(
 	}
 	b.Drop(existingNotNull)
 
-	domainElts.FilterDomainConstraintName().Filter(
+	nameElem := domainElts.FilterDomainConstraintName().Filter(
 		func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.DomainConstraintName) bool {
 			return e.ConstraintID == existingNotNull.ConstraintID
 		},
-	).ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.DomainConstraintName) {
-		b.Drop(e)
-	})
+	).MustGetZeroOrOneElement()
+	if nameElem != nil {
+		b.Drop(nameElem)
+	}
 }
 
 // chooseDomainNotNullConstraintName generates a unique name for a domain NOT

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_domain
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_domain
@@ -63,6 +63,34 @@ CREATE SCHEMA s;
 ----
 
 build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d SET DEFAULT 42
+----
+- [[DomainDefault:{DescID: 104, Expr: 0}, ABSENT], PUBLIC]
+  {expr: "0", typeId: 104}
+- [[DomainDefault:{DescID: 104, Expr: 42:::INT8}, PUBLIC], ABSENT]
+  {expr: '42:::INT8', typeId: 104}
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d DROP DEFAULT
+----
+- [[DomainDefault:{DescID: 104, Expr: 0}, ABSENT], PUBLIC]
+  {expr: "0", typeId: 104}
+
+setup
+CREATE DOMAIN defaultdb.d_no_def AS INT;
+----
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d_no_def SET DEFAULT 99
+----
+- [[DomainDefault:{DescID: 109, Expr: 99:::INT8}, PUBLIC], ABSENT]
+  {expr: '99:::INT8', typeId: 109}
+
+build skip=sql_dependencies
+ALTER DOMAIN defaultdb.d_no_def DROP DEFAULT
+----
+
+build skip=sql_dependencies
 ALTER DOMAIN defaultdb.d SET SCHEMA s
 ----
 - [[Namespace:{DescID: 104, Name: d, ReferencedDescID: 100, IntValue: 101}, ABSENT], PUBLIC]

--- a/pkg/sql/schemachanger/scexec/scmutationexec/type.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/type.go
@@ -261,3 +261,33 @@ func (i *immediateVisitor) RemoveDomainConstraintName(
 		op.ConstraintID, op.TypeID,
 	)
 }
+
+func (i *immediateVisitor) SetDomainDefault(ctx context.Context, op scop.SetDomainDefault) error {
+	typ, err := i.checkOutType(ctx, op.TypeID)
+	if err != nil {
+		return err
+	}
+	if typ.Domain == nil {
+		return errors.AssertionFailedf(
+			"type descriptor %d is not a domain type", op.TypeID,
+		)
+	}
+	typ.Domain.DefaultExpr = string(op.Expr)
+	return nil
+}
+
+func (i *immediateVisitor) RemoveDomainDefault(
+	ctx context.Context, op scop.RemoveDomainDefault,
+) error {
+	typ, err := i.checkOutType(ctx, op.TypeID)
+	if err != nil {
+		return err
+	}
+	if typ.Domain == nil {
+		return errors.AssertionFailedf(
+			"type descriptor %d is not a domain type", op.TypeID,
+		)
+	}
+	typ.Domain.DefaultExpr = ""
+	return nil
+}

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1437,3 +1437,17 @@ type RemoveDomainConstraintName struct {
 	TypeID       descpb.ID
 	ConstraintID descpb.ConstraintID
 }
+
+// SetDomainDefault sets the default expression on a domain type descriptor.
+type SetDomainDefault struct {
+	immediateMutationOp
+	TypeID descpb.ID
+	Expr   catpb.Expression
+}
+
+// RemoveDomainDefault removes the default expression from a domain type
+// descriptor.
+type RemoveDomainDefault struct {
+	immediateMutationOp
+	TypeID descpb.ID
+}

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -201,6 +201,8 @@ type ImmediateMutationVisitor interface {
 	RemoveDomainNotNull(context.Context, RemoveDomainNotNull) error
 	SetDomainConstraintName(context.Context, SetDomainConstraintName) error
 	RemoveDomainConstraintName(context.Context, RemoveDomainConstraintName) error
+	SetDomainDefault(context.Context, SetDomainDefault) error
+	RemoveDomainDefault(context.Context, RemoveDomainDefault) error
 }
 
 // Visit is part of the ImmediateMutationOp interface.
@@ -1121,4 +1123,14 @@ func (op SetDomainConstraintName) Visit(ctx context.Context, v ImmediateMutation
 // Visit is part of the ImmediateMutationOp interface.
 func (op RemoveDomainConstraintName) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.RemoveDomainConstraintName(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op SetDomainDefault) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.SetDomainDefault(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op RemoveDomainDefault) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.RemoveDomainDefault(ctx, op)
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_domain_default.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_domain_default.go
@@ -15,28 +15,25 @@ func init() {
 		toPublic(
 			scpb.Status_ABSENT,
 			to(scpb.Status_WRITE_ONLY,
-				emit(func(this *scpb.DomainDefault) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.DomainDefault) *scop.SetDomainDefault {
+					return &scop.SetDomainDefault{
+						TypeID: this.TypeID,
+						Expr:   this.Expression.Expr,
+					}
 				}),
 			),
-			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.DomainDefault) *scop.NotImplemented {
-					return notImplemented(this)
-				}),
-			),
+			to(scpb.Status_PUBLIC),
 		),
 		toAbsent(
 			scpb.Status_PUBLIC,
 			to(scpb.Status_WRITE_ONLY,
-				emit(func(this *scpb.DomainDefault) *scop.NotImplementedForPublicObjects {
-					return notImplementedForPublicObjects(this)
+				emit(func(this *scpb.DomainDefault) *scop.RemoveDomainDefault {
+					return &scop.RemoveDomainDefault{
+						TypeID: this.TypeID,
+					}
 				}),
 			),
-			to(scpb.Status_ABSENT,
-				emit(func(this *scpb.DomainDefault) *scop.NotImplementedForPublicObjects {
-					return notImplementedForPublicObjects(this)
-				}),
-			),
+			to(scpb.Status_ABSENT),
 		),
 	)
 }

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -148,6 +148,13 @@ func TestEndToEndSideEffects_alter_database_configure_zone_multiple(t *testing.T
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -166,6 +173,13 @@ func TestEndToEndSideEffects_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1093,6 +1107,13 @@ func TestExecuteWithDMLInjection_alter_database_configure_zone_multiple(t *testi
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestExecuteWithDMLInjection_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestExecuteWithDMLInjection_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1111,6 +1132,13 @@ func TestExecuteWithDMLInjection_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2038,6 +2066,13 @@ func TestGenerateSchemaChangeCorpus_alter_database_configure_zone_multiple(t *te
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2056,6 +2091,13 @@ func TestGenerateSchemaChangeCorpus_alter_domain_rename_collision(t *testing.T) 
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2983,6 +3025,13 @@ func TestPause_alter_database_configure_zone_multiple(t *testing.T) {
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPause_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPause_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3001,6 +3050,13 @@ func TestPause_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3928,6 +3984,13 @@ func TestPauseMixedVersion_alter_database_configure_zone_multiple(t *testing.T) 
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3946,6 +4009,13 @@ func TestPauseMixedVersion_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -4873,6 +4943,13 @@ func TestRollback_alter_database_configure_zone_multiple(t *testing.T) {
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestRollback_alter_domain_drop_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestRollback_alter_domain_drop_not_null(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -4891,6 +4968,13 @@ func TestRollback_alter_domain_rename_collision(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_rename_collision"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_domain_set_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TABLE t (c salmon);
+----
+
+test
+ALTER DOMAIN salmon DROP DEFAULT;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.explain
@@ -1,0 +1,34 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TABLE t (c salmon);
+
+/* test */
+EXPLAIN (DDL) ALTER DOMAIN salmon DROP DEFAULT;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› DROP DEFAULT;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → WRITE_ONLY DomainDefault:{DescID: 104 (salmon), Expr: 0}
+ │         └── 1 Mutation operation
+ │              └── RemoveDomainDefault {"TypeID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── WRITE_ONLY → PUBLIC DomainDefault:{DescID: 104 (salmon), Expr: 0}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → WRITE_ONLY DomainDefault:{DescID: 104 (salmon), Expr: 0}
+ │         └── 3 Mutation operations
+ │              ├── RemoveDomainDefault {"TypeID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: PostCom..."}
+ └── PostCommitPhase
+      └── Stage 1 of 1 in PostCommitPhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── WRITE_ONLY → ABSENT DomainDefault:{DescID: 104 (salmon), Expr: 0}
+           └── 2 Mutation operations
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TABLE t (c salmon);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER DOMAIN salmon DROP DEFAULT;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› DROP DEFAULT;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_drop_default/alter_domain_drop_default.side_effects
@@ -1,0 +1,113 @@
+/* setup */
+CREATE DOMAIN salmon AS INT DEFAULT 0;
+CREATE TABLE t (c salmon);
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
++object {100 101 t} -> 106
+
+/* test */
+ALTER DOMAIN salmon DROP DEFAULT;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER DOMAIN
+increment telemetry for sql.schema.alter_domain.drop_default
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  -    defaultExpr: "0"
+       nextConstraintId: 1
+     id: 104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 104
+  +      name: salmon
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› DROP DEFAULT
+  +        statement: ALTER DOMAIN salmon DROP DEFAULT
+  +        statementTag: ALTER DOMAIN
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     domain:
+       baseType:
+  ...
+         oid: 20
+         width: 64
+  -    defaultExpr: "0"
+       nextConstraintId: 1
+     id: 104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER DOMAIN defaultdb.public.salmon DROP DEFAULT"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      id: 104
+  -      name: salmon
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› DROP DEFAULT
+  -        statement: ALTER DOMAIN salmon DROP DEFAULT
+  -        statementTag: ALTER DOMAIN
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     domain:
+       baseType:
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #3
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DOMAIN salmon AS INT;
+CREATE TABLE t (c salmon);
+----
+
+test
+ALTER DOMAIN salmon SET DEFAULT 42;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.explain
@@ -1,0 +1,34 @@
+/* setup */
+CREATE DOMAIN salmon AS INT;
+CREATE TABLE t (c salmon);
+
+/* test */
+EXPLAIN (DDL) ALTER DOMAIN salmon SET DEFAULT 42;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET DEFAULT ‹42›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY DomainDefault:{DescID: 104 (salmon), Expr: 42:::INT8}
+ │         └── 1 Mutation operation
+ │              └── SetDomainDefault {"Expr":"42:::INT8","TypeID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → ABSENT DomainDefault:{DescID: 104 (salmon), Expr: 42:::INT8}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY DomainDefault:{DescID: 104 (salmon), Expr: 42:::INT8}
+ │         └── 3 Mutation operations
+ │              ├── SetDomainDefault {"Expr":"42:::INT8","TypeID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"Pending: PostCom..."}
+ └── PostCommitPhase
+      └── Stage 1 of 1 in PostCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── WRITE_ONLY → PUBLIC DomainDefault:{DescID: 104 (salmon), Expr: 42:::INT8}
+           └── 2 Mutation operations
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DOMAIN salmon AS INT;
+CREATE TABLE t (c salmon);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER DOMAIN salmon SET DEFAULT 42;
+----
+Schema change plan for ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET DEFAULT ‹42›;
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_domain_set_default/alter_domain_set_default.side_effects
@@ -1,0 +1,113 @@
+/* setup */
+CREATE DOMAIN salmon AS INT;
+CREATE TABLE t (c salmon);
+----
+...
++object {100 101 salmon} -> 104
++object {100 101 _salmon} -> 105
++object {100 101 t} -> 106
+
+/* test */
+ALTER DOMAIN salmon SET DEFAULT 42;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER DOMAIN
+increment telemetry for sql.schema.alter_domain.set_default
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  +    defaultExpr: 42:::INT8
+       nextConstraintId: 1
+     id: 104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      id: 104
+  +      name: salmon
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET DEFAULT ‹42›
+  +        statement: ALTER DOMAIN salmon SET DEFAULT 42
+  +        statementTag: ALTER DOMAIN
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     domain:
+       baseType:
+  ...
+         oid: 20
+         width: 64
+  +    defaultExpr: 42:::INT8
+       nextConstraintId: 1
+     id: 104
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER DOMAIN defaultdb.public.salmon SET DEFAULT 42"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+   type:
+     arrayTypeId: 105
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      id: 104
+  -      name: salmon
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER DOMAIN ‹defaultdb›.‹public›.‹salmon› SET DEFAULT ‹42›
+  -        statement: ALTER DOMAIN salmon SET DEFAULT 42
+  -        statementTag: ALTER DOMAIN
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     domain:
+       baseType:
+  ...
+     referencingDescriptorIds:
+     - 106
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #3
+# end PostCommitPhase


### PR DESCRIPTION
This change implements the `ALTER DOMAIN ... [SET
| DROP] DEFAULT` statements which were previously
unsupported. The legacy schemachanger did not
support domain types so logic tests are added to
cover the feature.

Closes: #166935
Epic: CRDB-62146

Release note (sql change): The `ALTER DOMAIN ... [SET
| DROP] DEFAULT` statements are supported.
