### PR TITLE
[CNSL-2270] ui: migrate cluster-ui npm publishing to OIDC

### DIFF
--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -12,6 +12,9 @@ jobs:
   publish_cluster_ui:
     if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: write # Required for git tagging
     defaults:
       run:
         working-directory: pkg/ui/workspaces/cluster-ui
@@ -39,8 +42,6 @@ jobs:
         always-auth: true
         cache: 'pnpm'
         cache-dependency-path: "${{ github.workspace }}/pkg/ui/pnpm-lock.yaml"
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Always install node dependencies. It seems silly to do if we're not
       # going to actually use them, but setup-node's post-run action attempts
@@ -89,6 +90,10 @@ jobs:
           git tag $TAGNAME
           git push origin $TAGNAME
         fi
+
+    - name: Upgrade npm for OIDC trusted publishing
+      if: steps.version-check.outputs.published == 'no'
+      run: npm install -g npm@11.5.1
 
     - name: Publish patch version
       if: steps.version-check.outputs.published == 'no'


### PR DESCRIPTION
Replace stored NPM_TOKEN secret with OIDC-based authentication for cluster-ui package publishing.

Changes:
- Add id-token: write permission for OIDC token generation
- Add contents: write permission for git tag operations
- Remove NODE_AUTH_TOKEN environment variable
- Add explicit npm@11.5.1 upgrade step for OIDC support

This requires trusted publisher configuration on npmjs.com for the @cockroachlabs/cluster-ui package (already configured).

Issue: CNSL-2270

See docs:
https://docs.npmjs.com/trusted-publishers#supported-cicd-providers