### PR TITLE
kvserver: deflake TestStoreMetrics replica removal

### DIFF
--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -327,7 +327,10 @@ func TestStoreMetrics(t *testing.T) {
 	verifyStatsOnServers(t, tc, specs, stickyVFSRegistry, 1, 2)
 	checkGauge(t, "store 0", tc.GetFirstStoreFromServer(t, 0).Metrics().ReplicaCount, initialCount+1)
 	tc.RemoveLeaseHolderOrFatal(t, desc, tc.Target(0), tc.Target(1))
+	// The removed replica may never learn about its own removal through raft,
+	// so force the replica GC queue to clean it up.
 	testutils.SucceedsSoon(t, func() error {
+		tc.GetFirstStoreFromServer(t, 0).MustForceReplicaGCScanAndProcess()
 		_, err := tc.GetFirstStoreFromServer(t, 0).GetReplica(desc.RangeID)
 		if err == nil {
 			return fmt.Errorf("replica still exists on dest 0")


### PR DESCRIPTION
Force the replica GC queue to scan and process replicas after removing the voter from store 0.

The removed replica may never receive the raft entry for its own removal (the leader can apply the conf change before the removed learner receives the corresponding `MsgApp`), leaving the replica GC queue scanner as the only cleanup mechanism. The default 10-minute scanner interval far exceeds the 45s `SucceedsSoon` timeout.

Fixes #170677