### PR TITLE
ptstorage: drop the dead meta-read surface

### DIFF
--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -264,5 +264,4 @@ ORDER BY raw_start_key ASC LIMIT 1`)
 	state, err := ptsWithDB.GetState(ctx)
 	require.NoError(t, err)
 	require.Len(t, state.Records, 0)
-	require.Equal(t, int(state.NumRecords), len(state.Records))
 }

--- a/pkg/kv/kvserver/protectedts/protectedts.go
+++ b/pkg/kv/kvserver/protectedts/protectedts.go
@@ -88,9 +88,6 @@ type Storage interface {
 	// passed txn remains safe for future use.
 	Release(context.Context, uuid.UUID) error
 
-	// GetMetadata retrieves the metadata with the provided Txn.
-	GetMetadata(context.Context) (ptpb.Metadata, error)
-
 	// GetState retrieves the entire state of protectedts.Storage with the
 	// provided Txn.
 	GetState(context.Context) (ptpb.State, error)

--- a/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
+++ b/pkg/kv/kvserver/protectedts/ptpb/protectedts.proto
@@ -54,32 +54,6 @@ enum ProtectionMode {
   // PROTECT_AT = 1;
 }
 
-// Metadata is the system metadata. The metadata is stored explicitly and all
-// operations which create or release Records increment the version and update
-// the metadata fields accordingly.
-//
-// The version provides a mechanism for cheap caching and forms the basis of
-// the implementation of the Tracker. The Tracker needs to provide a recent
-// view of the protectedts subsystem for GC to proceed. The protectedts
-// state changes rarely. The timestamp of cached state can by updated by
-// merely observing that the version has not changed.
-message Metadata {
-
-   // Version is incremented whenever a Record is created or removed.
-   uint64 version = 1 [deprecated=true];
-
-   // NumRecords is the number of records which exist in the subsystem.
-   uint64 num_records = 2 [deprecated=true];
-
-   // NumSpans is the number of spans currently being protected by the
-   // protectedts subsystem.
-   uint64 num_spans = 3 [deprecated=true];
-
-   // TotalBytes is the number of bytes currently in use by records
-   // to store their spans and metadata.
-   uint64 total_bytes = 4 [deprecated=true];
-}
-
 // Record corresponds to a protected timestamp.
 message Record {
   // ID uniquely identifies this row.
@@ -125,7 +99,13 @@ message Record {
 
 // State is the complete system state.
 message State {
-  Metadata metadata = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // Field 1 was an embedded Metadata message (version, num_records, num_spans,
+  // total_bytes) read from the system.protected_ts_meta table. It fed the now-
+  // removed ptcache, which observed Version to decide when to refresh. The
+  // cache and its consumers are gone; the meta table is still written to but
+  // no longer read into the State proto.
+  reserved 1;
+  reserved "metadata";
   repeated Record records = 2 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/severity",
-        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/protectedts/ptstorage/sql.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/sql.go
@@ -11,8 +11,8 @@ const (
 	// none exists yet. At the time of writing, there will never be a
 	// physical row in the meta table with version zero.
 	//
-	// This is the read-only variant, used by getMetadataQuery. Mutating
-	// queries (protect, release) use currentMetaCTEForUpdate to avoid the
+	// This is the read-only variant, used by GetState. Mutating queries
+	// (protect, release) use currentMetaCTEForUpdate to avoid the
 	// WriteTooOld retry storm that concurrent writers would otherwise
 	// trigger on the shared meta row.
 	currentMetaCTE = `
@@ -199,12 +199,4 @@ WHERE
 RETURNING
     id
 `
-
-	getMetadataQuery = `
-WITH
-    current_meta AS (` + currentMetaCTE + `)
-SELECT
-    version, num_records, num_spans, total_bytes
-FROM
-    current_meta;`
 )

--- a/pkg/kv/kvserver/protectedts/ptstorage/sql.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/sql.go
@@ -7,36 +7,18 @@ package ptstorage
 
 const (
 
-	// currentMetaCTE reads the meta row, returning a default zero row if
-	// none exists yet. At the time of writing, there will never be a
-	// physical row in the meta table with version zero.
+	// currentMetaCTEForUpdate reads the singleton meta row with FOR UPDATE,
+	// returning a default zero row if none exists yet. At the time of writing,
+	// there will never be a physical row in the meta table with version zero.
 	//
-	// This is the read-only variant, used by GetState. Mutating queries
-	// (protect, release) use currentMetaCTEForUpdate to avoid the
-	// WriteTooOld retry storm that concurrent writers would otherwise
-	// trigger on the shared meta row.
-	currentMetaCTE = `
-SELECT
-    version, num_records, num_spans, total_bytes
-FROM
-    system.protected_ts_meta
-UNION ALL
-    SELECT 0 AS version, 0 AS num_records, 0 AS num_spans, 0 AS total_bytes
-ORDER BY
-    version DESC
-LIMIT
-    1
-`
-
-	// currentMetaCTEForUpdate is the locking variant of currentMetaCTE used by
-	// the protect and release queries. Both are read-modify-writes against
-	// the singleton meta row: every concurrent caller reads the same row,
-	// then upserts a new version. Without serialization the writers race,
-	// producing a storm of WriteTooOld retries on the shared key. Acquiring
-	// an exclusive lock on the real meta row during the read forces those
-	// callers to queue rather than collide. The FOR UPDATE clause is bound
-	// to the real-table leg only; the synthetic zero-row fallback (used when
-	// no meta row exists yet) does not lock anything.
+	// It is used by the protect and release queries. Both are read-modify-
+	// writes against the singleton meta row: every concurrent caller reads the
+	// same row, then upserts a new version. Without serialization the writers
+	// race, producing a storm of WriteTooOld retries on the shared key.
+	// Acquiring an exclusive lock on the real meta row during the read forces
+	// those callers to queue rather than collide. The FOR UPDATE clause is
+	// bound to the real-table leg only; the synthetic zero-row fallback (used
+	// when no meta row exists yet) does not lock anything.
 	currentMetaCTEForUpdate = `
 SELECT
     version, num_records, num_spans, total_bytes

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -187,10 +187,25 @@ func (p storage) Release(ctx context.Context, id uuid.UUID) (err error) {
 	return nil
 }
 
-func (p storage) GetMetadata(ctx context.Context) (ptpb.Metadata, error) {
+func (p storage) GetState(ctx context.Context) (ptpb.State, error) {
+	md, err := p.getMetadata(ctx)
+	if err != nil {
+		return ptpb.State{}, err
+	}
+	records, err := p.getRecords(ctx)
+	if err != nil {
+		return ptpb.State{}, err
+	}
+	return ptpb.State{
+		Metadata: md,
+		Records:  records,
+	}, nil
+}
+
+func (p storage) getMetadata(ctx context.Context) (ptpb.Metadata, error) {
 	row, err := p.txn.QueryRowEx(ctx, "protectedts-GetMetadata", p.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		getMetadataQuery)
+		currentMetaCTE)
 	if err != nil {
 		return ptpb.Metadata{}, errors.Wrap(err, "failed to read metadata")
 	}
@@ -202,21 +217,6 @@ func (p storage) GetMetadata(ctx context.Context) (ptpb.Metadata, error) {
 		NumRecords: uint64(*row[1].(*tree.DInt)),
 		NumSpans:   uint64(*row[2].(*tree.DInt)),
 		TotalBytes: uint64(*row[3].(*tree.DInt)),
-	}, nil
-}
-
-func (p storage) GetState(ctx context.Context) (ptpb.State, error) {
-	md, err := p.GetMetadata(ctx)
-	if err != nil {
-		return ptpb.State{}, err
-	}
-	records, err := p.getRecords(ctx)
-	if err != nil {
-		return ptpb.State{}, err
-	}
-	return ptpb.State{
-		Metadata: md,
-		Records:  records,
 	}, nil
 }
 

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage.go
@@ -188,36 +188,11 @@ func (p storage) Release(ctx context.Context, id uuid.UUID) (err error) {
 }
 
 func (p storage) GetState(ctx context.Context) (ptpb.State, error) {
-	md, err := p.getMetadata(ctx)
-	if err != nil {
-		return ptpb.State{}, err
-	}
 	records, err := p.getRecords(ctx)
 	if err != nil {
 		return ptpb.State{}, err
 	}
-	return ptpb.State{
-		Metadata: md,
-		Records:  records,
-	}, nil
-}
-
-func (p storage) getMetadata(ctx context.Context) (ptpb.Metadata, error) {
-	row, err := p.txn.QueryRowEx(ctx, "protectedts-GetMetadata", p.txn.KV(),
-		sessiondata.NodeUserSessionDataOverride,
-		currentMetaCTE)
-	if err != nil {
-		return ptpb.Metadata{}, errors.Wrap(err, "failed to read metadata")
-	}
-	if row == nil {
-		return ptpb.Metadata{}, errors.New("failed to read metadata")
-	}
-	return ptpb.Metadata{
-		Version:    uint64(*row[0].(*tree.DInt)),
-		NumRecords: uint64(*row[1].(*tree.DInt)),
-		NumSpans:   uint64(*row[2].(*tree.DInt)),
-		TotalBytes: uint64(*row[3].(*tree.DInt)),
-	}, nil
+	return ptpb.State{Records: records}, nil
 }
 
 func (p *storage) getRecords(ctx context.Context) ([]ptpb.Record, error) {

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -602,10 +602,6 @@ func TestErrorsFromSQL(t *testing.T) {
 		return pts.WithTxn(wrapTxn(txn, errFunc)).Release(ctx, rec.ID.GetUUID())
 	}), fmt.Sprintf("failed to release record %v: boom", rec.ID))
 	require.EqualError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		_, err := pts.WithTxn(wrapTxn(txn, errFunc)).GetMetadata(ctx)
-		return err
-	}), "failed to read metadata: boom")
-	require.EqualError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		_, err := pts.WithTxn(wrapTxn(txn, errFunc)).GetState(ctx)
 		return err
 	}), "failed to read metadata: boom")

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -241,17 +240,10 @@ func (r releaseOp) run(ctx context.Context, t *testing.T, tCtx *testContext) {
 		i := sort.Search(len(tCtx.state.Records), func(i int) bool {
 			return bytes.Compare(id[:], tCtx.state.Records[i].ID[:]) <= 0
 		})
-		rec := tCtx.state.Records[i]
 		tCtx.state.Records = append(tCtx.state.Records[:i], tCtx.state.Records[i+1:]...)
 		if len(tCtx.state.Records) == 0 {
 			tCtx.state.Records = nil
 		}
-		tCtx.state.Version++
-		tCtx.state.NumRecords--
-		tCtx.state.NumSpans -= uint64(len(rec.DeprecatedSpans))
-		encoded, err := protoutil.Marshal(&ptpb.Target{Union: rec.Target.GetUnion()})
-		require.NoError(t, err)
-		tCtx.state.TotalBytes -= uint64(len(encoded) + len(rec.Meta) + len(rec.MetaType))
 	}
 }
 
@@ -302,12 +294,6 @@ func (p protectOp) run(ctx context.Context, t *testing.T, tCtx *testContext) {
 		tail := tCtx.state.Records[i:]
 		tCtx.state.Records = append(tCtx.state.Records[:i:i], rec)
 		tCtx.state.Records = append(tCtx.state.Records, tail...)
-		tCtx.state.Version++
-		tCtx.state.NumRecords++
-		tCtx.state.NumSpans += uint64(len(rec.DeprecatedSpans))
-		encoded, err := protoutil.Marshal(&ptpb.Target{Union: rec.Target.GetUnion()})
-		require.NoError(t, err)
-		tCtx.state.TotalBytes += uint64(len(encoded) + len(p.meta) + len(p.metaType))
 	}
 }
 
@@ -330,7 +316,6 @@ func (p updateTimestampOp) run(ctx context.Context, t *testing.T, tCtx *testCont
 			return bytes.Equal(id[:], tCtx.state.Records[i].ID[:])
 		})
 		tCtx.state.Records[i] = p.expectedRecordFn(tCtx.state.Records[i])
-		tCtx.state.Version++
 	}
 }
 
@@ -601,21 +586,6 @@ func TestErrorsFromSQL(t *testing.T) {
 	require.EqualError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		return pts.WithTxn(wrapTxn(txn, errFunc)).Release(ctx, rec.ID.GetUUID())
 	}), fmt.Sprintf("failed to release record %v: boom", rec.ID))
-	require.EqualError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		_, err := pts.WithTxn(wrapTxn(txn, errFunc)).GetState(ctx)
-		return err
-	}), "failed to read metadata: boom")
-	// Test that we get an error retrieving the records in GetState.
-	// The preceding call tested the error while retrieving the metadata in a
-	// call to GetState.
-	var seen bool
-	errFunc = func(string) error {
-		if !seen {
-			seen = true
-			return nil
-		}
-		return errors.New("boom")
-	}
 	require.EqualError(t, db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		_, err := pts.WithTxn(wrapTxn(txn, errFunc)).GetState(ctx)
 		return err

--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_with_database.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_with_database.go
@@ -53,13 +53,6 @@ func (s *storageWithDatabase) Release(ctx context.Context, id uuid.UUID) error {
 	})
 }
 
-func (s *storageWithDatabase) GetMetadata(ctx context.Context) (md ptpb.Metadata, _ error) {
-	return md, s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
-		md, err = s.s.WithTxn(txn).GetMetadata(ctx)
-		return err
-	})
-}
-
 func (s *storageWithDatabase) GetState(ctx context.Context) (state ptpb.State, err error) {
 	return state, s.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) (err error) {
 		state, err = s.s.WithTxn(txn).GetState(ctx)


### PR DESCRIPTION
Follow-on cleanup to #170706. With the ptcache package gone, nothing in the
tree reads the contents of the `system.protected_ts_meta` row through Go code
anymore. This PR removes the now-dead read-side surface:

- The `Storage.GetMetadata` interface method had no callers outside
  ptstorage itself.
- The `Metadata` field on the `State` proto fed the cache's revision check;
  its fields were marked `deprecated=true` in #112093, and the cache was
  deleted in late 2025. `ptpb.State` is never marshaled (no RPC, no other
  proto embeds it), so dropping the field has no wire-format implications.

The meta table itself is unchanged — protect and release still maintain it.

Epic: none
Release note: None