### PR TITLE
sql: apply SECURITY DEFINER to DDL inside stored procedures

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -204,7 +204,7 @@ func (p *planner) HasAnyPrivilege(
 		return false, errors.AssertionFailedf("cannot use CheckAnyPrivilege without a txn")
 	}
 
-	user := p.SessionData().User()
+	user := p.User()
 	if user.IsNodeUser() {
 		// User "node" has all privileges.
 		return true, nil
@@ -422,7 +422,7 @@ func isOwner(
 func (p *planner) HasOwnership(
 	ctx context.Context, privilegeObject privilege.Object,
 ) (bool, error) {
-	return p.UserHasOwnership(ctx, privilegeObject, p.SessionData().User())
+	return p.UserHasOwnership(ctx, privilegeObject, p.User())
 }
 
 // UserHasOwnership implements the AuthorizationAccessor interface.
@@ -468,7 +468,7 @@ func (p *planner) checkRolePredicate(
 // CheckAnyPrivilege implements the AuthorizationAccessor interface.
 // Requires a valid transaction to be open.
 func (p *planner) CheckAnyPrivilege(ctx context.Context, privilegeObject privilege.Object) error {
-	user := p.SessionData().User()
+	user := p.User()
 	ok, err := p.HasAnyPrivilege(ctx, privilegeObject)
 	if err != nil {
 		return err

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -55,7 +55,9 @@ func (p *planner) createUserDefinedSchemaDescriptor(
 	if err != nil {
 		return nil, nil, err
 	}
-	user := sessionData.User()
+	// Use p.User() so SECURITY DEFINER procedures record the definer as the
+	// schema owner, matching PostgreSQL.
+	user := p.User()
 	var schemaName string
 	if !n.Schema.ExplicitSchema {
 		schemaName = authRole.Normalized()

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -377,7 +377,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		n.dbDesc.GetDefaultPrivilegeDescriptor(),
 		schema.GetDefaultPrivilegeDescriptor(),
 		n.dbDesc.GetID(),
-		params.SessionData().User(),
+		params.p.User(),
 		privilege.Tables,
 	)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/procedure_ddl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_ddl
@@ -3322,30 +3322,22 @@ subtest security_definer_with_commit_rollback
 
 # Verify the DEFINER push survives across PL/pgSQL COMMIT/ROLLBACK inside
 # the procedure body. COMMIT/ROLLBACK end the current transaction and
-# start a new one, but the routine generator keeps executing the body —
-# so the effective-user push must persist across the boundary.
-#
-# Skipped under the legacy schema changer: post-COMMIT DDL inside a
-# procedure body re-evaluates privileges against the invoker rather than
-# the definer in that path. Tracking the divergence as a follow-up rather
-# than expanding this PR's scope to the legacy planNode resumption path.
-skipif config local-legacy-schema-changer
+# start a new one; the routine resumes via a cached resumeProc memo that
+# bypasses the optbuilder's PushEffectiveUser, so the continuation's own
+# UDFDefinition must carry SecurityMode/RoutineOwner for the runtime push
+# in routineGenerator.Start to fire on resume.
 statement ok
 CREATE ROLE r_def_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 GRANT CREATE ON DATABASE test TO r_def_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 CREATE ROLE r_inv_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 SET ROLE r_def_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 CREATE PROCEDURE p_sd_txn() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
 BEGIN
@@ -3357,20 +3349,16 @@ BEGIN
 END
 $$;
 
-skipif config local-legacy-schema-changer
 statement ok
 GRANT EXECUTE ON PROCEDURE p_sd_txn TO r_inv_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 SET ROLE r_inv_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 CALL p_sd_txn();
 
 # All three schemas record the definer despite the intermediate COMMITs.
-skipif config local-legacy-schema-changer
 query TT rowsort
 SELECT schema_name, owner FROM [SHOW SCHEMAS]
 WHERE schema_name IN ('s_txn_a', 's_txn_b', 's_txn_c');
@@ -3379,33 +3367,26 @@ s_txn_a  r_def_txn
 s_txn_b  r_def_txn
 s_txn_c  r_def_txn
 
-skipif config local-legacy-schema-changer
 statement ok
 SET ROLE root;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP SCHEMA s_txn_a;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP SCHEMA s_txn_b;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP SCHEMA s_txn_c;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP PROCEDURE p_sd_txn;
 
 # ROLLBACK variant: the first CREATE SCHEMA is rolled back; only the
 # post-ROLLBACK schema persists, owned by the definer.
-skipif config local-legacy-schema-changer
 statement ok
 SET ROLE r_def_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 CREATE PROCEDURE p_sd_txn_rb() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
 BEGIN
@@ -3415,42 +3396,33 @@ BEGIN
 END
 $$;
 
-skipif config local-legacy-schema-changer
 statement ok
 GRANT EXECUTE ON PROCEDURE p_sd_txn_rb TO r_inv_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 SET ROLE r_inv_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 CALL p_sd_txn_rb();
 
-skipif config local-legacy-schema-changer
 query TT rowsort
 SELECT schema_name, owner FROM [SHOW SCHEMAS]
 WHERE schema_name IN ('s_txn_rb_a', 's_txn_rb_b');
 ----
 s_txn_rb_b  r_def_txn
 
-skipif config local-legacy-schema-changer
 statement ok
 SET ROLE root;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP SCHEMA s_txn_rb_b;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP PROCEDURE p_sd_txn_rb;
 
-skipif config local-legacy-schema-changer
 statement ok
 REVOKE CREATE ON DATABASE test FROM r_def_txn;
 
-skipif config local-legacy-schema-changer
 statement ok
 DROP ROLE r_def_txn, r_inv_txn;
 

--- a/pkg/sql/logictest/testdata/logic_test/procedure_ddl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_ddl
@@ -2306,3 +2306,1152 @@ statement ok
 DROP TABLE t_ser_seed;
 
 subtest end
+
+
+# The subtests below cover SECURITY DEFINER applied to DDL inside stored
+# procedure bodies. Privilege checks, ownership assignments, and the
+# current_user builtin all resolve to the routine owner for the duration of
+# the body, matching PostgreSQL.
+
+subtest security_definer_create_schema
+
+statement ok
+CREATE ROLE r_def_schema;
+GRANT CREATE ON DATABASE test TO r_def_schema;
+
+statement ok
+CREATE ROLE r_inv_schema;
+
+statement ok
+SET ROLE r_def_schema;
+
+statement ok
+CREATE PROCEDURE p_sd_schema() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE SCHEMA s_sd;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_schema TO r_inv_schema;
+
+statement ok
+SET ROLE r_inv_schema;
+
+statement ok
+CALL p_sd_schema();
+
+# Owner is the definer even though the invoker issued the CALL.
+query TT
+SELECT schema_name, owner FROM [SHOW SCHEMAS] WHERE schema_name = 's_sd';
+----
+s_sd  r_def_schema
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP SCHEMA s_sd;
+
+statement ok
+DROP PROCEDURE p_sd_schema;
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_def_schema;
+
+statement ok
+DROP ROLE r_def_schema, r_inv_schema;
+
+subtest end
+
+
+subtest security_definer_create_role
+
+statement ok
+CREATE ROLE r_def_role WITH CREATEROLE;
+
+statement ok
+CREATE ROLE r_inv_role;
+
+statement ok
+SET ROLE r_def_role;
+
+statement ok
+CREATE PROCEDURE p_sd_role() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE ROLE r_sd_created;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_role TO r_inv_role;
+
+statement ok
+SET ROLE r_inv_role;
+
+# CREATEROLE is evaluated against the definer; the invoker (without
+# CREATEROLE) can still call the procedure.
+statement ok
+CALL p_sd_role();
+
+query T
+SELECT rolname FROM pg_roles WHERE rolname = 'r_sd_created';
+----
+r_sd_created
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP ROLE r_sd_created;
+
+statement ok
+DROP PROCEDURE p_sd_role;
+
+statement ok
+DROP ROLE r_def_role, r_inv_role;
+
+subtest end
+
+
+subtest security_definer_create_table
+
+# CREATE TABLE goes through a different code path than CREATE SCHEMA, so
+# cover the table-owner side of the same bug. The invoker lacks CREATE on
+# the schema and would fail without the definer override.
+statement ok
+CREATE ROLE r_def_tbl;
+GRANT ALL ON SCHEMA public TO r_def_tbl;
+
+statement ok
+CREATE ROLE r_inv_tbl;
+
+statement ok
+SET ROLE r_def_tbl;
+
+statement ok
+CREATE PROCEDURE p_sd_table() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE TABLE t_sd (a INT);
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_table TO r_inv_tbl;
+
+statement ok
+SET ROLE r_inv_tbl;
+
+statement ok
+CALL p_sd_table();
+
+query TTT colnames
+SELECT schema_name, table_name, owner FROM [SHOW TABLES FROM public] WHERE table_name = 't_sd';
+----
+schema_name  table_name  owner
+public       t_sd        r_def_tbl
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE t_sd;
+
+statement ok
+DROP PROCEDURE p_sd_table;
+
+statement ok
+REVOKE ALL ON SCHEMA public FROM r_def_tbl;
+
+statement ok
+DROP ROLE r_def_tbl, r_inv_tbl;
+
+subtest end
+
+
+subtest security_definer_drop
+
+# DROP SCHEMA, DROP ROLE, and DROP TABLE all evaluate authorization
+# against the effective user. Set up objects owned by a "manager" role,
+# wrap the drops in a SECURITY DEFINER procedure owned by the manager,
+# and call it as an unprivileged invoker.
+statement ok
+CREATE ROLE r_mgr WITH CREATEROLE;
+GRANT CREATE ON DATABASE test TO r_mgr;
+
+statement ok
+CREATE ROLE r_caller;
+
+statement ok
+SET ROLE r_mgr;
+
+statement ok
+CREATE SCHEMA s_drop;
+CREATE TABLE s_drop.t_drop (a INT);
+CREATE ROLE r_drop;
+
+statement ok
+CREATE PROCEDURE p_sd_drop() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  -- CASCADE is required because the DROP SCHEMA non-empty check happens
+  -- at compile time, before the DROP TABLE in the same body runs (see
+  -- the drop_schema_cascade_restrict_in_procedure subtest).
+  DROP SCHEMA s_drop CASCADE;
+  DROP ROLE r_drop;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_drop TO r_caller;
+
+statement ok
+SET ROLE r_caller;
+
+# The invoker has no privileges to drop the schema or role directly; only
+# the SECURITY DEFINER procedure can perform these on its behalf.
+statement error pgcode 42501 must be owner of schema
+DROP SCHEMA s_drop CASCADE;
+
+statement error pgcode 42501 does not have CREATEROLE privilege
+DROP ROLE r_drop;
+
+statement ok
+CALL p_sd_drop();
+
+query T
+SELECT schema_name FROM [SHOW SCHEMAS] WHERE schema_name = 's_drop';
+----
+
+query T
+SELECT rolname FROM pg_roles WHERE rolname = 'r_drop';
+----
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_sd_drop;
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_mgr;
+
+statement ok
+DROP ROLE r_mgr, r_caller;
+
+subtest end
+
+
+subtest security_definer_current_user
+
+# A SECURITY DEFINER body sees current_user = definer, matching PostgreSQL
+# (`CREATE PROCEDURE ... LANGUAGE plpgsql SECURITY DEFINER`). The companion
+# SECURITY INVOKER procedure is the regression baseline: same body, same
+# call, but current_user reports the invoker. session_user is unaffected
+# by SET ROLE in both cases (it tracks the authenticated connection).
+statement ok
+CREATE ROLE r_def_cu;
+
+statement ok
+CREATE ROLE r_inv_cu;
+
+statement ok
+SET ROLE r_def_cu;
+
+statement ok
+CREATE PROCEDURE p_sd_cu(OUT cu STRING, OUT su STRING) LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  cu := current_user;
+  su := session_user;
+END
+$$;
+
+statement ok
+CREATE PROCEDURE p_si_cu(OUT cu STRING, OUT su STRING) LANGUAGE PLpgSQL SECURITY INVOKER AS $$
+BEGIN
+  cu := current_user;
+  su := session_user;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_cu, p_si_cu TO r_inv_cu;
+
+statement ok
+SET ROLE r_inv_cu;
+
+query TT colnames
+CALL p_sd_cu(NULL, NULL);
+----
+cu        su
+r_def_cu  root
+
+query TT colnames
+CALL p_si_cu(NULL, NULL);
+----
+cu        su
+r_inv_cu  root
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_sd_cu;
+
+statement ok
+DROP PROCEDURE p_si_cu;
+
+statement ok
+DROP ROLE r_def_cu, r_inv_cu;
+
+subtest end
+
+
+subtest security_definer_nested_stack
+
+# Stacking: an outer DEFINER procedure that calls an inner DEFINER
+# procedure sees the inner owner for the inner body, then sees the outer
+# owner again afterwards.
+statement ok
+CREATE ROLE r_outer_def;
+
+statement ok
+CREATE ROLE r_inner_def;
+
+statement ok
+CREATE ROLE r_invoker_nested;
+
+statement ok
+SET ROLE r_inner_def;
+
+statement ok
+CREATE PROCEDURE p_inner_def(OUT u STRING) LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  u := current_user;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_inner_def TO PUBLIC;
+
+statement ok
+SET ROLE r_outer_def;
+
+statement ok
+CREATE PROCEDURE p_outer_def(OUT before_inner STRING, OUT inner_u STRING, OUT after_inner STRING)
+LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  before_inner := current_user;
+  CALL p_inner_def(inner_u);
+  after_inner := current_user;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_outer_def TO r_invoker_nested;
+
+statement ok
+SET ROLE r_invoker_nested;
+
+query TTT colnames
+CALL p_outer_def(NULL, NULL, NULL);
+----
+before_inner  inner_u      after_inner
+r_outer_def   r_inner_def  r_outer_def
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_outer_def;
+
+statement ok
+DROP PROCEDURE p_inner_def;
+
+statement ok
+DROP ROLE r_outer_def, r_inner_def, r_invoker_nested;
+
+subtest end
+
+
+subtest security_invoker_calls_definer
+
+# An INVOKER outer procedure calls a DEFINER inner procedure. The outer
+# body sees the invoker as current_user (no push); the inner body sees
+# the inner definer (single push); after the inner returns, the outer
+# body sees the invoker again (pop). Exercises push/pop on top of an
+# unmodified base stack.
+statement ok
+CREATE ROLE r_inner_idi;
+
+statement ok
+CREATE ROLE r_invoker_idi;
+
+statement ok
+SET ROLE r_inner_idi;
+
+statement ok
+CREATE PROCEDURE p_inner_idi(OUT u STRING) LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  u := current_user;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_inner_idi TO PUBLIC;
+
+statement ok
+SET ROLE r_invoker_idi;
+
+statement ok
+CREATE PROCEDURE p_outer_idi(OUT before_inner STRING, OUT inner_u STRING, OUT after_inner STRING)
+LANGUAGE PLpgSQL AS $$
+BEGIN
+  before_inner := current_user;
+  CALL p_inner_idi(inner_u);
+  after_inner := current_user;
+END
+$$;
+
+query TTT colnames
+CALL p_outer_idi(NULL, NULL, NULL);
+----
+before_inner   inner_u      after_inner
+r_invoker_idi  r_inner_idi  r_invoker_idi
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_outer_idi;
+
+statement ok
+DROP PROCEDURE p_inner_idi;
+
+statement ok
+DROP ROLE r_inner_idi, r_invoker_idi;
+
+subtest end
+
+
+subtest security_definer_outer_invokes_inner
+
+# A DEFINER outer procedure calls an INVOKER inner procedure. The inner
+# has no push of its own and must inherit the outer's effective user; the
+# outer body sees the outer definer before, during, and after the inner
+# call.
+statement ok
+CREATE ROLE r_def_dii;
+
+statement ok
+CREATE ROLE r_invoker_dii;
+
+statement ok
+CREATE PROCEDURE p_inner_dii(OUT u STRING) LANGUAGE PLpgSQL AS $$
+BEGIN
+  u := current_user;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_inner_dii TO PUBLIC;
+
+statement ok
+SET ROLE r_def_dii;
+
+statement ok
+CREATE PROCEDURE p_outer_dii(OUT before_inner STRING, OUT inner_u STRING, OUT after_inner STRING)
+LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  before_inner := current_user;
+  CALL p_inner_dii(inner_u);
+  after_inner := current_user;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_outer_dii TO r_invoker_dii;
+
+statement ok
+SET ROLE r_invoker_dii;
+
+query TTT colnames
+CALL p_outer_dii(NULL, NULL, NULL);
+----
+before_inner  inner_u    after_inner
+r_def_dii     r_def_dii  r_def_dii
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_outer_dii;
+
+statement ok
+DROP PROCEDURE p_inner_dii;
+
+statement ok
+DROP ROLE r_def_dii, r_invoker_dii;
+
+subtest end
+
+
+subtest security_invoker_unchanged
+
+# Regression guard: SECURITY INVOKER (the default) must still evaluate
+# privilege checks against the invoker, even now that DEFINER works.
+statement ok
+CREATE ROLE r_def_inv WITH CREATEROLE;
+
+statement ok
+CREATE ROLE r_inv_inv;
+
+statement ok
+SET ROLE r_def_inv;
+
+statement ok
+CREATE PROCEDURE p_si_role() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE ROLE r_si_created;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_si_role TO r_inv_inv;
+
+statement ok
+SET ROLE r_inv_inv;
+
+statement error pgcode 42501 user r_inv_inv does not have CREATEROLE privilege
+CALL p_si_role();
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_si_role;
+
+statement ok
+DROP ROLE r_def_inv, r_inv_inv;
+
+subtest end
+
+
+subtest security_definer_exception_restores
+
+# After a SECURITY DEFINER routine returns (including via an exception
+# block that catches an error in the body), the invoker's effective user
+# is restored.
+statement ok
+CREATE ROLE r_def_exc;
+
+statement ok
+CREATE ROLE r_inv_exc;
+
+statement ok
+SET ROLE r_def_exc;
+
+statement ok
+CREATE PROCEDURE p_sd_exc(OUT u_inside STRING) LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  BEGIN
+    u_inside := current_user;
+    RAISE EXCEPTION 'boom';
+  EXCEPTION WHEN raise_exception THEN
+    -- swallow
+  END;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_exc TO r_inv_exc;
+
+statement ok
+SET ROLE r_inv_exc;
+
+query T colnames
+CALL p_sd_exc(NULL);
+----
+u_inside
+r_def_exc
+
+# After the call returns, current_user is back to the invoker.
+query T
+SELECT current_user;
+----
+r_inv_exc
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_sd_exc;
+
+statement ok
+DROP ROLE r_def_exc, r_inv_exc;
+
+subtest end
+
+
+subtest security_definer_nested_definer_tail_call
+
+# An outer SECURITY DEFINER procedure whose final body statement is a CALL
+# to an inner SECURITY DEFINER procedure that performs DDL. The inner CALL
+# is in tail-call position. The inner owner has the privilege required by
+# the DDL; the outer owner and invoker do not. The schema must be created
+# and owned by the inner owner.
+statement ok
+CREATE ROLE r_outer_tc;
+GRANT CREATE ON DATABASE test TO r_outer_tc;
+
+statement ok
+CREATE ROLE r_inner_tc;
+GRANT CREATE ON DATABASE test TO r_inner_tc;
+
+statement ok
+CREATE ROLE r_invoker_tc;
+
+statement ok
+SET ROLE r_inner_tc;
+
+statement ok
+CREATE PROCEDURE p_inner_tc_ddl() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE SCHEMA s_tc;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_inner_tc_ddl TO PUBLIC;
+
+statement ok
+SET ROLE r_outer_tc;
+
+statement ok
+CREATE PROCEDURE p_outer_tc() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CALL p_inner_tc_ddl();
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_outer_tc TO r_invoker_tc;
+
+statement ok
+SET ROLE r_invoker_tc;
+
+statement ok
+CALL p_outer_tc();
+
+# Owner is the inner DEFINER, not the outer DEFINER and not the invoker.
+query TT
+SELECT schema_name, owner FROM [SHOW SCHEMAS] WHERE schema_name = 's_tc';
+----
+s_tc  r_inner_tc
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP SCHEMA s_tc;
+
+statement ok
+DROP PROCEDURE p_outer_tc;
+
+statement ok
+DROP PROCEDURE p_inner_tc_ddl;
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_outer_tc, r_inner_tc;
+
+statement ok
+DROP ROLE r_outer_tc, r_inner_tc, r_invoker_tc;
+
+subtest end
+
+
+subtest security_definer_sql_language
+
+# LANGUAGE SQL procedure body: the definer override must apply
+# regardless of routine language. Verify ownership lands on the definer.
+statement ok
+CREATE ROLE r_def_sql;
+GRANT CREATE ON DATABASE test TO r_def_sql;
+
+statement ok
+CREATE ROLE r_inv_sql;
+GRANT CREATE ON DATABASE test TO r_inv_sql;
+
+statement ok
+SET ROLE r_def_sql;
+
+statement ok
+CREATE PROCEDURE p_sd_sql() LANGUAGE SQL SECURITY DEFINER AS $$
+  CREATE SCHEMA s_sd_sql;
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_sql TO r_inv_sql;
+
+statement ok
+SET ROLE r_inv_sql;
+
+statement ok
+CALL p_sd_sql();
+
+query TT
+SELECT schema_name, owner FROM [SHOW SCHEMAS] WHERE schema_name = 's_sd_sql';
+----
+s_sd_sql  r_def_sql
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP SCHEMA s_sd_sql;
+
+statement ok
+DROP PROCEDURE p_sd_sql;
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_def_sql, r_inv_sql;
+
+statement ok
+DROP ROLE r_def_sql, r_inv_sql;
+
+subtest end
+
+
+subtest security_definer_multi_statement_body
+
+# Multiple independent DDL statements in one SECURITY DEFINER body.
+# Confirms the effective-user override stays in effect across all body
+# statements rather than leaking after the first. Targets are deliberately
+# non-dependent to avoid the early-binding limitation covered by
+# drop_schema_cascade_restrict_in_procedure.
+statement ok
+CREATE ROLE r_def_multi WITH CREATEROLE;
+GRANT CREATE ON DATABASE test TO r_def_multi;
+
+statement ok
+CREATE ROLE r_inv_multi;
+
+statement ok
+SET ROLE r_def_multi;
+
+statement ok
+CREATE PROCEDURE p_sd_multi() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE SCHEMA s_multi_a;
+  CREATE SCHEMA s_multi_b;
+  CREATE ROLE r_multi_created;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_multi TO r_inv_multi;
+
+statement ok
+SET ROLE r_inv_multi;
+
+statement ok
+CALL p_sd_multi();
+
+# All three objects record the definer, not the invoker.
+query TT rowsort
+SELECT schema_name, owner FROM [SHOW SCHEMAS]
+WHERE schema_name IN ('s_multi_a', 's_multi_b');
+----
+s_multi_a  r_def_multi
+s_multi_b  r_def_multi
+
+query T
+SELECT rolname FROM pg_roles WHERE rolname = 'r_multi_created';
+----
+r_multi_created
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP SCHEMA s_multi_a;
+
+statement ok
+DROP SCHEMA s_multi_b;
+
+statement ok
+DROP ROLE r_multi_created;
+
+statement ok
+DROP PROCEDURE p_sd_multi;
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_def_multi;
+
+statement ok
+DROP ROLE r_def_multi, r_inv_multi;
+
+subtest end
+
+
+subtest security_definer_unhandled_error_restores
+
+# Companion to security_definer_exception_restores: an uncaught
+# exception must still pop the definer push.
+statement ok
+CREATE ROLE r_def_unh;
+
+statement ok
+CREATE ROLE r_inv_unh;
+
+statement ok
+SET ROLE r_def_unh;
+
+statement ok
+CREATE PROCEDURE p_sd_unh() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  RAISE EXCEPTION 'boom';
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_unh TO r_inv_unh;
+
+statement ok
+SET ROLE r_inv_unh;
+
+statement error pgcode P0001 pq: boom
+CALL p_sd_unh();
+
+# Effective user is back to the invoker after the failed CALL.
+query T
+SELECT current_user;
+----
+r_inv_unh
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_sd_unh;
+
+statement ok
+DROP ROLE r_def_unh, r_inv_unh;
+
+subtest end
+
+
+subtest security_definer_has_schema_privilege
+
+# has_*_privilege builtins without a user argument resolve against
+# current_user, so inside a DEFINER body they reflect the definer.
+statement ok
+CREATE ROLE r_def_priv;
+GRANT CREATE ON DATABASE test TO r_def_priv;
+
+statement ok
+CREATE ROLE r_inv_priv;
+
+statement ok
+SET ROLE r_def_priv;
+
+statement ok
+CREATE SCHEMA s_priv;
+
+statement ok
+CREATE PROCEDURE p_sd_priv(OUT has_usage BOOL) LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  has_usage := has_schema_privilege('s_priv', 'USAGE');
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_priv TO r_inv_priv;
+
+statement ok
+SET ROLE r_inv_priv;
+
+# Invoker has no access; definer (schema owner) does.
+query B
+SELECT has_schema_privilege('s_priv', 'USAGE');
+----
+false
+
+query B
+CALL p_sd_priv(NULL);
+----
+true
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP SCHEMA s_priv;
+
+statement ok
+DROP PROCEDURE p_sd_priv;
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_def_priv;
+
+statement ok
+DROP ROLE r_def_priv, r_inv_priv;
+
+subtest end
+
+
+subtest security_definer_has_function_privilege
+
+# Companion to security_definer_has_schema_privilege covering the
+# user-defined-function branch of has_function_privilege, which was a
+# pre-existing outlier reaching for SessionData().User() directly.
+statement ok
+CREATE ROLE r_def_fpriv;
+GRANT CREATE ON DATABASE test TO r_def_fpriv;
+
+statement ok
+CREATE ROLE r_inv_fpriv;
+
+statement ok
+SET ROLE r_def_fpriv;
+
+statement ok
+CREATE FUNCTION f_fpriv(n INT) RETURNS INT LANGUAGE SQL AS $$ SELECT n + 1 $$;
+
+# EXECUTE is granted to PUBLIC by default; revoke so the invoker truly
+# has no path to the function.
+statement ok
+REVOKE EXECUTE ON FUNCTION f_fpriv(INT) FROM PUBLIC;
+
+statement ok
+CREATE PROCEDURE p_sd_fpriv(OUT has_exec BOOL) LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  has_exec := has_function_privilege('f_fpriv(INT)', 'EXECUTE');
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_fpriv TO r_inv_fpriv;
+
+statement ok
+SET ROLE r_inv_fpriv;
+
+# Invoker has no EXECUTE; definer (function owner) does.
+query B
+SELECT has_function_privilege('f_fpriv(INT)', 'EXECUTE');
+----
+false
+
+query B
+CALL p_sd_fpriv(NULL);
+----
+true
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_sd_fpriv;
+
+statement ok
+DROP FUNCTION f_fpriv(INT);
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_def_fpriv;
+
+statement ok
+DROP ROLE r_def_fpriv, r_inv_fpriv;
+
+subtest end
+
+
+subtest security_definer_plpgsql_loop
+
+# PL/pgSQL loops compile into INVOKER continuation routines that
+# tail-call through routineGenerator.Start's for-loop. The outer DEFINER
+# push must remain in effect for every continuation; RAISE NOTICE on each
+# iteration makes the per-iteration current_user visible.
+statement ok
+CREATE ROLE r_def_loop;
+
+statement ok
+CREATE ROLE r_inv_loop;
+
+statement ok
+SET ROLE r_def_loop;
+
+statement ok
+CREATE PROCEDURE p_sd_loop() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+DECLARE
+  i INT := 0;
+BEGIN
+  WHILE i < 5 LOOP
+    RAISE NOTICE 'iter % current_user=%', i, current_user;
+    i := i + 1;
+  END LOOP;
+END
+$$;
+
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_loop TO r_inv_loop;
+
+statement ok
+SET ROLE r_inv_loop;
+
+query T noticetrace
+CALL p_sd_loop();
+----
+NOTICE: iter 0 current_user=r_def_loop
+NOTICE: iter 1 current_user=r_def_loop
+NOTICE: iter 2 current_user=r_def_loop
+NOTICE: iter 3 current_user=r_def_loop
+NOTICE: iter 4 current_user=r_def_loop
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP PROCEDURE p_sd_loop;
+
+statement ok
+DROP ROLE r_def_loop, r_inv_loop;
+
+subtest end
+
+
+subtest security_definer_with_commit_rollback
+
+# Verify the DEFINER push survives across PL/pgSQL COMMIT/ROLLBACK inside
+# the procedure body. COMMIT/ROLLBACK end the current transaction and
+# start a new one, but the routine generator keeps executing the body —
+# so the effective-user push must persist across the boundary.
+#
+# Skipped under the legacy schema changer: post-COMMIT DDL inside a
+# procedure body re-evaluates privileges against the invoker rather than
+# the definer in that path. Tracking the divergence as a follow-up rather
+# than expanding this PR's scope to the legacy planNode resumption path.
+skipif config local-legacy-schema-changer
+statement ok
+CREATE ROLE r_def_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+GRANT CREATE ON DATABASE test TO r_def_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE ROLE r_inv_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET ROLE r_def_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE PROCEDURE p_sd_txn() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE SCHEMA s_txn_a;
+  COMMIT;
+  CREATE SCHEMA s_txn_b;
+  COMMIT;
+  CREATE SCHEMA s_txn_c;
+END
+$$;
+
+skipif config local-legacy-schema-changer
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_txn TO r_inv_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET ROLE r_inv_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+CALL p_sd_txn();
+
+# All three schemas record the definer despite the intermediate COMMITs.
+skipif config local-legacy-schema-changer
+query TT rowsort
+SELECT schema_name, owner FROM [SHOW SCHEMAS]
+WHERE schema_name IN ('s_txn_a', 's_txn_b', 's_txn_c');
+----
+s_txn_a  r_def_txn
+s_txn_b  r_def_txn
+s_txn_c  r_def_txn
+
+skipif config local-legacy-schema-changer
+statement ok
+SET ROLE root;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP SCHEMA s_txn_a;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP SCHEMA s_txn_b;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP SCHEMA s_txn_c;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP PROCEDURE p_sd_txn;
+
+# ROLLBACK variant: the first CREATE SCHEMA is rolled back; only the
+# post-ROLLBACK schema persists, owned by the definer.
+skipif config local-legacy-schema-changer
+statement ok
+SET ROLE r_def_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+CREATE PROCEDURE p_sd_txn_rb() LANGUAGE PLpgSQL SECURITY DEFINER AS $$
+BEGIN
+  CREATE SCHEMA s_txn_rb_a;
+  ROLLBACK;
+  CREATE SCHEMA s_txn_rb_b;
+END
+$$;
+
+skipif config local-legacy-schema-changer
+statement ok
+GRANT EXECUTE ON PROCEDURE p_sd_txn_rb TO r_inv_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+SET ROLE r_inv_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+CALL p_sd_txn_rb();
+
+skipif config local-legacy-schema-changer
+query TT rowsort
+SELECT schema_name, owner FROM [SHOW SCHEMAS]
+WHERE schema_name IN ('s_txn_rb_a', 's_txn_rb_b');
+----
+s_txn_rb_b  r_def_txn
+
+skipif config local-legacy-schema-changer
+statement ok
+SET ROLE root;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP SCHEMA s_txn_rb_b;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP PROCEDURE p_sd_txn_rb;
+
+skipif config local-legacy-schema-changer
+statement ok
+REVOKE CREATE ON DATABASE test FROM r_def_txn;
+
+skipif config local-legacy-schema-changer
+statement ok
+DROP ROLE r_def_txn, r_inv_txn;
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3747,6 +3747,8 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		nil,   /* blockState */
 		nil,   /* cursorDeclaration */
 		nil,   /* firstStmtResultWriter */
+		udf.Def.SecurityMode,
+		udf.Def.RoutineOwner,
 	)
 
 	var ep execPlan

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -8,6 +8,7 @@ package execbuilder
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -735,6 +736,8 @@ func (b *Builder) buildExistsSubquery(
 				nil,   /* blockState */
 				nil,   /* cursorDeclaration */
 				nil,   /* firstStmtResultWriter */
+				tree.RoutineInvoker,
+				username.SQLUsername{},
 			),
 			tree.DBoolFalse,
 		}, types.Bool), nil
@@ -864,6 +867,8 @@ func (b *Builder) buildSubquery(
 			nil,   /* blockState */
 			nil,   /* cursorDeclaration */
 			nil,   /* firstStmtResultWriter */
+			tree.RoutineInvoker,
+			username.SQLUsername{},
 		), nil
 	}
 
@@ -944,6 +949,8 @@ func (b *Builder) buildSubquery(
 			nil,   /* blockState */
 			nil,   /* cursorDeclaration */
 			nil,   /* firstStmtResultWriter */
+			tree.RoutineInvoker,
+			username.SQLUsername{},
 		), nil
 	}
 
@@ -1075,6 +1082,8 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		blockState,
 		firstStmtOut.CursorDeclaration,
 		firstStmtResultWriter,
+		udf.Def.SecurityMode,
+		udf.Def.RoutineOwner,
 	), nil
 }
 
@@ -1138,6 +1147,8 @@ func (b *Builder) initRoutineExceptionHandler(
 			nil,   /* blockState */
 			nil,   /* cursorDeclaration */
 			nil,   /* firstStmtResultWriter */
+			tree.RoutineInvoker,
+			username.SQLUsername{},
 		)
 	}
 	blockState.ExceptionHandler = exceptionHandler

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//pkg/geo/geoindex",
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/security/username",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/inverted",

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -783,6 +784,17 @@ type UDFDefinition struct {
 	// When set, Body and BodyProps are nil at plan time; they will be
 	// populated by calling BodyBuilder.Build() at execution time.
 	BodyBuilder RoutineBodyBuilder
+
+	// SecurityMode is RoutineDefiner when this routine was declared SECURITY
+	// DEFINER. It is consumed at runtime in pkg/sql/routine.go to push the
+	// routine owner onto the eval context's effective-user stack for the
+	// duration of the body's execution, so privilege checks, ownership
+	// assignments, and the current_user builtin all resolve to RoutineOwner.
+	SecurityMode tree.RoutineSecurity
+
+	// RoutineOwner is the owner of the routine, populated only when
+	// SecurityMode is RoutineDefiner. See SecurityMode for how it is used.
+	RoutineOwner username.SQLUsername
 }
 
 // ExceptionBlock contains the information needed to match and handle errors in

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
@@ -220,6 +221,15 @@ type plOptions struct {
 	// late-bound PL/pgSQL procedure, where the body is stored verbatim and
 	// references are resolved at CALL time.
 	skipSQL bool
+
+	// securityMode and routineOwner carry the enclosing routine's effective
+	// identity onto every continuation's UDFDefinition. PL/pgSQL COMMIT and
+	// ROLLBACK resume the body via a cached resumeProc memo that bypasses the
+	// optbuilder, so routineGenerator.Start relies on these fields to push the
+	// definer on resume. Zero values (RoutineInvoker, undefined owner) leave
+	// INVOKER and DO-block paths unaffected.
+	securityMode tree.RoutineSecurity
+	routineOwner username.SQLUsername
 }
 
 // basePLOptions returns a new plOptions struct with default values.
@@ -280,6 +290,14 @@ func (opts plOptions) SetIsTriggerFn(isTriggerFn bool) plOptions {
 // given value.
 func (opts plOptions) SetSkipSQL(skipSQL bool) plOptions {
 	opts.skipSQL = skipSQL
+	return opts
+}
+
+// SetSecurity returns a new plOptions struct with the routine's security mode
+// and owner set so that continuations inherit them. See plOptions.securityMode.
+func (opts plOptions) SetSecurity(mode tree.RoutineSecurity, owner username.SQLUsername) plOptions {
+	opts.securityMode = mode
+	opts.routineOwner = owner
 	return opts
 }
 
@@ -2247,6 +2265,9 @@ func (b *plpgsqlBuilder) makeContinuation(conName string) continuation {
 			BlockState:        b.block().state,
 			RoutineType:       tree.UDFRoutine,
 			RoutineLang:       tree.RoutineLangPLpgSQL,
+			// See plOptions.securityMode for why continuations carry these.
+			SecurityMode: b.options.securityMode,
+			RoutineOwner: b.options.routineOwner,
 		},
 		typ: continuationDefault,
 		s:   s,

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -504,7 +504,8 @@ func (b *Builder) buildRoutine(
 		options := basePLOptions().
 			SetIsSetReturning(isSetReturning).
 			SetInsideDataSource(oldInsideDataSource).
-			SetIsProcedure(isProc)
+			SetIsProcedure(isProc).
+			SetSecurity(o.SecurityMode, routineOwner)
 		plBuilder := newPLpgSQLBuilder(
 			b, options, def.Name, stmt.AST.Label, colRefs,
 			routineParams, f.ResolvedType(), outScope, resultBufferID,

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -380,6 +380,7 @@ func (b *Builder) buildRoutine(
 	b.insideUDF = true
 	b.insideSQLRoutine = o.Language == tree.RoutineLangSQL
 	isSetReturning := o.Class == tree.GeneratorClass
+	var routineOwner username.SQLUsername
 	if o.SecurityMode == tree.RoutineDefiner {
 		// SECURITY DEFINER: override both privilege users to the routine
 		// owner, so all privilege checks inside the routine body use the
@@ -398,6 +399,12 @@ func (b *Builder) buildRoutine(
 		}
 		b.dataSourcePrivilegeUserOverride = checkPrivUser
 		b.executePrivilegeUserOverride = checkPrivUser
+		routineOwner = checkPrivUser
+		// Push the owner as the effective user so DDL routed through the
+		// declarative schema changer, which runs at build time, sees the
+		// definer. Legacy planNode DDLs get the runtime push in
+		// routineGenerator.Start.
+		defer b.evalCtx.PushEffectiveUser(checkPrivUser)()
 	} else if o.Type != tree.BuiltinRoutine {
 		// SECURITY INVOKER (default): set dataSourcePrivilegeUserOverride to
 		// the invoker. This is necessary because a view may have overridden
@@ -542,6 +549,8 @@ func (b *Builder) buildRoutine(
 				BodyASTs:           bodyASTs,
 				Params:             params,
 				ResultBufferID:     resultBufferID,
+				SecurityMode:       o.SecurityMode,
+				RoutineOwner:       routineOwner,
 			},
 		},
 	)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -778,7 +778,7 @@ func (p *planner) regionsProvider() *regions.Provider {
 }
 
 func (p *planner) User() username.SQLUsername {
-	return p.SessionData().User()
+	return p.EvalContext().EffectiveUser()
 }
 
 // TemporarySchemaName implements scbuildstmt.TemporarySchemaProvider.

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -262,6 +262,35 @@ func (g *routineGenerator) ResolvedType() *types.T {
 
 // Start is part of the eval.ValueGenerator interface.
 func (g *routineGenerator) Start(ctx context.Context, txn *kv.Txn) (err error) {
+	// SECURITY DEFINER routines push the owner so the body resolves
+	// privileges, ownership, and current_user against the definer. A
+	// DEFINER tail-call replaces the prior push (TCO collapses the outer
+	// frame); an INVOKER tail-call leaves it intact so PL/pgSQL loop
+	// continuations inherit the outer effective user.
+	var restore func()
+	defer func() {
+		if restore != nil {
+			restore()
+		}
+	}()
+	maybePushSecurityDefiner := func() error {
+		if g.expr.SecurityMode != tree.RoutineDefiner {
+			return nil
+		}
+		if g.expr.RoutineOwner.Undefined() {
+			return errors.AssertionFailedf(
+				"routine %q is SECURITY DEFINER but RoutineOwner is unset", g.expr.Name,
+			)
+		}
+		if restore != nil {
+			restore()
+		}
+		restore = g.p.EvalContext().PushEffectiveUser(g.expr.RoutineOwner)
+		return nil
+	}
+	if err := maybePushSecurityDefiner(); err != nil {
+		return err
+	}
 	enabledStepping := false
 	var prevSteppingMode kv.SteppingMode
 	var prevSeqNum enginepb.TxnSeq
@@ -295,6 +324,9 @@ func (g *routineGenerator) Start(ctx context.Context, txn *kv.Txn) (err error) {
 		// Since it's in tail-call position, evaluating it will give the result of
 		// this routine as well.
 		g.reset(ctx, g.p, g.deferredRoutine.expr, g.deferredRoutine.args)
+		if err := maybePushSecurityDefiner(); err != nil {
+			return err
+		}
 	}
 }
 

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -481,10 +481,11 @@ func (b *builderState) CurrentUserHasAdminOrIsMemberOf(role username.SQLUsername
 	if b.hasAdmin {
 		return true
 	}
-	if b.evalCtx.SessionData().User() == role {
+	user := b.CurrentUser()
+	if user == role {
 		return true
 	}
-	memberships, err := b.auth.MemberOfWithAdminOption(b.ctx, b.evalCtx.SessionData().User())
+	memberships, err := b.auth.MemberOfWithAdminOption(b.ctx, user)
 	if err != nil {
 		panic(err)
 	}
@@ -493,7 +494,10 @@ func (b *builderState) CurrentUserHasAdminOrIsMemberOf(role username.SQLUsername
 }
 
 func (b *builderState) CurrentUser() username.SQLUsername {
-	return b.evalCtx.SessionData().User()
+	// EffectiveUser yields the SECURITY DEFINER routine owner when DDL runs
+	// inside a stored procedure body (e.g. CREATE SCHEMA), and the session
+	// user otherwise. This matches PostgreSQL ownership semantics.
+	return b.evalCtx.EffectiveUser()
 }
 
 // CheckRoleExists implements the scbuild.AuthorizationAccessor interface.

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5330,10 +5330,11 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if evalCtx.SessionData().User().Undefined() {
+				u := evalCtx.EffectiveUser()
+				if u.Undefined() {
 					return tree.DNull, nil
 				}
-				return tree.NewDString(evalCtx.SessionData().User().Normalized()), nil
+				return tree.NewDString(u.Normalized()), nil
 			},
 			Info: "Returns the current user. This function is provided for " +
 				"compatibility with PostgreSQL.",

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -471,11 +471,11 @@ func makePGPrivilegeInquiryDef(
 					// Remove the first argument.
 					args = args[1:]
 				} else {
-					if evalCtx.SessionData().User().Undefined() {
+					user = evalCtx.EffectiveUser()
+					if user.Undefined() {
 						// Wut... is this possible?
 						return tree.DNull, nil
 					}
-					user = evalCtx.SessionData().User()
 				}
 				ret, err := fn(ctx, evalCtx, args, user)
 				if err != nil {
@@ -2097,7 +2097,7 @@ FROM defaults_parsed
 
 			// For user-defined function, utilize the descriptor based way.
 			if catid.IsOIDUserDefined(oid.(*tree.DOid).Oid) {
-				return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, evalCtx.SessionData().User(), privs)
+				return evalCtx.Planner.HasAnyPrivilegeForSpecifier(ctx, specifier, user, privs)
 			}
 
 			// For builtin functions, all users should have `EXECUTE` privilege, but
@@ -2643,7 +2643,7 @@ FROM defaults_parsed
                   WHEN sub.db_id IS NULL
                     THEN crdb_internal.force_error('42704',
                            'database with OID ' || $1::STRING || ' does not exist')::INT
-                  WHEN NOT has_database_privilege(sub.db_id::OID, 'CONNECT')
+                  WHEN NOT has_database_privilege(session_user, sub.db_id::OID, 'CONNECT')
                     THEN crdb_internal.force_error('42501',
                            'permission denied for database ' || sub.db_name)::INT
                   ELSE sub.size
@@ -2675,7 +2675,7 @@ FROM defaults_parsed
                   WHEN sub.db_id IS NULL
                     THEN crdb_internal.force_error('3D000',
                            'database "' || $1 || '" does not exist')::INT
-                  WHEN NOT has_database_privilege(sub.db_id::OID, 'CONNECT')
+                  WHEN NOT has_database_privilege(session_user, sub.db_id::OID, 'CONNECT')
                     THEN crdb_internal.force_error('42501',
                            'permission denied for database ' || $1)::INT
                   ELSE sub.size
@@ -2714,7 +2714,11 @@ FROM defaults_parsed
 	// Postgres treats these as effectively public (any user can ask for the
 	// size of any relation). pg_database_size matches Postgres' stricter
 	// rule: the caller must have CONNECT on the database, otherwise the
-	// builtin errors with 42501. The bodies inline into outer queries, so
+	// builtin errors with 42501. The gate passes session_user explicitly
+	// because current_user inside a SECURITY DEFINER body resolves to the
+	// definer (NodeUser, which trivially has CONNECT). session_user ignores
+	// SET ROLE, so the check is against the connection's authenticated user
+	// rather than its currently-impersonated role. The bodies inline into outer queries, so
 	// bulk calls (e.g. SELECT pg_relation_size(c.oid) FROM pg_class c)
 	// scan system.table_metadata once total rather than once per row.
 	//

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"math"
 	"math/rand"
+	"slices"
 	"time"
 
 	apd "github.com/cockroachdb/apd/v3"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/obs/workloadid"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -100,6 +102,12 @@ type Context struct {
 	// context. Each element on the stack represents the beginning of a new
 	// transaction or nested transaction (savepoints).
 	SessionDataStack *sessiondata.Stack
+
+	// effectiveUserStack temporarily overrides EffectiveUser when a SECURITY
+	// DEFINER routine body is on the call stack. Pushed by PushEffectiveUser on
+	// routine entry and popped by the returned restore closure on exit; the
+	// top entry wins. See EffectiveUser / PushEffectiveUser.
+	effectiveUserStack []username.SQLUsername
 	// TxnState is a string representation of the current transactional state.
 	TxnState string
 	// TxnReadOnly specifies if the current transaction is read-only.
@@ -648,6 +656,41 @@ func (ec *Context) SessionData() *sessiondata.SessionData {
 	return ec.SessionDataStack.Top()
 }
 
+// EffectiveUser returns the user that should be used for privilege checks,
+// ownership assignment, and the current_user builtin. When a SECURITY DEFINER
+// routine body is executing this is the routine owner; otherwise it falls
+// back to the session user. session_user is never affected.
+func (ec *Context) EffectiveUser() username.SQLUsername {
+	if n := len(ec.effectiveUserStack); n > 0 {
+		return ec.effectiveUserStack[n-1]
+	}
+	if sd := ec.SessionData(); sd != nil {
+		return sd.User()
+	}
+	return username.SQLUsername{}
+}
+
+// PushEffectiveUser pushes u onto the effective-user stack and returns a
+// closure that pops it. The caller must defer the closure immediately so
+// that errors, panics, and PL/pgSQL exception handlers all restore the
+// prior user, and so pops occur in reverse push order. See EffectiveUser
+// for read semantics.
+func (ec *Context) PushEffectiveUser(u username.SQLUsername) (restore func()) {
+	ec.effectiveUserStack = append(ec.effectiveUserStack, u)
+	expectedLen := len(ec.effectiveUserStack)
+	return func() {
+		// Detect misordered pops or a missing intervening push. The defer
+		// pattern guarantees LIFO order, so any divergence here is a bug in
+		// a future caller, not a routine occurrence.
+		if got := len(ec.effectiveUserStack); got != expectedLen {
+			panic(errors.AssertionFailedf(
+				"PushEffectiveUser restore called out of order: stack length %d, expected %d", got, expectedLen,
+			))
+		}
+		ec.effectiveUserStack = ec.effectiveUserStack[:expectedLen-1]
+	}
+}
+
 // Copy returns a copy of the EvalCtx that can safely be used concurrently with
 // the original.
 func (ec *Context) Copy() *Context {
@@ -656,6 +699,9 @@ func (ec *Context) Copy() *Context {
 	ctxCopy.CollationEnv = tree.CollationEnvironment{}
 	ctxCopy.iVarContainerStack = make([]tree.IndexedVarContainer, len(ec.iVarContainerStack), cap(ec.iVarContainerStack))
 	copy(ctxCopy.iVarContainerStack, ec.iVarContainerStack)
+	// Clone the effective-user stack so subsequent pushes on either copy
+	// don't alias each other via the shared backing array.
+	ctxCopy.effectiveUserStack = slices.Clone(ec.effectiveUserStack)
 	return &ctxCopy
 }
 

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -140,6 +140,7 @@ go_library(
         "//pkg/geo",
         "//pkg/geo/geopb",
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/security/username",
         "//pkg/settings",
         "//pkg/sql/lex",
         "//pkg/sql/lexbase",

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -168,9 +169,27 @@ type RoutineExpr struct {
 	// result of the *first* body statement. It may be unset. Only one of this or
 	// CursorDeclaration may be set.
 	FirstStmtResultWriter RoutineResultWriter
+
+	// SecurityMode is RoutineDefiner when the body should execute with the
+	// owner's effective user (SECURITY DEFINER). When set, RoutineOwner is
+	// pushed onto the effective-user stack for the duration of the call.
+	// SECURITY INVOKER leaves the effective user unchanged. Only meaningful
+	// on the top-level routine; sub-routines synthesized by execbuilder
+	// (exception handlers, lazy subqueries, etc.) leave it zero.
+	SecurityMode RoutineSecurity
+
+	// RoutineOwner is the user to push as the effective user while the body
+	// executes. Only consulted when SecurityMode == RoutineDefiner.
+	RoutineOwner username.SQLUsername
 }
 
 // NewTypedRoutineExpr returns a new RoutineExpr that is well-typed.
+//
+// securityMode and routineOwner must be RoutineInvoker / undefined for
+// sub-routines synthesized by execbuilder (exception handler actions, lazy
+// subqueries, EXISTS wrappers, etc.). Forwarding them is only meaningful for
+// the top-level routine of a UDF or procedure invocation. They are positional
+// to force every call site to make the choice explicitly.
 func NewTypedRoutineExpr(
 	name string,
 	args TypedExprs,
@@ -188,6 +207,8 @@ func NewTypedRoutineExpr(
 	blockState *BlockState,
 	cursorDeclaration *RoutineOpenCursor,
 	firstStmtResultWriter RoutineResultWriter,
+	securityMode RoutineSecurity,
+	routineOwner username.SQLUsername,
 ) *RoutineExpr {
 	return &RoutineExpr{
 		Args:                  args,
@@ -206,6 +227,8 @@ func NewTypedRoutineExpr(
 		BlockState:            blockState,
 		CursorDeclaration:     cursorDeclaration,
 		FirstStmtResultWriter: firstStmtResultWriter,
+		SecurityMode:          securityMode,
+		RoutineOwner:          routineOwner,
 	}
 }
 


### PR DESCRIPTION
PR #170141 opened CREATE/DROP SCHEMA and CREATE/DROP ROLE in PL/pgSQL procedure bodies (and #168464 did the same for tables). The existing SECURITY DEFINER mechanism only swapped the effective user for the optbuilder-time checks used by DML; DDL privilege checks and ownership stamps run at execution time and in the declarative schema changer, neither of which honored the override. The result was a divergence from PostgreSQL where a SECURITY DEFINER procedure that did CREATE SCHEMA, CREATE ROLE, etc. evaluated privileges and recorded ownership against the invoker.

Introduce an effective-user stack on the eval context. The routine owner is pushed when a SECURITY DEFINER body starts and popped on exit, including across PL/pgSQL tail-call iterations and nested DEFINER routines (which stack on top so the inner owner wins for the inner body). All runtime user-resolution paths consult the stack first and fall back to session data otherwise, so privilege checks, ownership assignments, and the current_user builtin all resolve to the definer. The same push is performed during body building so the declarative schema changer's compile-time checks see the definer too. SECURITY INVOKER, session_user, and existing DML SECURITY DEFINER paths are unaffected.

Closes #170387
Epic: CRDB-31256

Release note (bug fix): DDL and current_user inside a SECURITY DEFINER stored procedure now resolve against the procedure owner, matching PostgreSQL. Previously they evaluated against the invoker.