### PR TITLE
ui: fix cluster-ui repository URL for OIDC publishing

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -4,7 +4,7 @@
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cockroachdb/ui/"
+    "url": "https://github.com/cockroachdb/cockroach"
   },
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
Update cluster-ui package.json repository URL from cockroachdb/ui to cockroachdb/cockroach to match the actual repository where the code lives and where the publish workflow runs.

This fixes OIDC trusted publishing validation which requires the package.json repository URL to match the workflow repository.

Fixes the publish failure:
```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle: 
Failed to validate repository information: package.json: "repository.url" is 
"git+https://github.com/cockroachdb/ui.git", expected to match 
"https://github.com/cockroachdb/cockroach" from provenance
```

Release justification: This fixes OIDC trusted publishing validation which requires the package.json repository URL to match the workflow repository.


Epic: CNSL-2270