### PR TITLE
opt: add session setting `optimizer_inline_placeholder_equalities`

### DIFF
--- a/docs/generated/sql/session_vars.md
+++ b/docs/generated/sql/session_vars.md
@@ -156,6 +156,7 @@ SHOW application_name;
 <tr><td><code>optimizer_enable_lock_elision</code></td><td>Controls whether the optimizer can eliminate unnecessary locking operations.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>optimizer_hoist_uncorrelated_equality_subqueries</code></td><td>Controls whether the optimizer hoists uncorrelated subqueries in equality expressions with columns, potentially producing more efficient plans.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>optimizer_inline_any_unnest_subquery</code></td><td>Controls whether the optimizer inlines subqueries containing ANY expressions combined with UNNEST.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
+<tr><td><code>optimizer_inline_placeholder_equalities</code></td><td>Controls whether the optimizer inlines placeholder equalities in the InlineConstVar normalization rule.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>optimizer_merge_joins_enabled</code></td><td>Controls whether the optimizer should explore query plans with merge joins.</td><td><code>on</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>optimizer_min_row_count</code></td><td>Sets a lower bound on row count estimates during query planning, except for expressions with zero cardinality.</td><td><code>1</code></td><td>No</td><td>-</td></tr>
 <tr><td><code>optimizer_plan_lookup_joins_with_reverse_scans</code></td><td>Controls whether the optimizer can plan lookup joins using reverse index scans.</td><td><code>on</code></td><td>No</td><td>-</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3998,6 +3998,7 @@ optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on
 optimizer_enable_lock_elision                                    on
 optimizer_hoist_uncorrelated_equality_subqueries                 on
 optimizer_inline_any_unnest_subquery                             on
+optimizer_inline_placeholder_equalities                          on
 optimizer_merge_joins_enabled                                    on
 optimizer_min_row_count                                          1
 optimizer_plan_lookup_joins_with_reverse_scans                   on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3424,6 +3424,7 @@ optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on             
 optimizer_enable_lock_elision                                    on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL      NULL        NULL        string
 optimizer_inline_any_unnest_subquery                             on                  NULL      NULL        NULL        string
+optimizer_inline_placeholder_equalities                          on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                                    on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                          1                   NULL      NULL        NULL        string
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL      NULL        NULL        string
@@ -3686,6 +3687,7 @@ optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on             
 optimizer_enable_lock_elision                                    on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  NULL  user     NULL      on                  on
 optimizer_inline_any_unnest_subquery                             on                  NULL  user     NULL      on                  on
+optimizer_inline_placeholder_equalities                          on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                                    on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                          1                   NULL  user     NULL      1                   1
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  NULL  user     NULL      on                  on
@@ -3939,6 +3941,7 @@ optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  NULL    NULL   
 optimizer_enable_lock_elision                                    NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries                 NULL    NULL     NULL     NULL        NULL
 optimizer_inline_any_unnest_subquery                             NULL    NULL     NULL     NULL        NULL
+optimizer_inline_placeholder_equalities                          NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                                    NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                          NULL    NULL     NULL     NULL        NULL
 optimizer_plan_lookup_joins_with_reverse_scans                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -163,6 +163,7 @@ optimizer_disable_cross_region_cascade_fast_path_for_rbr_tables  on             
 optimizer_enable_lock_elision                                    on                  Controls whether the optimizer can eliminate unnecessary locking operations.
 optimizer_hoist_uncorrelated_equality_subqueries                 on                  Controls whether the optimizer hoists uncorrelated subqueries in equality expressions with columns, potentially producing more efficient plans.
 optimizer_inline_any_unnest_subquery                             on                  Controls whether the optimizer inlines subqueries containing ANY expressions combined with UNNEST.
+optimizer_inline_placeholder_equalities                          on                  Controls whether the optimizer inlines placeholder equalities in the InlineConstVar normalization rule.
 optimizer_merge_joins_enabled                                    on                  Controls whether the optimizer should explore query plans with merge joins.
 optimizer_min_row_count                                          1                   Sets a lower bound on row count estimates during query planning, except for expressions with zero cardinality.
 optimizer_plan_lookup_joins_with_reverse_scans                   on                  Controls whether the optimizer can plan lookup joins using reverse index scans.

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -223,6 +223,7 @@ type Memo struct {
 	preventUpdateSetColumnDrop                 bool
 	useImprovedRoutineDepsTriggersComputedCols bool
 	inlineAnyUnnestSubquery                    bool
+	inlinePlaceholderEqualities                bool
 	useMinRowCountAntiJoinFix                  bool
 	useBackupsWithIDs                          bool
 	pgDumpCompatibility                        string
@@ -372,6 +373,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		preventUpdateSetColumnDrop:                 evalCtx.SessionData().PreventUpdateSetColumnDrop,
 		useImprovedRoutineDepsTriggersComputedCols: evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols,
 		inlineAnyUnnestSubquery:                    evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery,
+		inlinePlaceholderEqualities:                evalCtx.SessionData().OptimizerInlinePlaceholderEqualities,
 		useMinRowCountAntiJoinFix:                  evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix,
 		skipUnderlyingViewPrivilegeChecks:          sqlclustersettings.SkipUnderlyingViewPrivilegeChecks.Get(&evalCtx.Settings.SV),
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
@@ -562,6 +564,7 @@ func (m *Memo) IsStale(
 		m.preventUpdateSetColumnDrop != evalCtx.SessionData().PreventUpdateSetColumnDrop ||
 		m.useImprovedRoutineDepsTriggersComputedCols != evalCtx.SessionData().UseImprovedRoutineDepsTriggersAndComputedCols ||
 		m.inlineAnyUnnestSubquery != evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery ||
+		m.inlinePlaceholderEqualities != evalCtx.SessionData().OptimizerInlinePlaceholderEqualities ||
 		m.useMinRowCountAntiJoinFix != evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix ||
 		m.skipUnderlyingViewPrivilegeChecks != sqlclustersettings.SkipUnderlyingViewPrivilegeChecks.Get(&evalCtx.Settings.SV) ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel ||

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -632,6 +632,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerInlineAnyUnnestSubquery = false
 	notStale()
 
+	// Stale optimizer_inline_placeholder_equalities.
+	evalCtx.SessionData().OptimizerInlinePlaceholderEqualities = true
+	stale()
+	evalCtx.SessionData().OptimizerInlinePlaceholderEqualities = false
+	notStale()
+
 	// Stale optimizer_use_min_row_count_anti_join_fix.
 	evalCtx.SessionData().OptimizerUseMinRowCountAntiJoinFix = true
 	stale()

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -301,8 +301,12 @@ func (c *CustomFuncs) extractVarEqualsConst(
 	if eq, ok := e.(*memo.EqExpr); ok {
 		if l, ok := eq.Left.(*memo.VariableExpr); ok {
 			switch eq.Right.(type) {
-			case *memo.ConstExpr, *memo.PlaceholderExpr:
+			case *memo.ConstExpr:
 				return true, l, eq.Right
+			case *memo.PlaceholderExpr:
+				if c.f.evalCtx.SessionData().OptimizerInlinePlaceholderEqualities {
+					return true, l, eq.Right
+				}
 			}
 		}
 	}

--- a/pkg/sql/session_var_descriptions.go
+++ b/pkg/sql/session_var_descriptions.go
@@ -147,6 +147,7 @@ var sessionVarDescriptions = map[string]string{
 	"optimizer_enable_lock_elision":                                   "Controls whether the optimizer can eliminate unnecessary locking operations.",
 	"optimizer_hoist_uncorrelated_equality_subqueries":                "Controls whether the optimizer hoists uncorrelated subqueries in equality expressions with columns, potentially producing more efficient plans.",
 	"optimizer_inline_any_unnest_subquery":                            "Controls whether the optimizer inlines subqueries containing ANY expressions combined with UNNEST.",
+	"optimizer_inline_placeholder_equalities":                         "Controls whether the optimizer inlines placeholder equalities in the InlineConstVar normalization rule.",
 	"optimizer_merge_joins_enabled":                                   "Controls whether the optimizer should explore query plans with merge joins.",
 	"optimizer_min_row_count":                                         "Sets a lower bound on row count estimates during query planning, except for expressions with zero cardinality.",
 	"optimizer_plan_lookup_joins_with_reverse_scans":                  "Controls whether the optimizer can plan lookup joins using reverse index scans.",

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -829,6 +829,11 @@ message LocalOnlySessionData {
   // return an error if no SQL instance matches DistSQLPlanLocalityFilter
   // instead of falling back to the gateway / random instance selection.
   bool distsql_plan_locality_filter_strict = 209 [(gogoproto.customname) = "DistSQLPlanLocalityFilterStrict"];
+  // OptimizerInlinePlaceholderEqualities, when true, allows the
+  // InlineConstVar normalization rule to inline placeholder expressions
+  // (e.g. $1) in addition to constants. This enables better index usage
+  // in correlated subqueries with placeholder equalities.
+  bool optimizer_inline_placeholder_equalities = 210;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1164,6 +1164,10 @@ func (m *SessionDataMutator) SetOptimizerInlineAnyUnnestSubquery(val bool) {
 	m.Data.OptimizerInlineAnyUnnestSubquery = val
 }
 
+func (m *SessionDataMutator) SetOptimizerInlinePlaceholderEqualities(val bool) {
+	m.Data.OptimizerInlinePlaceholderEqualities = val
+}
+
 func (m *SessionDataMutator) SetUseBackupsWithIDs(val bool) {
 	m.Data.UseBackupsWithIDs = val
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -5035,6 +5035,24 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`optimizer_inline_placeholder_equalities`: {
+		Description:  sessionVarDescriptions["optimizer_inline_placeholder_equalities"],
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_inline_placeholder_equalities`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_inline_placeholder_equalities", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerInlinePlaceholderEqualities(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerInlinePlaceholderEqualities), nil
+		},
+		GlobalDefault: globalTrue,
+	},
+
+	// CockroachDB extension.
 	`optimizer_use_min_row_count_anti_join_fix`: {
 		Description:  sessionVarDescriptions["optimizer_use_min_row_count_anti_join_fix"],
 		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_min_row_count_anti_join_fix`),


### PR DESCRIPTION
Epic: None

Release note (sql change): Added a new session setting `optimizer_inline_placeholder_equalities` (default true). When disabled, the optimizer will not propagate placeholder equalities into correlated subqueries via the `InlineConstVar` normalization rule.