### PR TITLE
release-26.1: release: route build/publish notify to #release-ops by ID-vs-name

### DIFF
--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -850,7 +850,7 @@ jobs:
           SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
           SLACK_PAYLOAD: >-
             {
-              "channel": "C08H9FA1W3C",
+              "channel": "#release-ops",
               "text": "${{ steps.status.outputs.emoji }} Release build *${{ steps.status.outputs.result }}* for `${{ github.ref_name }}` (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
               "attachments": [
                 {

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -545,7 +545,7 @@ jobs:
           SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
           SLACK_PAYLOAD: >-
             {
-              "channel": "C08H9FA1W3C",
+              "channel": "#release-ops",
               "text": "${{ steps.status.outputs.emoji }} Release publish *${{ steps.status.outputs.result }}* for `${{ github.ref_name }}` (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
               "attachments": [
                 {


### PR DESCRIPTION
Backport 1/1 commits from #170778 on behalf of @rail.

----

The 'Slack notification' steps in release-build-and-sign.yml and release-publish.yml advertise themselves as 'Post to #release-ops' in their step names, but the hardcoded channel ID C08H9FA1W3C actually resolves to #db-release-test — so the notifications were landing in the wrong channel. Replace the ID with the literal '#release-ops' channel name, matching the convention the other release workflows (release-pick-sha.yml, release-branch-cut.yml) already use.

Epic: none
Release note: None

----

Release justification: release automation changes