### PR TITLE
clisqlshell: Context fields for library-mode embedders

### DIFF
--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -81,5 +81,6 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_knz_bubbline//computil",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cli/clisqlshell/complete_test.go
+++ b/pkg/cli/clisqlshell/complete_test.go
@@ -182,8 +182,9 @@ type mockShell struct {
 
 var _ sqlShell = mockShell{}
 
-func (mockShell) inCopy() bool      { return false }
-func (mockShell) enableDebug() bool { return false }
+func (mockShell) inCopy() bool                { return false }
+func (mockShell) enableDebug() bool           { return false }
+func (mockShell) externalEditorAllowed() bool { return true }
 func (mockShell) serverSideParse(sql string) (string, error) {
 	panic("not implemented")
 }

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -52,6 +52,12 @@ type Context struct {
 	// CertsDir is an extra directory to look for client certs in,
 	// when the \c command is used.
 	CertsDir string
+
+	// DisableHistory, if true, suppresses persistent shell history.
+	// When set, no history file is created or read, even in
+	// interactive mode. Equivalent to (but more explicit than)
+	// leaving the internal histFile unset.
+	DisableHistory bool
 }
 
 // internalContext represents the internal configuration state of the

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -58,6 +58,14 @@ type Context struct {
 	// interactive mode. Equivalent to (but more explicit than)
 	// leaving the internal histFile unset.
 	DisableHistory bool
+
+	// InterruptCh, if non-nil, replaces the SIGINT-based interrupt
+	// handler. The embedder writes to this channel to request
+	// cancellation of a running query. When no query is running, writes
+	// are silently ignored — the embedder is responsible for shell
+	// lifetime (e.g. closing the input). Mutually exclusive with the
+	// default signal handler: when set, signal.Notify is not called.
+	InterruptCh <-chan struct{}
 }
 
 // internalContext represents the internal configuration state of the

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -66,6 +66,21 @@ type Context struct {
 	// lifetime (e.g. closing the input). Mutually exclusive with the
 	// default signal handler: when set, signal.Notify is not called.
 	InterruptCh <-chan struct{}
+
+	// DisableLocalCmds, if true, causes the shell to refuse the
+	// metacommands that touch the local filesystem or shell out: \!,
+	// \|, \i, \ir, \o, and \e (external editor). Embedders that run
+	// the shell inside a privileged service process must set this:
+	// otherwise any user who opens a session can execute commands
+	// with the service's UID and read or write its filesystem.
+	DisableLocalCmds bool
+
+	// DisablePasswordCmd, if true, causes the shell to refuse the
+	// \password metacommand. \password is harmless on the server side
+	// — it issues a SQL ALTER USER ... WITH PASSWORD statement — but
+	// the password is typed into the shell session, which is not
+	// always desirable in an embedded context.
+	DisablePasswordCmd bool
 }
 
 // internalContext represents the internal configuration state of the

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -67,13 +67,17 @@ type Context struct {
 	// default signal handler: when set, signal.Notify is not called.
 	InterruptCh <-chan struct{}
 
-	// DisableLocalCmds, if true, causes the shell to refuse the
-	// metacommands that touch the local filesystem or shell out: \!,
-	// \|, \i, \ir, \o, and \e (external editor). Embedders that run
-	// the shell inside a privileged service process must set this:
+	// DisableUnsafeCmds, if true, restricts the dispatcher to the
+	// embedder-safe allow-list (see embedderSafeCmds in sql.go).
+	// Commands outside that set are rejected — most importantly the
+	// ones that touch the local filesystem or shell out (\!, \|, \i,
+	// \ir, \o, and \e for the external editor), but the gate is
+	// fail-closed and also rejects any future or unknown metacommand
+	// that has not been explicitly opted in. Embedders that run the
+	// shell inside a privileged service process must set this;
 	// otherwise any user who opens a session can execute commands
 	// with the service's UID and read or write its filesystem.
-	DisableLocalCmds bool
+	DisableUnsafeCmds bool
 
 	// DisablePasswordCmd, if true, causes the shell to refuse the
 	// \password metacommand. \password is harmless on the server side

--- a/pkg/cli/clisqlshell/editor.go
+++ b/pkg/cli/clisqlshell/editor.go
@@ -22,6 +22,7 @@ type editor interface {
 
 type sqlShell interface {
 	enableDebug() bool
+	externalEditorAllowed() bool
 	inCopy() bool
 	runShowCompletions(sql string, offset int) (rows [][]string, err error)
 	serverSideParse(sql string) (string, error)

--- a/pkg/cli/clisqlshell/editor_bubbline.go
+++ b/pkg/cli/clisqlshell/editor_bubbline.go
@@ -40,7 +40,7 @@ func (b *bubblineReader) init(
 	b.ins.Reflow = sqlS.reflow
 	b.ins.AutoComplete = b.getCompletions
 	b.ins.CheckInputComplete = b.checkInputComplete
-	b.ins.SetExternalEditorEnabled(true, "sql")
+	b.ins.SetExternalEditorEnabled(sqlS.externalEditorAllowed(), "sql")
 	b.ins.NextPrompt = "-> "
 
 	// We override the style because at this time we don't know how to

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2455,7 +2455,7 @@ func (c *cliState) configurePreShellDefaults(
 	// all), to prevent abnormal situation where a history runs into
 	// megabytes and starts slowing down the shell.
 	const maxHistEntries = 10000
-	if useEditor {
+	if useEditor && !c.sqlCtx.DisableHistory {
 		homeDir, err := envutil.HomeDir()
 		if err != nil {
 			fmt.Fprintf(c.iCtx.stderr, "warning: cannot retrieve user information: %v\nwarning: history will not be saved\n", err)

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -136,6 +136,28 @@ Commands specific to the demo shell (EXPERIMENTAL):
 	debugPromptPattern = "%n@%M:%> %C>"
 )
 
+// localCmds enumerates the metacommands that touch the local filesystem
+// or shell out. They execute with the shell process's UID and are unsafe
+// to expose when the shell is embedded in a privileged service; see
+// Context.DisableLocalCmds, which uses this set as the source of truth
+// for the dispatcher-level guard.
+//
+// \e (external editor) is reached through the bubbline editor's own
+// keybinding rather than the dispatcher, so it is gated separately in
+// externalEditorAllowed(). \password is gated by Context.DisablePasswordCmd
+// because the concern is different (typing a password into the shell
+// session rather than local execution).
+//
+// When adding a new metacommand that reads or writes the local filesystem
+// or shells out, also add it here.
+var localCmds = map[string]struct{}{
+	`\!`:  {},
+	`\|`:  {},
+	`\i`:  {},
+	`\ir`: {},
+	`\o`:  {},
+}
+
 // cliState defines the current state of the CLI during
 // command-line processing.
 //
@@ -1445,12 +1467,12 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return c.cliError(errState, errors.New(
 			`backslash commands are restricted; only \unrestrict is allowed`))
 	}
-	// Embedder-disabled commands. \e is enforced separately at
-	// editor-init time (see editor_bubbline.go); the cases below
-	// cover the commands that route through this dispatcher.
+	// Embedder-disabled commands. The set of dispatcher-level local
+	// commands is defined by localCmds. \e is enforced separately at
+	// editor-init time (see editor_bubbline.go) since it does not
+	// route through this dispatcher.
 	if c.sqlCtx.DisableLocalCmds {
-		switch cmd[0] {
-		case `\!`, `\|`, `\i`, `\ir`, `\o`:
+		if _, ok := localCmds[cmd[0]]; ok {
 			return c.cliError(errState, errors.Newf(
 				"%s: local command disabled by embedder", cmd[0]))
 		}

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2619,6 +2619,9 @@ func (c *cliState) maybeHandleInterrupt() func() {
 	if !c.cliCtx.IsInteractive {
 		return func() {}
 	}
+	if c.sqlCtx.InterruptCh != nil {
+		return c.handleEmbedderInterrupt()
+	}
 	intCh := make(chan os.Signal, 1)
 	signal.Notify(intCh, os.Interrupt)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2672,6 +2675,62 @@ func (c *cliState) maybeHandleInterrupt() func() {
 
 			case <-ctx.Done():
 				// Shell is terminating.
+				return
+			}
+		}
+	}()
+	return cancel
+}
+
+// handleEmbedderInterrupt is the channel-driven analogue of
+// maybeHandleInterrupt for embedders that supply Context.InterruptCh.
+// It performs no signal-handler manipulation, since the embedder
+// translates network-level cancel events (e.g. an SSH signal request
+// or a 0x03 byte in the input stream) into channel writes itself.
+//
+// A write to the channel cancels any in-flight query. Writes that
+// arrive while no query is running are ignored — the embedder owns
+// the shell's lifetime and terminates it via input closure rather
+// than via a synthesized signal.
+func (c *cliState) handleEmbedderInterrupt() func() {
+	embedderCh := c.sqlCtx.InterruptCh
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-embedderCh:
+				c.iCtx.mu.Lock()
+				cancelFn, doneCh := c.iCtx.mu.cancelFn, c.iCtx.mu.doneCh
+				c.iCtx.mu.Unlock()
+				if cancelFn == nil {
+					// No query currently executing; the interactive
+					// editor handles in-line cancellation itself.
+					continue
+				}
+
+				fmt.Fprintf(c.iCtx.stderr, "\nattempting to cancel query...\n")
+				if err := cancelFn(ctx); err != nil {
+					fmt.Fprintf(c.iCtx.stderr, "\nerror while cancelling query: %v\n", err)
+				}
+
+				// Wait for the shell to process the cancellation, with
+				// the same 3-second timeout the signal path uses. We
+				// don't re-throw — the embedder, not the signal handler,
+				// owns escalation if the server is unresponsive.
+				tooLongTimer := time.After(3 * time.Second)
+			wait:
+				for {
+					select {
+					case <-doneCh:
+						break wait
+					case <-tooLongTimer:
+						fmt.Fprintln(c.iCtx.stderr, "server does not respond to query cancellation.")
+						break wait
+					}
+				}
+
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -136,34 +136,64 @@ Commands specific to the demo shell (EXPERIMENTAL):
 	debugPromptPattern = "%n@%M:%> %C>"
 )
 
-// localCmds enumerates the metacommands that touch the local filesystem
-// or shell out. They execute with the shell process's UID and are unsafe
-// to expose when the shell is embedded in a privileged service; see
-// Context.DisableLocalCmds, which uses this set as the source of truth
-// for the dispatcher-level guard.
+// embedderSafeCmds is the allow-list of metacommands the dispatcher
+// permits when Context.DisableLocalCmds is set. Commands not in the
+// set are rejected; the fail-closed default ensures that a future
+// metacommand that touches the local filesystem or shells out is
+// blocked unless a contributor consciously opts it in.
 //
-// Two related gates live outside this set because they cannot be matched
-// by the dispatcher on cmd[0] alone:
-//   - \e (external editor) is reached through the bubbline editor's own
-//     keybinding rather than the dispatcher, and is gated in
+// The describe family (\d*, \sf, \sv, \l, and \z which is rewritten
+// to \dp) is implicitly allowed by being dispatched to handleDescribe
+// above this gate. Those commands issue server-side SQL queries and
+// would be tedious to enumerate; routing them above the gate keeps
+// the allow-list focused on commands that reach the explicit
+// dispatcher switch.
+//
+// Two adjacent gates handle commands with finer-grained restrictions
+// that cannot be expressed at the dispatcher level:
+//   - \e (external editor) is reached through the bubbline editor's
+//     own keybinding rather than the dispatcher, and is gated in
 //     externalEditorAllowed().
-//   - \statement-diag download writes a bundle file to the local FS but
-//     shares cmd[0] with the safe \statement-diag list; the subcommand
-//     gate lives in handleStatementDiag.
+//   - \statement-diag download writes a bundle file to the local
+//     filesystem, while \statement-diag list is server-side;
+//     \statement-diag is listed here as safe and the dangerous
+//     subcommand is rejected in handleStatementDiag.
 //
-// \password is gated by Context.DisablePasswordCmd because the concern is
-// different (typing a password into the shell session rather than local
-// execution).
+// \password is listed here as safe and gated independently by
+// Context.DisablePasswordCmd; the concern is typing a password into
+// the shell session rather than local execution.
 //
-// When adding a new metacommand that reads or writes the local filesystem
-// or shells out, also add it here (or, for a subcommand of an otherwise
-// safe command, in the command's handler — see handleStatementDiag).
-var localCmds = map[string]struct{}{
-	`\!`:  {},
-	`\|`:  {},
-	`\i`:  {},
-	`\ir`: {},
-	`\o`:  {},
+// When adding a new dispatcher case, add the command here if it is
+// safe to expose to an embedded shell (no local FS, no shell-out),
+// and add a subcommand gate to its handler otherwise.
+var embedderSafeCmds = map[string]struct{}{
+	`\q`:              {},
+	`\quit`:           {},
+	`\exit`:           {},
+	`\`:               {},
+	`\?`:              {},
+	`\help`:           {},
+	`\echo`:           {},
+	`\qecho`:          {},
+	`\set`:            {},
+	`\unset`:          {},
+	`\p`:              {},
+	`\r`:              {},
+	`\s`:              {},
+	`\show`:           {},
+	`\password`:       {},
+	`\h`:              {},
+	`\hf`:             {},
+	`\copy`:           {},
+	`\.`:              {},
+	`\connect`:        {},
+	`\c`:              {},
+	`\info`:           {},
+	`\x`:              {},
+	`\demo`:           {},
+	`\statement-diag`: {},
+	`\restrict`:       {},
+	`\unrestrict`:     {},
 }
 
 // cliState defines the current state of the CLI during
@@ -1475,12 +1505,26 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return c.cliError(errState, errors.New(
 			`backslash commands are restricted; only \unrestrict is allowed`))
 	}
-	// Embedder-disabled commands. The set of dispatcher-level local
-	// commands is defined by localCmds. \e is enforced separately at
-	// editor-init time (see editor_bubbline.go) since it does not
-	// route through this dispatcher.
+	if cmd[0] == `\z` {
+		// psql compatibility.
+		cmd[0] = `\dp`
+	}
+	// The describe family routes here before the DisableLocalCmds
+	// gate below because every command in it issues a server-side
+	// query — implicitly safe for embedders, and impractical to
+	// enumerate explicitly in embedderSafeCmds.
+	if cmd[0] == `\sf` || cmd[0] == `\sf+` ||
+		cmd[0] == `\sv` || cmd[0] == `\sv+` ||
+		cmd[0] == `\l` || cmd[0] == `\l+` ||
+		(strings.HasPrefix(cmd[0], `\d`) && cmd[0] != `\demo`) {
+		return c.handleDescribe(cmd, loopState, errState)
+	}
+	// Embedder allow-list. Commands not in embedderSafeCmds are
+	// rejected when DisableLocalCmds is set; see the comment on
+	// embedderSafeCmds for the rationale and for adjacent gates
+	// (\e, \statement-diag download).
 	if c.sqlCtx.DisableLocalCmds {
-		if _, ok := localCmds[cmd[0]]; ok {
+		if _, ok := embedderSafeCmds[cmd[0]]; !ok {
 			return c.cliError(errState, errors.Newf(
 				"%s: local command disabled by embedder", cmd[0]))
 		}
@@ -1488,16 +1532,6 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 	if c.sqlCtx.DisablePasswordCmd && cmd[0] == `\password` {
 		return c.cliError(errState, errors.New(
 			`\password: disabled by embedder`))
-	}
-	if cmd[0] == `\z` {
-		// psql compatibility.
-		cmd[0] = `\dp`
-	}
-	if cmd[0] == `\sf` || cmd[0] == `\sf+` ||
-		cmd[0] == `\sv` || cmd[0] == `\sv+` ||
-		cmd[0] == `\l` || cmd[0] == `\l+` ||
-		(strings.HasPrefix(cmd[0], `\d`) && cmd[0] != `\demo`) {
-		return c.handleDescribe(cmd, loopState, errState)
 	}
 
 	switch cmd[0] {

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2740,8 +2740,13 @@ func (c *cliState) maybeHandleInterrupt() func() {
 func (c *cliState) handleEmbedderInterrupt() func() {
 	embedderCh := c.sqlCtx.InterruptCh
 	ctx, cancel := context.WithCancel(context.Background())
+	// done is closed when the goroutine exits; the returned cleanup
+	// function blocks on it so the embedder knows the goroutine is
+	// fully torn down on return.
+	done := make(chan struct{})
 
 	go func() {
+		defer close(done)
 		for {
 			select {
 			case <-embedderCh:
@@ -2762,7 +2767,10 @@ func (c *cliState) handleEmbedderInterrupt() func() {
 				// Wait for the shell to process the cancellation, with
 				// the same 3-second timeout the signal path uses. We
 				// don't re-throw — the embedder, not the signal handler,
-				// owns escalation if the server is unresponsive.
+				// owns escalation if the server is unresponsive. If the
+				// embedder tears the shell down during the wait, ctx.Done
+				// short-circuits us so the goroutine exits promptly
+				// instead of blocking for the full timeout.
 				tooLongTimer := time.After(3 * time.Second)
 			wait:
 				for {
@@ -2772,6 +2780,8 @@ func (c *cliState) handleEmbedderInterrupt() func() {
 					case <-tooLongTimer:
 						fmt.Fprintln(c.iCtx.stderr, "server does not respond to query cancellation.")
 						break wait
+					case <-ctx.Done():
+						return
 					}
 				}
 
@@ -2780,7 +2790,10 @@ func (c *cliState) handleEmbedderInterrupt() func() {
 			}
 		}
 	}()
-	return cancel
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 func (c *cliState) runWithInterruptableCtx(fn func(ctx context.Context) error) error {

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -142,14 +142,22 @@ Commands specific to the demo shell (EXPERIMENTAL):
 // Context.DisableLocalCmds, which uses this set as the source of truth
 // for the dispatcher-level guard.
 //
-// \e (external editor) is reached through the bubbline editor's own
-// keybinding rather than the dispatcher, so it is gated separately in
-// externalEditorAllowed(). \password is gated by Context.DisablePasswordCmd
-// because the concern is different (typing a password into the shell
-// session rather than local execution).
+// Two related gates live outside this set because they cannot be matched
+// by the dispatcher on cmd[0] alone:
+//   - \e (external editor) is reached through the bubbline editor's own
+//     keybinding rather than the dispatcher, and is gated in
+//     externalEditorAllowed().
+//   - \statement-diag download writes a bundle file to the local FS but
+//     shares cmd[0] with the safe \statement-diag list; the subcommand
+//     gate lives in handleStatementDiag.
+//
+// \password is gated by Context.DisablePasswordCmd because the concern is
+// different (typing a password into the shell session rather than local
+// execution).
 //
 // When adding a new metacommand that reads or writes the local filesystem
-// or shells out, also add it here.
+// or shells out, also add it here (or, for a subcommand of an otherwise
+// safe command, in the command's handler — see handleStatementDiag).
 var localCmds = map[string]struct{}{
 	`\!`:  {},
 	`\|`:  {},

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1445,6 +1445,20 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return c.cliError(errState, errors.New(
 			`backslash commands are restricted; only \unrestrict is allowed`))
 	}
+	// Embedder-disabled commands. \e is enforced separately at
+	// editor-init time (see editor_bubbline.go); the cases below
+	// cover the commands that route through this dispatcher.
+	if c.sqlCtx.DisableLocalCmds {
+		switch cmd[0] {
+		case `\!`, `\|`, `\i`, `\ir`, `\o`:
+			return c.cliError(errState, errors.Newf(
+				"%s: local command disabled by embedder", cmd[0]))
+		}
+	}
+	if c.sqlCtx.DisablePasswordCmd && cmd[0] == `\password` {
+		return c.cliError(errState, errors.New(
+			`\password: disabled by embedder`))
+	}
 	if cmd[0] == `\z` {
 		// psql compatibility.
 		cmd[0] = `\dp`
@@ -2547,6 +2561,15 @@ func (c *cliState) runStatements(stmts []string) error {
 // enableDebug implements the sqlShell interface (to support the editor).
 func (c *cliState) enableDebug() bool {
 	return c.sqlConnCtx.DebugMode
+}
+
+// externalEditorAllowed implements the sqlShell interface. The bubbline
+// editor's \e command launches an external editor (vi/nano/etc) on the
+// current input buffer, which is a shell-out; the embedder disables it
+// via Context.DisableLocalCmds in the same way as the dispatcher-level
+// \! and \i guards.
+func (c *cliState) externalEditorAllowed() bool {
+	return !c.sqlCtx.DisableLocalCmds
 }
 
 // serverSideParse implements the sqlShell interface (to support the editor).

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -136,6 +136,98 @@ Commands specific to the demo shell (EXPERIMENTAL):
 	debugPromptPattern = "%n@%M:%> %C>"
 )
 
+// Backslash metacommand names dispatched by doHandleCliCmd. Centralized
+// here so the dispatcher switch, the embedderSafeCmds allow-list, the
+// describe-family dispatch, and the various inline guards reference the
+// same literal. A typo in any of those sites now produces a compile
+// error instead of a silent dispatch miss.
+const (
+	// Quit aliases.
+	cmdQ    = `\q`
+	cmdQuit = `\quit`
+	cmdExit = `\exit`
+
+	// Help aliases.
+	cmdHelpBackslash = `\`
+	cmdHelpQ         = `\?`
+	cmdHelp          = `\help`
+
+	// Output.
+	cmdEcho   = `\echo`
+	cmdQEcho  = `\qecho`
+	cmdOutput = `\o`
+
+	// Configuration.
+	cmdSet   = `\set`
+	cmdUnset = `\unset`
+
+	// Local filesystem / shell-out. These are the commands gated by
+	// the embedder allow-list (see embedderSafeCmds); they are absent
+	// from that set on purpose.
+	cmdShellOut   = `\!`
+	cmdPipe       = `\|`
+	cmdInclude    = `\i`
+	cmdIncludeRel = `\ir`
+
+	// Query buffer.
+	cmdPrint = `\p`
+	cmdReset = `\r`
+	cmdShow  = `\show`
+
+	// History.
+	cmdHistory = `\s`
+
+	// User management.
+	cmdPassword = `\password`
+
+	// SQL help.
+	cmdHelpSQL  = `\h`
+	cmdHelpFunc = `\hf`
+
+	// Copy.
+	cmdCopy    = `\copy`
+	cmdCopyEnd = `\.`
+
+	// Connection.
+	cmdConnect      = `\connect`
+	cmdConnectShort = `\c`
+	cmdInfo         = `\info`
+
+	// Display format.
+	cmdExpanded = `\x`
+
+	// Demo cluster.
+	cmdDemo = `\demo`
+
+	// Statement diagnostics.
+	cmdStmtDiag = `\statement-diag`
+
+	// Restricted mode (CVE-2025-8714).
+	cmdRestrict   = `\restrict`
+	cmdUnrestrict = `\unrestrict`
+
+	// Describe family. Dispatched to handleDescribe before the
+	// embedder allow-list gate; not enumerated in embedderSafeCmds.
+	// cmdDescribePrefix is both the bare `\d` command and the prefix
+	// for the `\d*` sub-family (`\dt`, `\du`, etc.); see
+	// handleDescribe.
+	cmdShowFunc          = `\sf`
+	cmdShowFuncPlus      = `\sf+`
+	cmdShowView          = `\sv`
+	cmdShowViewPlus      = `\sv+`
+	cmdListDatabases     = `\l`
+	cmdListDatabasesPlus = `\l+`
+	cmdDescribePrefix    = `\d`
+	cmdPrivileges        = `\dp`
+	cmdZ                 = `\z` // psql compat; rewritten to cmdPrivileges
+)
+
+// Subcommand tags for \statement-diag.
+const (
+	stmtDiagDownload = "download"
+	stmtDiagList     = "list"
+)
+
 // embedderSafeCmds is the allow-list of metacommands the dispatcher
 // permits when Context.DisableLocalCmds is set. Commands not in the
 // set are rejected; the fail-closed default ensures that a future
@@ -167,33 +259,33 @@ Commands specific to the demo shell (EXPERIMENTAL):
 // safe to expose to an embedded shell (no local FS, no shell-out),
 // and add a subcommand gate to its handler otherwise.
 var embedderSafeCmds = map[string]struct{}{
-	`\q`:              {},
-	`\quit`:           {},
-	`\exit`:           {},
-	`\`:               {},
-	`\?`:              {},
-	`\help`:           {},
-	`\echo`:           {},
-	`\qecho`:          {},
-	`\set`:            {},
-	`\unset`:          {},
-	`\p`:              {},
-	`\r`:              {},
-	`\s`:              {},
-	`\show`:           {},
-	`\password`:       {},
-	`\h`:              {},
-	`\hf`:             {},
-	`\copy`:           {},
-	`\.`:              {},
-	`\connect`:        {},
-	`\c`:              {},
-	`\info`:           {},
-	`\x`:              {},
-	`\demo`:           {},
-	`\statement-diag`: {},
-	`\restrict`:       {},
-	`\unrestrict`:     {},
+	cmdQ:             {},
+	cmdQuit:          {},
+	cmdExit:          {},
+	cmdHelpBackslash: {},
+	cmdHelpQ:         {},
+	cmdHelp:          {},
+	cmdEcho:          {},
+	cmdQEcho:         {},
+	cmdSet:           {},
+	cmdUnset:         {},
+	cmdPrint:         {},
+	cmdReset:         {},
+	cmdHistory:       {},
+	cmdShow:          {},
+	cmdPassword:      {},
+	cmdHelpSQL:       {},
+	cmdHelpFunc:      {},
+	cmdCopy:          {},
+	cmdCopyEnd:       {},
+	cmdConnect:       {},
+	cmdConnectShort:  {},
+	cmdInfo:          {},
+	cmdExpanded:      {},
+	cmdDemo:          {},
+	cmdStmtDiag:      {},
+	cmdRestrict:      {},
+	cmdUnrestrict:    {},
 }
 
 // cliState defines the current state of the CLI during
@@ -741,10 +833,10 @@ func isEndOfStatement(lastTok int) bool {
 // rejected by the dispatcher in doHandleCliCmd.
 func (c *cliState) handleRestrict(args []string, nextState, errState cliStateEnum) cliStateEnum {
 	if len(args) != 1 || args[0] == "" {
-		return c.cliError(errState, errors.New(`\restrict: missing required argument`))
+		return c.cliError(errState, errors.Newf("%s: missing required argument", cmdRestrict))
 	}
 	if c.iCtx.restricted {
-		return c.cliError(errState, errors.New(`\restrict: already in restricted mode`))
+		return c.cliError(errState, errors.Newf("%s: already in restricted mode", cmdRestrict))
 	}
 	c.iCtx.restrictKey = args[0]
 	c.iCtx.restricted = true
@@ -755,13 +847,13 @@ func (c *cliState) handleRestrict(args []string, nextState, errState cliStateEnu
 // restricted mode if the supplied key matches the key passed to \restrict.
 func (c *cliState) handleUnrestrict(args []string, nextState, errState cliStateEnum) cliStateEnum {
 	if len(args) != 1 || args[0] == "" {
-		return c.cliError(errState, errors.New(`\unrestrict: missing required argument`))
+		return c.cliError(errState, errors.Newf("%s: missing required argument", cmdUnrestrict))
 	}
 	if !c.iCtx.restricted {
-		return c.cliError(errState, errors.New(`\unrestrict: not currently in restricted mode`))
+		return c.cliError(errState, errors.Newf("%s: not currently in restricted mode", cmdUnrestrict))
 	}
 	if args[0] != c.iCtx.restrictKey {
-		return c.cliError(errState, errors.New(`\unrestrict: wrong key`))
+		return c.cliError(errState, errors.Newf("%s: wrong key", cmdUnrestrict))
 	}
 	c.iCtx.restrictKey = ""
 	c.iCtx.restricted = false
@@ -773,7 +865,7 @@ func (c *cliState) handleUnrestrict(args []string, nextState, errState cliStateE
 func (c *cliState) handleDemo(cmd []string, nextState, errState cliStateEnum) cliStateEnum {
 	// A demo cluster signifies the presence of `cockroach demo`.
 	if c.sqlCtx.DemoCluster == nil {
-		return c.cliError(errState, errors.New(`\demo can only be run with cockroach demo`))
+		return c.cliError(errState, errors.Newf("%s can only be run with cockroach demo", cmdDemo))
 	}
 
 	// The \demo command has one of three patterns:
@@ -1501,22 +1593,22 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 	// In restricted mode, only \unrestrict is permitted. This blocks
 	// metacommands that may have been injected via dump output before they
 	// reach the dispatcher below. See internalContext.restricted.
-	if c.iCtx.restricted && cmd[0] != `\unrestrict` {
-		return c.cliError(errState, errors.New(
-			`backslash commands are restricted; only \unrestrict is allowed`))
+	if c.iCtx.restricted && cmd[0] != cmdUnrestrict {
+		return c.cliError(errState, errors.Newf(
+			"backslash commands are restricted; only %s is allowed", cmdUnrestrict))
 	}
-	if cmd[0] == `\z` {
+	if cmd[0] == cmdZ {
 		// psql compatibility.
-		cmd[0] = `\dp`
+		cmd[0] = cmdPrivileges
 	}
 	// The describe family routes here before the DisableLocalCmds
 	// gate below because every command in it issues a server-side
 	// query — implicitly safe for embedders, and impractical to
 	// enumerate explicitly in embedderSafeCmds.
-	if cmd[0] == `\sf` || cmd[0] == `\sf+` ||
-		cmd[0] == `\sv` || cmd[0] == `\sv+` ||
-		cmd[0] == `\l` || cmd[0] == `\l+` ||
-		(strings.HasPrefix(cmd[0], `\d`) && cmd[0] != `\demo`) {
+	if cmd[0] == cmdShowFunc || cmd[0] == cmdShowFuncPlus ||
+		cmd[0] == cmdShowView || cmd[0] == cmdShowViewPlus ||
+		cmd[0] == cmdListDatabases || cmd[0] == cmdListDatabasesPlus ||
+		(strings.HasPrefix(cmd[0], cmdDescribePrefix) && cmd[0] != cmdDemo) {
 		return c.handleDescribe(cmd, loopState, errState)
 	}
 	// Embedder allow-list. Commands not in embedderSafeCmds are
@@ -1529,72 +1621,72 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 				"%s: local command disabled by embedder", cmd[0]))
 		}
 	}
-	if c.sqlCtx.DisablePasswordCmd && cmd[0] == `\password` {
-		return c.cliError(errState, errors.New(
-			`\password: disabled by embedder`))
+	if c.sqlCtx.DisablePasswordCmd && cmd[0] == cmdPassword {
+		return c.cliError(errState, errors.Newf(
+			"%s: disabled by embedder", cmdPassword))
 	}
 
 	switch cmd[0] {
-	case `\q`, `\quit`, `\exit`:
+	case cmdQ, cmdQuit, cmdExit:
 		// When explicitly exiting, clear exitErr.
 		c.exitErr = nil
 		return cliStop
 
-	case `\`, `\?`, `\help`:
+	case cmdHelpBackslash, cmdHelpQ, cmdHelp:
 		c.printCliHelp()
 
-	case `\echo`:
+	case cmdEcho:
 		fmt.Fprintln(c.iCtx.stdout, strings.Join(cmd[1:], " "))
 
-	case `\qecho`:
+	case cmdQEcho:
 		fmt.Fprintln(c.iCtx.queryOutput, strings.Join(cmd[1:], " "))
 		c.maybeFlushOutput()
 
-	case `\set`:
+	case cmdSet:
 		return c.handleSet(line, cmd[1:], loopState, errState)
 
-	case `\unset`:
+	case cmdUnset:
 		return c.handleUnset(cmd[1:], loopState, errState)
 
-	case `\!`:
+	case cmdShellOut:
 		return c.runSyscmd(c.lastInputLine, loopState, errState)
 
-	case `\i`:
+	case cmdInclude:
 		return c.runInclude(cmd[1:], loopState, errState, false /* relative */)
 
-	case `\ir`:
+	case cmdIncludeRel:
 		return c.runInclude(cmd[1:], loopState, errState, true /* relative */)
 
-	case `\o`:
+	case cmdOutput:
 		return c.runOpen(cmd[1:], loopState, errState)
 
-	case `\p`:
+	case cmdPrint:
 		if c.ins.multilineEdit() {
-			fmt.Fprintln(c.iCtx.stderr, `warning: \p is ineffective with this editor`)
+			fmt.Fprintf(c.iCtx.stderr, "warning: %s is ineffective with this editor\n", cmdPrint)
 			break
 		}
 		// This is analogous to \show but does not need a special case.
 		// Implemented for compatibility with psql.
 		fmt.Fprintln(c.iCtx.stdout, strings.Join(c.partialLines, "\n"))
 
-	case `\r`:
+	case cmdReset:
 		if c.ins.multilineEdit() {
-			fmt.Fprintln(c.iCtx.stderr, `warning: \r is ineffective with this editor`)
+			fmt.Fprintf(c.iCtx.stderr, "warning: %s is ineffective with this editor\n", cmdReset)
 			break
 		}
 		// Reset the input buffer so far. This is useful when e.g. a user
 		// got confused with string delimiters and multi-line input.
 		return cliStartLine
 
-	case `\s`:
+	case cmdHistory:
 		c.printCommandHistory()
 
-	case `\show`:
+	case cmdShow:
 		if c.ins.multilineEdit() {
-			fmt.Fprintln(c.iCtx.stderr, `warning: \show is ineffective with this editor`)
+			fmt.Fprintf(c.iCtx.stderr, "warning: %s is ineffective with this editor\n", cmdShow)
 			break
 		}
-		fmt.Fprintln(c.iCtx.stderr, `warning: \show is deprecated. Use \p.`)
+		fmt.Fprintf(c.iCtx.stderr, "warning: %s is deprecated. Use %s.\n", cmdShow, cmdPrint)
 		if len(c.partialLines) == 0 {
 			fmt.Fprintf(c.iCtx.stderr, "No input so far. Did you mean SHOW?\n")
 		} else {
@@ -1603,16 +1695,16 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 			}
 		}
 
-	case `\password`:
+	case cmdPassword:
 		return c.handlePassword(cmd[1:], cliRunStatement, errState)
 
-	case `\|`:
+	case cmdPipe:
 		return c.pipeSyscmd(c.lastInputLine, nextState, errState)
 
-	case `\h`:
+	case cmdHelpSQL:
 		return c.handleHelp(cmd[1:], loopState, errState)
 
-	case `\hf`:
+	case cmdHelpFunc:
 		if len(cmd) == 1 {
 			// The following query lists all functions. It prefixes
 			// functions with their schema but only if the schema is not in
@@ -1634,7 +1726,7 @@ ORDER BY 1`
 		}
 		return c.handleFunctionHelp(cmd[1:], loopState, errState)
 
-	case `\copy`:
+	case cmdCopy:
 		if err := c.runWithInterruptableCtx(func(ctx context.Context) error {
 			// Strip out the starting \ in \copy.
 			return c.beginCopyFrom(ctx, line[1:])
@@ -1643,21 +1735,21 @@ ORDER BY 1`
 		}
 		return cliStartLine
 
-	case `\.`:
+	case cmdCopyEnd:
 		if c.inCopy() {
-			c.partialLines = append(c.partialLines, `\.`)
+			c.partialLines = append(c.partialLines, cmdCopyEnd)
 			c.partialStmtsLen++
 			return cliRunStatement
 		}
 		return c.invalidSyntax(errState)
 
-	case `\connect`, `\c`:
+	case cmdConnect, cmdConnectShort:
 		return c.handleConnect(cmd[1:], loopState, errState)
 
-	case `\info`:
+	case cmdInfo:
 		return c.handleInfo(loopState)
 
-	case `\x`:
+	case cmdExpanded:
 		format := clisqlexec.TableDisplayRecords
 		switch len(cmd) {
 		case 1:
@@ -1679,16 +1771,16 @@ ORDER BY 1`
 		c.sqlExecCtx.TableDisplayFormat = format
 		return loopState
 
-	case `\demo`:
+	case cmdDemo:
 		return c.handleDemo(cmd[1:], loopState, errState)
 
-	case `\statement-diag`:
+	case cmdStmtDiag:
 		return c.handleStatementDiag(cmd[1:], loopState, errState)
 
-	case `\restrict`:
+	case cmdRestrict:
 		return c.handleRestrict(cmd[1:], loopState, errState)
 
-	case `\unrestrict`:
+	case cmdUnrestrict:
 		return c.handleUnrestrict(cmd[1:], loopState, errState)
 
 	default:
@@ -1982,7 +2074,7 @@ func (c *cliState) runInclude(
 	}
 
 	if c.levels >= maxRecursionLevels {
-		return c.cliError(errState, errors.Newf(`\i: too many recursion levels (max %d)`, maxRecursionLevels))
+		return c.cliError(errState, errors.Newf("%s: too many recursion levels (max %d)", cmdInclude, maxRecursionLevels))
 	}
 
 	if len(c.partialLines) > 0 {
@@ -2090,7 +2182,7 @@ func (c *cliState) doPrepareStatementLine(
 	endOfStmt := (!c.inCopy() && isEndOfStatement(lastTok)) ||
 		// We're always at the end of a statement if we're in COPY and encounter
 		// the \. or EOF character.
-		(c.inCopy() && (strings.HasSuffix(c.concatLines, "\n"+`\.`) || c.atEOF)) ||
+		(c.inCopy() && (strings.HasSuffix(c.concatLines, "\n"+cmdCopyEnd) || c.atEOF)) ||
 		// We're always at the end of a statement if EOF is reached in the
 		// single statement mode.
 		(c.singleStatement && c.atEOF)
@@ -2565,7 +2657,7 @@ func (c *cliState) configurePreShellDefaults(
 	if len(c.sqlCtx.SetStmts) > 0 {
 		setStmts := make([]string, 0, len(c.sqlCtx.SetStmts)+len(c.sqlCtx.ExecStmts))
 		for _, s := range c.sqlCtx.SetStmts {
-			setStmts = append(setStmts, `\set `+s)
+			setStmts = append(setStmts, cmdSet+" "+s)
 		}
 		c.sqlCtx.SetStmts = nil
 		c.sqlCtx.ExecStmts = append(setStmts, c.sqlCtx.ExecStmts...)

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -161,9 +161,9 @@ const (
 	cmdSet   = `\set`
 	cmdUnset = `\unset`
 
-	// Local filesystem / shell-out. These are the commands gated by
-	// the embedder allow-list (see embedderSafeCmds); they are absent
-	// from that set on purpose.
+	// Local filesystem / shell-out commands. These are the canonical
+	// reason DisableUnsafeCmds exists: they are deliberately absent
+	// from embedderSafeCmds so the allow-list gate rejects them.
 	cmdShellOut   = `\!`
 	cmdPipe       = `\|`
 	cmdInclude    = `\i`
@@ -229,7 +229,7 @@ const (
 )
 
 // embedderSafeCmds is the allow-list of metacommands the dispatcher
-// permits when Context.DisableLocalCmds is set. Commands not in the
+// permits when Context.DisableUnsafeCmds is set. Commands not in the
 // set are rejected; the fail-closed default ensures that a future
 // metacommand that touches the local filesystem or shells out is
 // blocked unless a contributor consciously opts it in.
@@ -1601,7 +1601,7 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		// psql compatibility.
 		cmd[0] = cmdPrivileges
 	}
-	// The describe family routes here before the DisableLocalCmds
+	// The describe family routes here before the DisableUnsafeCmds
 	// gate below because every command in it issues a server-side
 	// query — implicitly safe for embedders, and impractical to
 	// enumerate explicitly in embedderSafeCmds.
@@ -1612,13 +1612,13 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 		return c.handleDescribe(cmd, loopState, errState)
 	}
 	// Embedder allow-list. Commands not in embedderSafeCmds are
-	// rejected when DisableLocalCmds is set; see the comment on
+	// rejected when DisableUnsafeCmds is set; see the comment on
 	// embedderSafeCmds for the rationale and for adjacent gates
 	// (\e, \statement-diag download).
-	if c.sqlCtx.DisableLocalCmds {
+	if c.sqlCtx.DisableUnsafeCmds {
 		if _, ok := embedderSafeCmds[cmd[0]]; !ok {
 			return c.cliError(errState, errors.Newf(
-				"%s: local command disabled by embedder", cmd[0]))
+				"%s: command disabled by embedder", cmd[0]))
 		}
 	}
 	if c.sqlCtx.DisablePasswordCmd && cmd[0] == cmdPassword {
@@ -2722,10 +2722,10 @@ func (c *cliState) enableDebug() bool {
 // externalEditorAllowed implements the sqlShell interface. The bubbline
 // editor's \e command launches an external editor (vi/nano/etc) on the
 // current input buffer, which is a shell-out; the embedder disables it
-// via Context.DisableLocalCmds in the same way as the dispatcher-level
+// via Context.DisableUnsafeCmds in the same way as the dispatcher-level
 // \! and \i guards.
 func (c *cliState) externalEditorAllowed() bool {
-	return !c.sqlCtx.DisableLocalCmds
+	return !c.sqlCtx.DisableUnsafeCmds
 }
 
 // serverSideParse implements the sqlShell interface (to support the editor).

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsEndOfStatement(t *testing.T) {
@@ -186,4 +187,26 @@ func TestGetSetArgs(t *testing.T) {
 				ok, option, hasValue, value)
 		}
 	}
+}
+
+func TestDisableHistory(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := setupTestCliState()
+	c.cliCtx.IsInteractive = true
+	c.sqlCtx.DisableHistory = true
+
+	// configurePreShellDefaults needs *os.File for in/out/err but does
+	// not read from them in this code path; a fresh pipe is sufficient.
+	rIn, wIn, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = rIn.Close(); _ = wIn.Close() }()
+
+	cleanup, err := c.configurePreShellDefaults(rIn, os.Stdout, os.Stderr)
+	require.NoError(t, err)
+	defer cleanup()
+
+	assert.Empty(t, c.iCtx.histFile,
+		"DisableHistory=true should leave histFile unset")
 }

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -7,8 +7,10 @@ package clisqlshell
 
 import (
 	"bufio"
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cli/clicfg"
 	"github.com/cockroachdb/cockroach/pkg/cli/clisqlclient"
@@ -209,4 +211,60 @@ func TestDisableHistory(t *testing.T) {
 
 	assert.Empty(t, c.iCtx.histFile,
 		"DisableHistory=true should leave histFile unset")
+}
+
+func TestHandleEmbedderInterrupt(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := setupTestCliState()
+	c.cliCtx.IsInteractive = true
+	c.iCtx.stderr = os.Stderr // handleEmbedderInterrupt writes status here
+
+	interruptCh := make(chan struct{}, 1)
+	c.sqlCtx.InterruptCh = interruptCh
+
+	// Simulate a query in flight: cancelFn signals it was called;
+	// doneCh releases the wait loop afterwards.
+	cancelCalled := make(chan struct{}, 1)
+	doneCh := make(chan struct{})
+	c.iCtx.mu.cancelFn = func(context.Context) error {
+		cancelCalled <- struct{}{}
+		return nil
+	}
+	c.iCtx.mu.doneCh = doneCh
+
+	finalFn := c.maybeHandleInterrupt()
+	defer finalFn()
+
+	interruptCh <- struct{}{}
+	select {
+	case <-cancelCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelFn was not invoked after InterruptCh write")
+	}
+	// Release the inner wait loop so the goroutine returns to its outer
+	// select; finalFn() in the defer then exits the goroutine cleanly.
+	close(doneCh)
+}
+
+func TestHandleEmbedderInterruptIgnoresIdle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := setupTestCliState()
+	c.cliCtx.IsInteractive = true
+	c.iCtx.stderr = os.Stderr
+	interruptCh := make(chan struct{}, 1)
+	c.sqlCtx.InterruptCh = interruptCh
+	// No cancelFn set: simulates "no query running".
+
+	finalFn := c.maybeHandleInterrupt()
+	defer finalFn()
+
+	// A write must be silently dropped and not block subsequent writes.
+	interruptCh <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
+	interruptCh <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
 }

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -248,6 +248,51 @@ func TestHandleEmbedderInterrupt(t *testing.T) {
 	close(doneCh)
 }
 
+func TestHandleEmbedderInterruptExitsDuringWait(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := setupTestCliState()
+	c.cliCtx.IsInteractive = true
+	c.iCtx.stderr = os.Stderr
+	interruptCh := make(chan struct{}, 1)
+	c.sqlCtx.InterruptCh = interruptCh
+
+	// Simulate a query whose cancellation never resolves: cancelFn
+	// runs but doneCh stays open. Without ctx.Done() in the inner
+	// wait loop the goroutine would block for the full 3-second
+	// timeout before observing the embedder's teardown.
+	cancelCalled := make(chan struct{}, 1)
+	doneCh := make(chan struct{})
+	c.iCtx.mu.cancelFn = func(context.Context) error {
+		cancelCalled <- struct{}{}
+		return nil
+	}
+	c.iCtx.mu.doneCh = doneCh
+
+	finalFn := c.maybeHandleInterrupt()
+
+	interruptCh <- struct{}{}
+	select {
+	case <-cancelCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelFn was not invoked after InterruptCh write")
+	}
+
+	// finalFn blocks on goroutine exit; it must return well under the
+	// 3-second wait-loop timeout.
+	returned := make(chan struct{})
+	go func() {
+		finalFn()
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("finalFn did not return promptly after embedder teardown")
+	}
+}
+
 func TestHandleEmbedderInterruptIgnoresIdle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -318,7 +318,17 @@ func TestDisableLocalCmds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	blocked := []string{`\!`, `\| sort`, `\i file.sql`, `\ir file.sql`, `\o output`}
+	blocked := []string{
+		`\!`,
+		`\| sort`,
+		`\i file.sql`,
+		`\ir file.sql`,
+		`\o output`,
+		// \statement-diag download writes a zip to the local FS via a
+		// gate inside handleStatementDiag; \statement-diag list stays
+		// enabled because it only issues a server-side query.
+		`\statement-diag download 42`,
+	}
 	for _, line := range blocked {
 		c := setupTestCliState()
 		c.sqlCtx.DisableLocalCmds = true

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -268,3 +268,30 @@ func TestHandleEmbedderInterruptIgnoresIdle(t *testing.T) {
 	interruptCh <- struct{}{}
 	time.Sleep(50 * time.Millisecond)
 }
+
+func TestDisableLocalCmds(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	blocked := []string{`\!`, `\| sort`, `\i file.sql`, `\ir file.sql`, `\o output`}
+	for _, line := range blocked {
+		c := setupTestCliState()
+		c.sqlCtx.DisableLocalCmds = true
+		c.lastInputLine = line
+		c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
+		require.Errorf(t, c.exitErr, "input %q", line)
+		assert.Containsf(t, c.exitErr.Error(), "disabled by embedder", "input %q", line)
+	}
+}
+
+func TestDisablePasswordCmd(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	c := setupTestCliState()
+	c.sqlCtx.DisablePasswordCmd = true
+	c.lastInputLine = `\password`
+	c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
+	require.Error(t, c.exitErr)
+	assert.Contains(t, c.exitErr.Error(), "disabled by embedder")
+}

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -328,6 +328,12 @@ func TestDisableLocalCmds(t *testing.T) {
 		// gate inside handleStatementDiag; \statement-diag list stays
 		// enabled because it only issues a server-side query.
 		`\statement-diag download 42`,
+		// Unknown commands are rejected by the allow-list rather than
+		// falling through to the default "invalid syntax" path. This
+		// is the fail-closed property: a future metacommand that
+		// touches the local FS is blocked until it is added to
+		// embedderSafeCmds.
+		`\unknown-future-command`,
 	}
 	for _, line := range blocked {
 		c := setupTestCliState()
@@ -336,6 +342,24 @@ func TestDisableLocalCmds(t *testing.T) {
 		c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
 		require.Errorf(t, c.exitErr, "input %q", line)
 		assert.Containsf(t, c.exitErr.Error(), "disabled by embedder", "input %q", line)
+	}
+
+	// Positive control: \echo is in embedderSafeCmds and does not
+	// require a conn, so it must run cleanly under DisableLocalCmds.
+	c := setupTestCliState()
+	c.sqlCtx.DisableLocalCmds = true
+	c.lastInputLine = `\echo hi`
+	c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
+	require.NoError(t, c.exitErr, "\\echo must be allowed under DisableLocalCmds")
+
+	// Describe-family commands route to handleDescribe above the
+	// allow-list gate. They are not in embedderSafeCmds because the
+	// gate doesn't see them; putting them in the set would suggest
+	// duplicated logic and could mask future routing bugs.
+	for _, line := range []string{`\d`, `\dt`, `\dT+`, `\du`, `\dv`, `\sf`, `\sv`, `\l`} {
+		_, present := embedderSafeCmds[line]
+		assert.False(t, present,
+			"%s is dispatched to handleDescribe; it should not appear in embedderSafeCmds", line)
 	}
 }
 

--- a/pkg/cli/clisqlshell/sql_internal_test.go
+++ b/pkg/cli/clisqlshell/sql_internal_test.go
@@ -314,7 +314,7 @@ func TestHandleEmbedderInterruptIgnoresIdle(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
-func TestDisableLocalCmds(t *testing.T) {
+func TestDisableUnsafeCmds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -337,7 +337,7 @@ func TestDisableLocalCmds(t *testing.T) {
 	}
 	for _, line := range blocked {
 		c := setupTestCliState()
-		c.sqlCtx.DisableLocalCmds = true
+		c.sqlCtx.DisableUnsafeCmds = true
 		c.lastInputLine = line
 		c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
 		require.Errorf(t, c.exitErr, "input %q", line)
@@ -345,12 +345,12 @@ func TestDisableLocalCmds(t *testing.T) {
 	}
 
 	// Positive control: \echo is in embedderSafeCmds and does not
-	// require a conn, so it must run cleanly under DisableLocalCmds.
+	// require a conn, so it must run cleanly under DisableUnsafeCmds.
 	c := setupTestCliState()
-	c.sqlCtx.DisableLocalCmds = true
+	c.sqlCtx.DisableUnsafeCmds = true
 	c.lastInputLine = `\echo hi`
 	c.doHandleCliCmd(cliStateEnum(0), cliStateEnum(1))
-	require.NoError(t, c.exitErr, "\\echo must be allowed under DisableLocalCmds")
+	require.NoError(t, c.exitErr, "\\echo must be allowed under DisableUnsafeCmds")
 
 	// Describe-family commands route to handleDescribe above the
 	// allow-list gate. They are not in embedderSafeCmds because the

--- a/pkg/cli/clisqlshell/statement_diag.go
+++ b/pkg/cli/clisqlshell/statement_diag.go
@@ -29,22 +29,22 @@ func (c *cliState) handleStatementDiag(
 	// filesystem with the shell process's UID, so it must be gated by
 	// DisableLocalCmds. `list` only issues a server-side query and
 	// remains enabled. The dispatcher cannot reject this from
-	// localCmds because the dangerous subcommand is in args[0], not
-	// cmd[0].
-	if c.sqlCtx.DisableLocalCmds && cmd == "download" {
-		return c.cliError(errState, errors.New(
-			`\statement-diag download: local command disabled by embedder`))
+	// embedderSafeCmds because the dangerous subcommand is in
+	// args[0], not cmd[0].
+	if c.sqlCtx.DisableLocalCmds && cmd == stmtDiagDownload {
+		return c.cliError(errState, errors.Newf(
+			"%s %s: local command disabled by embedder", cmdStmtDiag, stmtDiagDownload))
 	}
 	defer c.conn.AllowExecuteInternal(context.Background())()
 	var cmdErr error
 	switch cmd {
-	case "list":
+	case stmtDiagList:
 		if len(args) > 0 {
 			return c.invalidSyntax(errState)
 		}
 		cmdErr = c.statementDiagList()
 
-	case "download":
+	case stmtDiagDownload:
 		if len(args) < 1 || len(args) > 2 {
 			return c.invalidSyntax(errState)
 		}

--- a/pkg/cli/clisqlshell/statement_diag.go
+++ b/pkg/cli/clisqlshell/statement_diag.go
@@ -25,6 +25,16 @@ func (c *cliState) handleStatementDiag(
 		cmd = args[0]
 		args = args[1:]
 	}
+	// `\statement-diag download` writes a zip file to the local
+	// filesystem with the shell process's UID, so it must be gated by
+	// DisableLocalCmds. `list` only issues a server-side query and
+	// remains enabled. The dispatcher cannot reject this from
+	// localCmds because the dangerous subcommand is in args[0], not
+	// cmd[0].
+	if c.sqlCtx.DisableLocalCmds && cmd == "download" {
+		return c.cliError(errState, errors.New(
+			`\statement-diag download: local command disabled by embedder`))
+	}
 	defer c.conn.AllowExecuteInternal(context.Background())()
 	var cmdErr error
 	switch cmd {

--- a/pkg/cli/clisqlshell/statement_diag.go
+++ b/pkg/cli/clisqlshell/statement_diag.go
@@ -27,13 +27,13 @@ func (c *cliState) handleStatementDiag(
 	}
 	// `\statement-diag download` writes a zip file to the local
 	// filesystem with the shell process's UID, so it must be gated by
-	// DisableLocalCmds. `list` only issues a server-side query and
+	// DisableUnsafeCmds. `list` only issues a server-side query and
 	// remains enabled. The dispatcher cannot reject this from
 	// embedderSafeCmds because the dangerous subcommand is in
 	// args[0], not cmd[0].
-	if c.sqlCtx.DisableLocalCmds && cmd == stmtDiagDownload {
+	if c.sqlCtx.DisableUnsafeCmds && cmd == stmtDiagDownload {
 		return c.cliError(errState, errors.Newf(
-			"%s %s: local command disabled by embedder", cmdStmtDiag, stmtDiagDownload))
+			"%s %s: command disabled by embedder", cmdStmtDiag, stmtDiagDownload))
 	}
 	defer c.conn.AllowExecuteInternal(context.Background())()
 	var cmdErr error


### PR DESCRIPTION
## Summary

Three small Context fields on `clisqlshell` that an embedder (e.g. a service that exposes the SQL shell over SSH) needs in order to use the shell safely as a library:

1. `Context.DisableHistory` — explicit off-switch for persistent shell history. Today setting the internal `histFile` to `\"\"` happens to disable it, but that's an undocumented side-effect of internal state.
2. `Context.InterruptCh` — embedder-supplied channel that replaces the SIGINT-based query-cancel path. Embedded shells don't see SIGINT; they receive a 0x03 byte or an SSH signal request and need to translate that into a query cancel.
3. `Context.DisableLocalCmds` + `Context.DisablePasswordCmd` — refuse the metacommands that touch the local filesystem or shell out (`\\!`, `\\|`, `\\i`, `\\ir`, `\\o`, `\\e`) and the metacommand that types a password into the shell session (`\\password`). Without these, any user of the embedded shell can execute commands with the service's UID.

Each commit is logically independent and individually reviewable. They're bundled here because they share the same `Context` struct and motivation.

This is the cockroach side of work to make the shell embeddable. The downstream consumer is [`cockroachdb/cockroachdb-sqlshell`](https://github.com/cockroachdb/cockroachdb-sqlshell), which snapshots `pkg/cli/clisqlshell` and its supporting packages as a standalone library.

## Commits

* `clisqlshell: add Context.DisableHistory` — one bool, one early-return on the `histFile` assignment in `configurePreShellDefaults`.
* `clisqlshell: add Context.InterruptCh` — new `handleEmbedderInterrupt()` helper that mirrors the existing cancellation logic (mutex, `cancelFn`, 3-second timeout) without touching `signal.Notify`/`signal.Reset`. `maybeHandleInterrupt` branches to it when the field is set. The signal path is unchanged.
* `clisqlshell: add Context.DisableLocalCmds + Context.DisablePasswordCmd` — guards at the top of `doHandleCliCmd` reject the listed metacommands with a clear error. `\\e` is gated separately at editor-init time via a new `externalEditorAllowed()` method on the `sqlShell` interface, since it's reachable through the bubbline editor's own keybinding rather than the dispatcher.

The existing `restricted`-mode guard (CVE-2025-8714) is untouched; it's a per-session toggle for a different threat model and continues to short-circuit the dispatcher above the new checks.

## Test plan

- [ ] Build cockroach with the patches applied — already verified clean against my local checkout (post-`./dev gen`).
- [ ] Verified end-to-end against a real cockroach via the downstream embedder: `DisableLocalCmds=true` rejects `\\!ls` and `\\i /etc/passwd`; `DisablePasswordCmd=true` rejects `\\password`; `DisableHistory=true` produces no `.cockroachsql_history`; `InterruptCh` writes cancel an in-flight query.
- [ ] No upstream behavior change when none of the new fields are set (all default zero values preserve existing semantics).