### PR TITLE
schemachanger: error on `ALTER TYPE ... SET SCHEMA` to same schema

### DIFF
--- a/pkg/sql/alter_type.go
+++ b/pkg/sql/alter_type.go
@@ -362,10 +362,9 @@ func (p *planner) setTypeSchema(ctx context.Context, n *alterTypeNode, schema st
 		return err
 	}
 
-	// If the schema being changed to is the same as the current schema for the
-	// type, do a no-op.
 	if desiredSchemaID == schemaID {
-		return nil
+		return pgerror.Newf(pgcode.DuplicateObject,
+			"type %q is already in schema %q", typeDesc.GetName(), schema)
 	}
 
 	arrayDesc, err := p.Descriptors().MutableByID(p.txn).Type(ctx, n.desc.ArrayTypeID)

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -952,8 +952,7 @@ SELECT ARRAY['a']::s1._sc_type
 ----
 {a}
 
-# Setting the same schema should be a no-op.
-statement ok
+statement error pgcode 42710 type "sc_type" is already in schema "s1"
 ALTER TYPE s1.sc_type SET SCHEMA s1
 
 # Move from s1 to s2.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_type.go
@@ -286,7 +286,8 @@ func alterTypeSetSchema(
 	newSchemaID := newSchema.SchemaID
 
 	if currSchemaID == newSchemaID {
-		return
+		panic(pgerror.Newf(pgcode.DuplicateObject,
+			"type %q is already in schema %q", currNamespace.Name, t.Schema))
 	}
 
 	currName := tree.MakeTableNameFromPrefix(b.NamePrefix(enumType), tree.Name(currNamespace.Name))

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_type
@@ -34,10 +34,6 @@ ALTER TYPE defaultdb.climes RENAME TO environs
 - [[Namespace:{DescID: 105, Name: _environs, ReferencedDescID: 100, IntValue: 101}, PUBLIC], ABSENT]
   {databaseId: 100, descriptorId: 105, name: _environs, schemaId: 101}
 
-build
-ALTER TYPE defaultdb.climes SET SCHEMA public
-----
-
 setup
 CREATE SCHEMA s;
 ----


### PR DESCRIPTION
The previous no-op behavior was inconsistent with
PG. This change emits an error.

Part of: #166943
Epic: CRDB-62146

Release note (sql change): An `ALTER TYPE ... SET
SCHEMA` statement to move a type to its current
schema now emits an error.
