### PR TITLE
sql,admissionpb: show normalized CPU share in SHOW RESOURCE GROUP

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/resource_group
+++ b/pkg/sql/logictest/testdata/logic_test/resource_group
@@ -57,11 +57,11 @@ CREATE RESOURCE GROUP dup_max_cpu WITH cpu_weight = 1, max_cpu = true, max_cpu =
 statement ok
 CREATE RESOURCE GROUP high WITH cpu_weight = 100, max_cpu = true
 
-query ITIB colnames
+query ITIBF colnames
 SHOW RESOURCE GROUP high
 ----
-id  name  cpu_weight  max_cpu
-17  high  100         true
+id  name  cpu_weight  max_cpu  cpu_share_percent
+17  high  100         true     100
 
 # The parens form is also accepted.
 statement ok
@@ -74,11 +74,11 @@ DROP RESOURCE GROUP parens
 statement ok
 CREATE RESOURCE GROUP medium WITH cpu_weight = 50
 
-query ITIB colnames
+query ITIBF colnames
 SHOW RESOURCE GROUP medium
 ----
-id  name    cpu_weight  max_cpu
-19  medium  50          false
+id  name    cpu_weight  max_cpu  cpu_share_percent
+19  medium  50          false    33.33333333333333
 
 # Duplicate name is rejected; IF NOT EXISTS swallows the conflict.
 statement error pq: resource group "high" already exists
@@ -98,12 +98,12 @@ subtest end
 subtest show
 
 # SHOW RESOURCE GROUPS lists all.
-query ITIB colnames,rowsort
+query ITIBF colnames,rowsort
 SHOW RESOURCE GROUPS
 ----
-id  name    cpu_weight  max_cpu
-17  high    100         true
-19  medium  50          false
+id  name    cpu_weight  max_cpu  cpu_share_percent
+17  high    100         true     66.66666666666666
+19  medium  50          false    33.33333333333333
 
 # SHOW RESOURCE GROUP <name> errors when the named group does not exist.
 statement error pq: resource group "ghost" does not exist
@@ -117,20 +117,20 @@ subtest alter
 statement ok
 ALTER RESOURCE GROUP high WITH cpu_weight = 200
 
-query ITIB colnames
+query ITIBF colnames
 SHOW RESOURCE GROUP high
 ----
-id  name  cpu_weight  max_cpu
-17  high  200         true
+id  name  cpu_weight  max_cpu  cpu_share_percent
+17  high  200         true     80
 
 statement ok
 ALTER RESOURCE GROUP high WITH max_cpu = false
 
-query ITIB colnames
+query ITIBF colnames
 SHOW RESOURCE GROUP high
 ----
-id  name  cpu_weight  max_cpu
-17  high  200         false
+id  name  cpu_weight  max_cpu  cpu_share_percent
+17  high  200         false    80
 
 # ALTER on a missing group: error without IF EXISTS, no-op with.
 statement error pq: resource group "ghost" does not exist
@@ -157,11 +157,61 @@ statement ok
 DROP RESOURCE GROUP IF EXISTS medium
 
 # After dropping medium, only high remains.
-query ITIB colnames
+query ITIBF colnames
 SHOW RESOURCE GROUPS
 ----
-id  name  cpu_weight  max_cpu
-17  high  200         false
+id  name  cpu_weight  max_cpu  cpu_share_percent
+17  high  200         false    100
+
+subtest end
+
+subtest cpu_share
+
+# cpu_share_percent is derived from the entire set of user-defined
+# groups: share = weight / max(100, Σ weights). The 100-weight floor
+# prevents a single small group from appearing to receive 100% of CPU.
+#
+# Only `high` (weight 200) is present; the floor does not bind and the
+# whole 100% goes to `high`.
+query F
+SELECT cpu_share_percent FROM [SHOW RESOURCE GROUP high]
+----
+100
+
+statement ok
+ALTER RESOURCE GROUP high WITH cpu_weight = 20
+
+statement ok
+CREATE RESOURCE GROUP a WITH cpu_weight = 30
+
+statement ok
+CREATE RESOURCE GROUP b WITH cpu_weight = 50
+
+query TF rowsort
+SELECT name, cpu_share_percent FROM [SHOW RESOURCE GROUPS]
+----
+high  20
+a     30
+b     50
+
+# Drop b. Sum is now 50, below the floor, so the floor binds: each
+# group's share is weight/100 and the shares no longer add to 100%.
+statement ok
+DROP RESOURCE GROUP b
+
+query TF rowsort
+SELECT name, cpu_share_percent FROM [SHOW RESOURCE GROUPS]
+----
+high  40
+a     60
+
+# Restore the prior state so the rest of the file sees `high` alone
+# with cpu_weight=200.
+statement ok
+DROP RESOURCE GROUP a
+
+statement ok
+ALTER RESOURCE GROUP high WITH cpu_weight = 200
 
 subtest end
 

--- a/pkg/sql/resource_group.go
+++ b/pkg/sql/resource_group.go
@@ -300,10 +300,15 @@ var showResourceGroupColumns = colinfo.ResultColumns{
 	{Name: "name", Typ: types.String},
 	{Name: "cpu_weight", Typ: types.Int},
 	{Name: "max_cpu", Typ: types.Bool},
+	{Name: "cpu_share_percent", Typ: types.Float},
 }
 
 // showResourceGroupsImpl backs both SHOW RESOURCE GROUP <name> and
 // SHOW RESOURCE GROUPS. An empty name lists all groups.
+//
+// The cpu_share_percent column is derived: every row is loaded so
+// admissionpb.Normalize can compute each group's share from the full
+// set of weights, even when only one row is being returned.
 func (p *planner) showResourceGroupsImpl(name string) (planNode, error) {
 	planName := "SHOW RESOURCE GROUPS"
 	if name != "" {
@@ -320,48 +325,60 @@ func (p *planner) showResourceGroupsImpl(name string) (planNode, error) {
 				return nil, err
 			}
 
-			query := `SELECT id, name, config FROM system.resource_groups`
-			var args []any
-			if name != "" {
-				query += ` WHERE name = $1`
-				args = append(args, name)
-			}
-			query += ` ORDER BY id`
-
+			// Load every row, even when a single name was requested:
+			// share is a function of the entire set of weights.
 			it, err := p.InternalSQLTxn().QueryIteratorEx(
 				ctx, resourceGroupOp, p.Txn(),
 				sessiondata.NodeUserSessionDataOverride,
-				query, args...,
+				`SELECT id, name, config FROM system.resource_groups ORDER BY id`,
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "loading resource groups")
 			}
 			defer func() { _ = it.Close() }()
 
-			v := p.newContainerValuesNode(showResourceGroupColumns, 0)
-			seen := false
+			type rgRow struct {
+				id   tree.Datum
+				name tree.Datum
+				cfg  admissionpb.ResourceGroupConfig
+			}
+			var rows []rgRow
 			for {
 				ok, err := it.Next(ctx)
 				if err != nil {
-					v.Close(ctx)
 					return nil, err
 				}
 				if !ok {
 					break
 				}
-				seen = true
-				row := it.Cur()
+				cur := it.Cur()
 				var cfg admissionpb.ResourceGroupConfig
-				if err := protoutil.Unmarshal([]byte(tree.MustBeDBytes(row[2])), &cfg); err != nil {
-					v.Close(ctx)
+				if err := protoutil.Unmarshal([]byte(tree.MustBeDBytes(cur[2])), &cfg); err != nil {
 					return nil, errors.NewAssertionErrorWithWrappedErrf(err,
-						"decoding resource group config for row %v", row[0])
+						"decoding resource group config for row %v", cur[0])
 				}
+				rows = append(rows, rgRow{id: cur[0], name: cur[1], cfg: cfg})
+			}
+
+			cfgs := make([]admissionpb.ResourceGroupConfig, len(rows))
+			for i, r := range rows {
+				cfgs[i] = r.cfg
+			}
+			admissionpb.Normalize(cfgs)
+
+			v := p.newContainerValuesNode(showResourceGroupColumns, 0)
+			matched := false
+			for i, r := range rows {
+				if name != "" && string(tree.MustBeDString(r.name)) != name {
+					continue
+				}
+				matched = true
 				out := tree.Datums{
-					row[0],
-					row[1],
-					tree.NewDInt(tree.DInt(cfg.CPUWeight)),
-					tree.MakeDBool(tree.DBool(cfg.MaxCPU)),
+					r.id,
+					r.name,
+					tree.NewDInt(tree.DInt(cfgs[i].CPUWeight)),
+					tree.MakeDBool(tree.DBool(cfgs[i].MaxCPU)),
+					tree.NewDFloat(tree.DFloat(cfgs[i].BurstFrac * 100)),
 				}
 				if _, err := v.rows.AddRow(ctx, out); err != nil {
 					v.Close(ctx)
@@ -371,7 +388,7 @@ func (p *planner) showResourceGroupsImpl(name string) (planNode, error) {
 			// SHOW RESOURCE GROUP <name> errors if the named group does not
 			// exist, matching SHOW HISTOGRAM / SHOW CREATE TABLE. SHOW
 			// RESOURCE GROUPS (no name) is allowed to return zero rows.
-			if name != "" && !seen {
+			if name != "" && !matched {
 				v.Close(ctx)
 				return nil, pgerror.Newf(pgcode.UndefinedObject,
 					"resource group %q does not exist", name)

--- a/pkg/util/admission/admissionpb/BUILD.bazel
+++ b/pkg/util/admission/admissionpb/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "admissionpb.go",
         "doc.go",
         "io_threshold.go",
+        "resource_group.go",
     ],
     embed = [":admissionpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb",
@@ -50,7 +51,10 @@ go_proto_library(
 
 go_test(
     name = "admissionpb_test",
-    srcs = ["io_threshold_test.go"],
+    srcs = [
+        "io_threshold_test.go",
+        "resource_group_test.go",
+    ],
     embed = [":admissionpb"],
     deps = ["@com_github_stretchr_testify//require"],
 )

--- a/pkg/util/admission/admissionpb/resource_group.go
+++ b/pkg/util/admission/admissionpb/resource_group.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admissionpb
+
+// Normalize fills the BurstFrac of each ResourceGroupConfig in cfgs:
+//
+//	BurstFrac = CPUWeight / sum(CPUWeight)
+//
+// The slice is mutated in place and returned for chaining. Callers that
+// need to preserve the original BurstFrac values must copy first.
+//
+// CPUWeight values must be non-negative; SQL DDL rejects zero and
+// negative values at ingest.
+func Normalize(cfgs []ResourceGroupConfig) []ResourceGroupConfig {
+	var sum int64
+	for _, c := range cfgs {
+		if c.CPUWeight > 0 {
+			sum += c.CPUWeight
+		}
+	}
+	for i := range cfgs {
+		if cfgs[i].CPUWeight <= 0 {
+			cfgs[i].BurstFrac = 0
+			continue
+		}
+		cfgs[i].BurstFrac = float64(cfgs[i].CPUWeight) / float64(sum)
+	}
+	return cfgs
+}

--- a/pkg/util/admission/admissionpb/resource_group.proto
+++ b/pkg/util/admission/admissionpb/resource_group.proto
@@ -22,4 +22,12 @@ message ResourceGroupConfig {
   // MaxCPU allows the group to burst to the cluster's maximum
   // available CPU when no other group is contending.
   bool max_cpu = 2 [(gogoproto.customname) = "MaxCPU"];
+
+  // BurstFrac is the share of CPU the group is entitled to, derived
+  // from CPUWeight by Normalize(). It is never written to
+  // system.resource_groups: writers leave it zero, and readers (e.g.
+  // SHOW RESOURCE GROUP) populate it by calling Normalize over the
+  // full set of rows. The field is on the proto so the same struct can
+  // carry the derived share across package boundaries.
+  double burst_frac = 3 [(gogoproto.customname) = "BurstFrac"];
 }

--- a/pkg/util/admission/admissionpb/resource_group_test.go
+++ b/pkg/util/admission/admissionpb/resource_group_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package admissionpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name              string
+		weights           []int64
+		expectedBurstFrac []float64
+	}{
+		{
+			name:              "empty",
+			weights:           nil,
+			expectedBurstFrac: nil,
+		},
+		{
+			name:              "single group below floor",
+			weights:           []int64{50},
+			expectedBurstFrac: []float64{1.0},
+		},
+		{
+			name:              "sum below 100 still normalized",
+			weights:           []int64{20, 20},
+			expectedBurstFrac: []float64{0.5, 0.5},
+		},
+		{
+			name:              "sum equals 100",
+			weights:           []int64{80, 20},
+			expectedBurstFrac: []float64{0.8, 0.2},
+		},
+		{
+			name:              "sum above 100",
+			weights:           []int64{100, 100, 50},
+			expectedBurstFrac: []float64{100.0 / 250.0, 100.0 / 250.0, 50.0 / 250.0},
+		},
+		{
+			// Non-positive CPUWeight is rejected at the SQL boundary. The
+			// helper still must not panic on divide-by-zero if it ever sees
+			// such input: a single zero-weight group yields BurstFrac=0,
+			// not a NaN.
+			name:              "non-positive weight tolerated",
+			weights:           []int64{0},
+			expectedBurstFrac: []float64{0},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgs := make([]ResourceGroupConfig, len(tc.weights))
+			for i, w := range tc.weights {
+				cfgs[i] = ResourceGroupConfig{CPUWeight: w}
+			}
+			got := Normalize(cfgs)
+			require.Len(t, got, len(tc.expectedBurstFrac))
+			for i, want := range tc.expectedBurstFrac {
+				require.InDelta(t, want, got[i].BurstFrac, 1e-9,
+					"index %d, weight %d", i, tc.weights[i])
+			}
+		})
+	}
+}


### PR DESCRIPTION
A raw cpu_weight is hard for an operator to interpret in isolation:
the share a group actually receives depends on what other groups
exist. A single group with weight 50 receives 100% of CPU; two such
groups receive 50% each; five receive 20% each. SHOW RESOURCE GROUP
and SHOW RESOURCE GROUPS now surface a cpu_share_percent column so the
operator can see what a given weight buys them.

The normalization rule is

    share = weight / Σ weights

Only user-defined groups participate in the sum; the built-in high/low
and system-tenant configs in the admission package stay independent
for now.

Epic: none