### PR TITLE
roachprod: wait for NodeID before starting next node

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -226,7 +226,9 @@ func runAdmissionControlSnapshotOverloadIO(
 	time.Sleep(2 * time.Hour)
 
 	t.Status(fmt.Sprintf("starting node 3... (<%s)", time.Minute))
-	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(envOptions), c.Node(3))
+	restartOpts := startOpts
+	restartOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), restartOpts, install.MakeClusterSettings(envOptions), c.Node(3))
 
 	t.Status(fmt.Sprintf("waiting for snapshot transfers to finish %s", 2*time.Hour))
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -417,7 +417,9 @@ func runWideReplication(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Stop the cluster and restart 2/3 of the nodes.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts())
 	tBeginDown := timeutil.Now()
-	c.Start(ctx, t.L(), startOpts, settings, c.Range(1, 6))
+	restartOpts := startOpts
+	restartOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), restartOpts, settings, c.Range(1, 6))
 
 	waitForUnderReplicated := func(count int) {
 		for start := timeutil.Now(); ; time.Sleep(time.Second) {

--- a/pkg/cmd/roachtest/tests/cli.go
+++ b/pkg/cmd/roachtest/tests/cli.go
@@ -129,7 +129,9 @@ func runCLINodeStatus(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Stop the remaining nodes and restart them. Verify that all five nodes
 	// show up in the node status output.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(1, 3))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 3))
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, 3))
 
 	waitUntil([]string{
 		"is_available is_live",

--- a/pkg/cmd/roachtest/tests/clock_monotonic.go
+++ b/pkg/cmd/roachtest/tests/clock_monotonic.go
@@ -67,7 +67,9 @@ func runClockMonotonicity(
 
 		offsetInjector.recover(ctx, c.Spec().NodeCount)
 
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(c.Spec().NodeCount))
+		startOpts := option.DefaultStartOpts()
+		startOpts.RoachprodOpts.IsRestart = true
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(c.Spec().NodeCount))
 		if !isAlive(db, t.L()) {
 			t.Fatal("Node unexpectedly crashed")
 		}
@@ -79,7 +81,9 @@ func runClockMonotonicity(
 	t.Status("injecting offset")
 	offsetInjector.offset(ctx, c.Spec().NodeCount, tc.offset)
 	t.Status("starting cockroach post offset")
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(c.Spec().NodeCount))
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(c.Spec().NodeCount))
 
 	if !isAlive(db, t.L()) {
 		t.Fatal("Node unexpectedly crashed")

--- a/pkg/cmd/roachtest/tests/event_log.go
+++ b/pkg/cmd/roachtest/tests/event_log.go
@@ -84,7 +84,9 @@ func runEventLog(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// Stop and Start Node 3, and verify the node restart message.
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(3))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(3))
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(3))
 
 	err = retry.ForDuration(10*time.Second, func() error {
 		// Query all node restart events. There should only be one.

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1877,6 +1877,7 @@ func failoverRestartOpts() option.StartOpts {
 	startOpts := option.DefaultStartOpts()
 	startOpts.RoachprodOpts.ScheduleBackups = false
 	startOpts.RoachprodOpts.SkipInit = true
+	startOpts.RoachprodOpts.IsRestart = true
 	return startOpts
 }
 

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -163,7 +163,9 @@ func executeNodeShutdown(
 	t.Status(fmt.Sprintf("restarting %s (node restart test is done)\n", target))
 	// Don't begin another backup schedule, as the parent test driver has already
 	// set or disallowed the automatic backup schedule.
-	if err := c.StartE(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule),
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
+	startOpts.RoachprodOpts.IsRestart = true
+	if err := c.StartE(ctx, t.L(), startOpts,
 		install.MakeClusterSettings(cfg.restartSettings...), target); err != nil {
 		return errors.Wrapf(err, "could not restart node %s", target)
 	}

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -351,7 +351,9 @@ func runMultiTenantMultiRegion(ctx context.Context, t test.Test, c cluster.Clust
 	require.NoErrorf(t, grp.WaitE(), "waited for go routines, expected no error.")
 
 	// Restart the KV storage servers first.
-	c.Start(ctx, t.L(), systemStartOpts, install.MakeClusterSettings(), killedRegion)
+	systemRestartOpts := systemStartOpts
+	systemRestartOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), systemRestartOpts, install.MakeClusterSettings(), killedRegion)
 	// Re-add dead tenants back again.
 	killedRegionStartOpts := option.StartVirtualClusterOpts(
 		virtualCluster, killedRegion, option.NoBackupSchedule,

--- a/pkg/cmd/roachtest/tests/quit.go
+++ b/pkg/cmd/roachtest/tests/quit.go
@@ -100,6 +100,7 @@ func (q *quitTest) runTest(
 func (q *quitTest) restartNode(ctx context.Context, nodeID int) {
 	settings := install.MakeClusterSettings(install.EnvOption(q.env))
 	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, q.args...)
 	q.c.Start(ctx, q.t.L(), startOpts, settings, q.c.Node(nodeID))
 

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -139,7 +139,9 @@ func runReplicaGCChangedPeers(
 		// do that within the store dead interval (5m, i.e. too long for this
 		// test).
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Range(4, 6))
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Range(4, 6))
+		restartOpts := option.DefaultStartOpts()
+		restartOpts.RoachprodOpts.IsRestart = true
+		c.Start(ctx, t.L(), restartOpts, settings, c.Range(4, 6))
 	}
 
 	// Restart n3. We have to manually tell it where to find a new node or it
@@ -159,7 +161,9 @@ func runReplicaGCChangedPeers(
 	h.waitForZeroReplicas(ctx, 3)
 
 	// Restart the remaining nodes to satisfy the dead node detector.
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 2))
+	recoverOpts := option.DefaultStartOpts()
+	recoverOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), recoverOpts, install.MakeClusterSettings(), c.Range(1, 2))
 }
 
 type replicagcTestHelper struct {

--- a/pkg/cmd/roachtest/tests/restart.go
+++ b/pkg/cmd/roachtest/tests/restart.go
@@ -64,7 +64,8 @@ func runRestart(ctx context.Context, t test.Test, c cluster.Cluster, downDuratio
 
 	// Bring it back up and make sure it can serve a query within a reasonable
 	// time limit. For now, less time than it was down for.
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), restartNode)
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), restartNode)
 
 	// Dialing the formerly down node may still be prevented by the circuit breaker
 	// for a short moment (seconds) after n3 restarts. If it happens, the COUNT(*)

--- a/pkg/cmd/roachtest/tests/revlog_backup_restore.go
+++ b/pkg/cmd/roachtest/tests/revlog_backup_restore.go
@@ -224,7 +224,9 @@ func revlogNodeRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	time.Sleep(10 * time.Second)
 
 	t.L().Printf("restarting node 3")
-	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Node(3))
+	restartOpts := startOpts
+	restartOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), restartOpts, install.MakeClusterSettings(), c.Node(3))
 	time.Sleep(15 * time.Second)
 
 	d.randomWait(t.L(), testRNG)

--- a/pkg/cmd/roachtest/tests/store_metrics.go
+++ b/pkg/cmd/roachtest/tests/store_metrics.go
@@ -119,7 +119,9 @@ func runStoreMetrics(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(1))
 
 	t.Status("restarting node")
-	c.Start(ctx, t.L(), startOpts, startSettings, c.Node(1))
+	restartOpts := startOpts
+	restartOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), restartOpts, startSettings, c.Node(1))
 
 	t.Status("checking metrics parity between stores after restart")
 	metricsMap2, err := getMetricsMap(ctx)

--- a/pkg/cmd/roachtest/tests/super_region_failover.go
+++ b/pkg/cmd/roachtest/tests/super_region_failover.go
@@ -237,7 +237,9 @@ func runSurviveRegionFailure(
 
 	// Recover us-east-1.
 	t.Status("recovering us-east-1 nodes")
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(),
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(),
 		c.Nodes(usEastNodes...))
 
 	// Reconnect to node 1 for recovery checks.
@@ -297,7 +299,9 @@ func runSurviveZoneFailure(
 
 	// Recover the killed node.
 	t.Status(fmt.Sprintf("recovering node %d", targetNode))
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(),
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.IsRestart = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(),
 		c.Node(targetNode))
 
 	rConn := c.Conn(ctx, t.L(), 1)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -2314,6 +2314,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 	restart := func(ctx context.Context) {
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), roachNodes)
 		startOpts, settings := b.startOpts()
+		startOpts.RoachprodOpts.IsRestart = true
 		c.Start(ctx, t.L(), startOpts, settings, roachNodes)
 	}
 
@@ -2819,7 +2820,9 @@ func runTPCCPublished(
 
 	restart := func(ctx context.Context) {
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), crdbNodes)
-		c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
+		restartOpts := startOpts
+		restartOpts.RoachprodOpts.IsRestart = true
+		c.Start(ctx, t.L(), restartOpts, settings, crdbNodes)
 	}
 
 	precision := int(math.Max(1.0, float64(opts.warehouses/50)))

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -49,7 +49,9 @@ func registerTPCHConcurrency(r registry.Registry) {
 
 	restartCluster := func(ctx context.Context, c cluster.Cluster, t test.Test) {
 		c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.CRDBNodes())
-		c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
+		startOpts := option.NewStartOpts(option.NoBackupSchedule)
+		startOpts.RoachprodOpts.IsRestart = true
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.CRDBNodes())
 	}
 
 	// checkConcurrency returns an error if at least one node of the cluster

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -653,6 +653,25 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		// `--start-single-node` flag will handle all of this for us.
 		shouldInit := startOpts.Target == StartDefault && !c.useStartSingleNode() && !startOpts.SkipInit
 
+		// We only need to serialize node startup when JoinNodeRequests will
+		// actually be sent — that is, on a true fresh bootstrap. If the
+		// cluster was already initialized in a prior Start() call (an
+		// "implicit restart" where the caller invokes Start() without
+		// IsRestart=true), each node rejoins with the NodeID already
+		// persisted on disk, so the wait would be both unnecessary and
+		// harmful: restart scenarios may need multiple nodes to come up
+		// together to form quorum.
+		shouldWait := shouldInit
+		if shouldInit {
+			bootstrapped, err := c.clusterAlreadyBootstrapped(ctx, l, startOpts.GetInitTarget())
+			if err != nil {
+				return errors.Wrap(err, "checking cluster bootstrap state")
+			}
+			if bootstrapped {
+				shouldWait = false
+			}
+		}
+
 		for _, node := range c.Nodes {
 			// NB: if cockroach started successfully, we ignore the output as it is
 			// some harmless start messaging.
@@ -661,12 +680,17 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 			}
 			// We reserve a few special operations (bootstrapping, and setting
 			// cluster settings) to the InitTarget.
-			if startOpts.GetInitTarget() != node {
-				continue
-			}
-
-			if shouldInit {
+			if startOpts.GetInitTarget() == node && shouldInit {
 				if err := c.initializeCluster(ctx, l, node); err != nil {
+					return err
+				}
+			}
+			if shouldWait {
+				// Wait for each node's join to complete before starting the next.
+				// We can't predict which NodeID this node will be assigned (it depends
+				// on what else has joined the cluster), so we only check that some
+				// NodeID exists. The serialization is what prevents the race in #142313.
+				if err := c.waitForNodeID(ctx, l, node); err != nil {
 					return err
 				}
 			}
@@ -994,6 +1018,57 @@ func (c *SyncedCluster) startNodeWithResult(
 	}
 
 	return c.runCmdOnSingleNode(ctx, l, node, runScriptCmd, defaultCmdOpts("run-start-script"))
+}
+
+// waitForNodeID polls until the given node has been assigned a NodeID. This
+// serializes startup so concurrent JoinNodeRequests cannot race and assign
+// out-of-order IDs. See #142313.
+func (c *SyncedCluster) waitForNodeID(ctx context.Context, l *logger.Logger, node Node) error {
+	retryOpts := retry.Options{
+		InitialBackoff: 100 * time.Millisecond,
+		MaxBackoff:     time.Second,
+		MaxRetries:     10,
+	}
+	return retryOpts.Do(ctx, func(ctx context.Context) error {
+		results, err := c.ExecSQL(ctx, l, Nodes{node}, SystemInterfaceName, 0,
+			AuthRootCert, "", []string{"--format", "csv", "-e", "SELECT crdb_internal.node_id()"})
+		if err != nil {
+			return err
+		}
+		if results[0].Err != nil {
+			return results[0].Err
+		}
+		lines := strings.Split(strings.TrimSpace(results[0].CombinedOut), "\n")
+		if len(lines) < 2 {
+			return errors.Newf("unexpected output: %q", results[0].CombinedOut)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(lines[1]))
+		if err != nil {
+			return err
+		}
+		if got <= 0 {
+			return errors.Newf("node %d: NodeID not yet assigned", node)
+		}
+		return nil
+	})
+}
+
+// clusterAlreadyBootstrapped reports whether the cluster appears to have
+// been initialized in a prior Start() call, based on the sentinel file
+// written by generateInitCmd after a successful cockroach init.
+func (c *SyncedCluster) clusterAlreadyBootstrapped(
+	ctx context.Context, l *logger.Logger, initTarget Node,
+) (bool, error) {
+	sentinel := fmt.Sprintf("%s/cluster-bootstrapped", c.NodeDir(initTarget, 1))
+	cmd := fmt.Sprintf("test -e %s && echo yes || echo no", sentinel)
+	res, err := c.runCmdOnSingleNode(ctx, l, initTarget, cmd, defaultCmdOpts("check-bootstrapped"))
+	if err != nil {
+		return false, err
+	}
+	if res.Err != nil {
+		return false, res.Err
+	}
+	return strings.TrimSpace(res.CombinedOut) == "yes", nil
 }
 
 // N.B. not thread-safe because startOpts is shared and may be mutated.


### PR DESCRIPTION
This PR fixes #142313 (NodeID race in roachprod cluster bootstrap) in two commits.

**Commit 1 — `roachprod: wait for NodeID before starting next node`**: the actual fix. Serializes node startup during cluster bootstrap by waiting for each node's NodeID to be assigned before launching the next. The wait is gated on `IsRestart=false` so it only kicks in for fresh-cluster startup, not individual node restarts. See the commit message for full context.

**Commit 2 — `roachtest: set IsRestart on node restart paths`**: a follow-on cleanup. The IsRestart gating in commit 1 exposed roachtests that stop and restart nodes without setting the flag. Without it, those restart paths take the new sequential-with-wait path, which can hang scenarios that need multiple nodes to come up together to form quorum. Sets `IsRestart=true` on the restart sites where it's safe — i.e. where the restart passes the same start arguments as the initial start. See the commit message for why a number of restart sites are deliberately left untouched.

Resolves: #142313
Epic: none

Release note: None