### PR TITLE
opt: add MergePlanGrams function

### DIFF
--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -830,3 +830,52 @@ func (pe *planGramExpr) visitAlternateExprs(
 	// alternates for the current level.
 	return true
 }
+
+// fixNames detects production names that are invalid or duplicate and returns a
+// rename map that resolves all issues. Returns nil when no fixes are needed.
+func (p PlanGram) fixNames() map[*planGramProduction]string {
+	if p.root == nil || p.root == nonePlanGramTerm {
+		return nil
+	}
+	seen := map[string]struct{}{
+		"":     {},
+		"any":  {},
+		"none": {},
+		"root": {},
+	}
+	var renames map[*planGramProduction]string
+	visited := make(map[*planGramProduction]struct{})
+	p.root.visitProductions(visited, func(pp *planGramProduction) {
+		name := strings.Map(func(r rune) rune {
+			if unicode.IsSpace(r) || strings.ContainsRune(`"'\,():;=|`, r) {
+				return '_'
+			}
+			return r
+		}, pp.name)
+		if len(name) > 0 && name[0] >= '0' && name[0] <= '9' {
+			name = "_" + name
+		}
+		if name != pp.name {
+			if renames == nil {
+				renames = make(map[*planGramProduction]string)
+			}
+			renames[pp] = name
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			return
+		}
+		for i := 1; ; i++ {
+			candidate := name + "_" + strconv.Itoa(i)
+			if _, ok := seen[candidate]; !ok {
+				seen[candidate] = struct{}{}
+				if renames == nil {
+					renames = make(map[*planGramProduction]string)
+				}
+				renames[pp] = candidate
+				return
+			}
+		}
+	})
+	return renames
+}

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -210,6 +210,14 @@ func (p PlanGram) WithNoneFallback() PlanGram {
 // FormatPretty writes the full PlanGram grammar to the buffer, starting with
 // the root, optionally with multiple lines.
 func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
+	p.formatPretty(b, newlines, p.fixNames())
+}
+
+// formatPretty writes the full PlanGram grammar to the buffer, substituting
+// production names from the renames map.
+func (p PlanGram) formatPretty(
+	b *bytes.Buffer, newlines bool, renames map[*planGramProduction]string,
+) {
 	if newlines {
 		defer b.WriteRune('\n')
 	}
@@ -220,6 +228,13 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 	if p.None() {
 		b.WriteString("root: none;")
 		return
+	}
+
+	prodName := func(pp *planGramProduction) string {
+		if n, ok := renames[pp]; ok {
+			return n
+		}
+		return pp.name
 	}
 
 	// formatTerm writes a RHS term to the buffer.
@@ -236,7 +251,7 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 		switch t := term.(type) {
 		case *planGramProduction:
 			// Assume nonterminal names don't need to be quoted.
-			b.WriteString(t.name)
+			b.WriteString(prodName(t))
 		case *planGramExpr:
 			b.WriteRune('(')
 			if t.op == opt.UnknownOp {
@@ -276,7 +291,7 @@ func (p PlanGram) FormatPretty(b *bytes.Buffer, newlines bool) {
 		} else {
 			b.WriteRune(' ')
 		}
-		b.WriteString(pp.name)
+		b.WriteString(prodName(pp))
 		for i, rule := range pp.rules {
 			if i == 0 {
 				b.WriteString(": ")

--- a/pkg/sql/opt/props/physical/plangram.go
+++ b/pkg/sql/opt/props/physical/plangram.go
@@ -106,12 +106,14 @@ type planGramTerm interface {
 // nonterminal matches the current optimizer sub-tree if any of its production
 // rules match the current sub-tree.
 type planGramProduction struct {
-	// name is the nonterminal symbol in the grammar, which must be unique in the
-	// graph. "any" and "none" are reserved, as are names starting with
+	// name is the nonterminal symbol in the grammar. Names are unique within a
+	// parsed grammar, but may collide after MergePlanGrams combines separately
+	// parsed grammars. "any" and "none" are reserved, as are names starting with
 	// underscores. "root" is the required entry-point production and cannot be
-	// referenced from other productions. The name must not be empty, must not
-	// contain any of the characters "'\,():;=| or whitespace, and must not start
-	// with a digit.
+	// referenced from other productions. The name should not be empty, should
+	// not contain any of the characters "'\,():;=| or whitespace, and should not
+	// start with a digit. fixNames corrects all of these violations (duplicates,
+	// invalid characters, reserved names) when printing.
 	name string
 	// rules are the set of production rules for this nonterminal. There must be
 	// at least one rule (which could be anyPlanGramTerm or nonePlanGramTerm if
@@ -168,6 +170,13 @@ var AnyPlanGram = PlanGram{anyPlanGramTerm}
 // NonePlanGram is the PlanGram: "root: none;". It matches no optimizer plans.
 var NonePlanGram = PlanGram{nonePlanGramTerm}
 
+// IdentifiedPlanGram pairs a PlanGram with an identifier, used when merging
+// multiple PlanGrams into a single grammar with labeled branches.
+type IdentifiedPlanGram struct {
+	ID       string
+	PlanGram PlanGram
+}
+
 var errInvalidUTF8 = errors.New("invalid UTF-8")
 
 // Any is true if this PlanGram matches any optimizer sub-tree.
@@ -190,21 +199,48 @@ func (p PlanGram) None() bool {
 	return false
 }
 
-// WithNoneFallback wraps this PlanGram in a production that includes
-// NonePlanGram as a fallback alternate. This ensures the optimizer also
-// considers the unconstrained (default) plan, so that if the PlanGram cannot be
-// fully matched, the optimizer falls back to its natural cost-based
-// selection. This should be called on the root PlanGram before optimization
-// starts.
-func (p PlanGram) WithNoneFallback() PlanGram {
-	if p.Any() || p.None() {
-		return p
+// MergePlanGrams combines multiple identified PlanGrams into a single PlanGram.
+// Each input gets its own labeled branch under a merge production. If no inputs
+// are provided, the result is AnyPlanGram. If no input is a None
+// PlanGram, a "default" none branch is added so the optimizer can fall back to
+// its natural cost-based selection.
+//
+// Production names from different inputs may collide after merging; fixNames
+// deduplicates them when the merged PlanGram is printed.
+//
+// For example, merging inputs "x" with root (Scan) and "y" with root (Select
+// (Scan)) produces:
+//
+//	root: _merge;
+//	_merge: _merge_x | _merge_y | _merge_default;
+//	_merge_x: (Scan);
+//	_merge_y: (Select (Scan));
+//	_merge_default: none;
+func MergePlanGrams(inputs ...IdentifiedPlanGram) PlanGram {
+	if len(inputs) == 0 {
+		return AnyPlanGram
 	}
-	prod := &planGramProduction{
-		name:  "_fallback",
-		rules: []planGramTerm{p.root, nonePlanGramTerm},
+	hasNone := false
+	mergeRules := make([]planGramTerm, 0, len(inputs)+1)
+	for _, ipg := range inputs {
+		if ipg.PlanGram.None() {
+			hasNone = true
+		}
+		mergeRules = append(mergeRules, &planGramProduction{
+			name:  "_merge_" + ipg.ID,
+			rules: []planGramTerm{ipg.PlanGram.root},
+		})
 	}
-	return PlanGram{root: prod}
+	if !hasNone {
+		mergeRules = append(mergeRules, &planGramProduction{
+			name:  "_merge_default",
+			rules: []planGramTerm{nonePlanGramTerm},
+		})
+	}
+	return PlanGram{root: &planGramProduction{
+		name:  "_merge",
+		rules: mergeRules,
+	}}
 }
 
 // FormatPretty writes the full PlanGram grammar to the buffer, starting with

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -1195,3 +1195,253 @@ func TestPlanGramParse(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanGramFixNames(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("any returns nil", func(t *testing.T) {
+		require.Nil(t, AnyPlanGram.fixNames())
+	})
+
+	t.Run("none returns nil", func(t *testing.T) {
+		require.Nil(t, NonePlanGram.fixNames())
+	})
+
+	t.Run("no duplicates returns nil", func(t *testing.T) {
+		scan := &planGramProduction{
+			name:  "scan",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{scan},
+		}}
+		require.Nil(t, pg.fixNames())
+	})
+
+	t.Run("duplicates get renamed", func(t *testing.T) {
+		s1 := &planGramProduction{
+			name:  "s",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		s2 := &planGramProduction{
+			name:  "s",
+			rules: []planGramTerm{&planGramExpr{op: opt.SelectOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.InnerJoinOp,
+			children: []planGramTerm{s1, s2},
+		}}
+		renames := pg.fixNames()
+		require.NotNil(t, renames)
+		require.Len(t, renames, 1)
+
+		// Exactly one of s1/s2 should be renamed. Collect all final names.
+		names := make(map[string]struct{})
+		for _, pp := range []*planGramProduction{s1, s2} {
+			if newName, ok := renames[pp]; ok {
+				names[newName] = struct{}{}
+			} else {
+				names[pp.name] = struct{}{}
+			}
+		}
+		require.Len(t, names, 2, "all names should be unique")
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "_1", renames[pp])
+	})
+
+	t.Run("whitespace in name", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "a b",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "a_b", renames[pp])
+	})
+
+	t.Run("illegal punctuation", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "a(b)",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "a_b_", renames[pp])
+	})
+
+	t.Run("starts with digit", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "1scan",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "_1scan", renames[pp])
+	})
+
+	t.Run("reserved name any", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "any",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "any_1", renames[pp])
+	})
+
+	t.Run("reserved name none", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "none",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "none_1", renames[pp])
+	})
+
+	t.Run("nested reserved name any", func(t *testing.T) {
+		inner := &planGramProduction{
+			name:  "any",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		outer := &planGramProduction{
+			name: "outer",
+			rules: []planGramTerm{
+				&planGramExpr{
+					op:       opt.SelectOp,
+					children: []planGramTerm{inner},
+				},
+			},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{outer},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "any_1", renames[inner])
+		require.NotContains(t, renames, outer)
+	})
+
+	t.Run("nested reserved name none", func(t *testing.T) {
+		inner := &planGramProduction{
+			name:  "none",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		outer := &planGramProduction{
+			name:  "outer",
+			rules: []planGramTerm{inner},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{outer},
+		}}
+		renames := pg.fixNames()
+		require.Equal(t, "none_1", renames[inner])
+		require.NotContains(t, renames, outer)
+	})
+
+	t.Run("any term in production not renamed", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "p",
+			rules: []planGramTerm{nil, &planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		require.Nil(t, pg.fixNames())
+	})
+
+	t.Run("none term in production not renamed", func(t *testing.T) {
+		pp := &planGramProduction{
+			name:  "p",
+			rules: []planGramTerm{nonePlanGramTerm, &planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.SelectOp,
+			children: []planGramTerm{pp},
+		}}
+		require.Nil(t, pg.fixNames())
+	})
+
+	t.Run("sanitize then deduplicate", func(t *testing.T) {
+		p1 := &planGramProduction{
+			name:  "a b",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		p2 := &planGramProduction{
+			name:  "a b",
+			rules: []planGramTerm{&planGramExpr{op: opt.SelectOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.InnerJoinOp,
+			children: []planGramTerm{p1, p2},
+		}}
+		renames := pg.fixNames()
+		require.NotNil(t, renames)
+
+		names := make(map[string]struct{})
+		for _, pp := range []*planGramProduction{p1, p2} {
+			names[renames[pp]] = struct{}{}
+		}
+		require.Len(t, names, 2, "all names should be unique")
+		_, hasBase := names["a_b"]
+		_, hasSuffix := names["a_b_1"]
+		require.True(t, hasBase && hasSuffix)
+	})
+
+	t.Run("three-way duplicates", func(t *testing.T) {
+		prods := make([]*planGramProduction, 3)
+		for i := range prods {
+			prods[i] = &planGramProduction{
+				name:  "p",
+				rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+			}
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.InnerJoinOp,
+			children: []planGramTerm{prods[0], prods[1], prods[2]},
+		}}
+		renames := pg.fixNames()
+		require.NotNil(t, renames)
+		require.Len(t, renames, 2)
+
+		names := make(map[string]struct{})
+		for _, pp := range prods {
+			if newName, ok := renames[pp]; ok {
+				names[newName] = struct{}{}
+			} else {
+				names[pp.name] = struct{}{}
+			}
+		}
+		require.Len(t, names, 3, "all names should be unique")
+	})
+}

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -260,6 +260,65 @@ func TestPlanGramFormatPretty(t *testing.T) {
 			require.Equal(t, tc.expectedNewlines, b.String())
 		})
 	}
+
+	t.Run("with renames", func(t *testing.T) {
+		s1 := &planGramProduction{
+			name:  "s",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		s2 := &planGramProduction{
+			name:  "s",
+			rules: []planGramTerm{&planGramExpr{op: opt.SelectOp, children: []planGramTerm{s1}}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.InnerJoinOp,
+			children: []planGramTerm{s1, s2},
+		}}
+		renames := pg.fixNames()
+		require.NotNil(t, renames)
+
+		var b bytes.Buffer
+		pg.formatPretty(&b, false /* newlines */, renames)
+		require.Equal(t,
+			`root: (InnerJoin s s_1); s: (Scan); s_1: (Select s);`,
+			b.String(),
+		)
+
+		b.Reset()
+		pg.formatPretty(&b, true /* newlines */, renames)
+		require.Equal(t,
+			"root: (InnerJoin s s_1);\ns: (Scan);\ns_1: (Select s);\n",
+			b.String(),
+		)
+	})
+
+	t.Run("all empty names", func(t *testing.T) {
+		p1 := &planGramProduction{
+			name:  "",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		p2 := &planGramProduction{
+			name:  "",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		p3 := &planGramProduction{
+			name:  "",
+			rules: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+		}
+		pg := PlanGram{root: &planGramExpr{
+			op:       opt.InnerJoinOp,
+			children: []planGramTerm{p1, p2, p3},
+		}}
+		renames := pg.fixNames()
+		require.NotNil(t, renames)
+
+		var b bytes.Buffer
+		pg.formatPretty(&b, false /* newlines */, renames)
+		require.Equal(t,
+			`root: (InnerJoin _1 _2 _3); _1: (Scan); _2: (Scan); _3: (Scan);`,
+			b.String(),
+		)
+	})
 }
 
 type mockExpr struct {

--- a/pkg/sql/opt/props/physical/plangram_test.go
+++ b/pkg/sql/opt/props/physical/plangram_test.go
@@ -859,50 +859,83 @@ func TestPlanGramVisitAlternates(t *testing.T) {
 	}
 }
 
-func TestPlanGramWithNoneFallback(t *testing.T) {
+func TestMergePlanGrams(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	t.Run("any is idempotent", func(t *testing.T) {
-		result := AnyPlanGram.WithNoneFallback()
-		require.True(t, result.Any())
-	})
+	scanPG := PlanGram{root: &planGramExpr{op: opt.ScanOp}}
+	selectPG := PlanGram{root: &planGramExpr{
+		op:       opt.SelectOp,
+		children: []planGramTerm{&planGramExpr{op: opt.ScanOp}},
+	}}
 
-	t.Run("none is idempotent", func(t *testing.T) {
-		result := NonePlanGram.WithNoneFallback()
-		require.True(t, result.Equals(NonePlanGram))
-	})
+	tests := []struct {
+		name     string
+		inputs   []IdentifiedPlanGram
+		expected string
+	}{
+		{
+			name:     "zero inputs",
+			inputs:   nil,
+			expected: "root: any;",
+		},
+		{
+			name: "single input adds default",
+			inputs: []IdentifiedPlanGram{
+				{ID: "x", PlanGram: scanPG},
+			},
+			expected: "root: _merge; _merge: _merge_x | _merge_default; _merge_x: (Scan); _merge_default: none;",
+		},
+		{
+			name: "multiple inputs",
+			inputs: []IdentifiedPlanGram{
+				{ID: "x", PlanGram: scanPG},
+				{ID: "y", PlanGram: selectPG},
+			},
+			expected: "root: _merge; _merge: _merge_x | _merge_y | _merge_default; _merge_x: (Scan); _merge_y: (Select (Scan)); _merge_default: none;",
+		},
+		{
+			name: "any input kept as branch",
+			inputs: []IdentifiedPlanGram{
+				{ID: "a", PlanGram: scanPG},
+				{ID: "b", PlanGram: AnyPlanGram},
+			},
+			expected: "root: _merge; _merge: _merge_a | _merge_b | _merge_default; _merge_a: (Scan); _merge_b: any; _merge_default: none;",
+		},
+		{
+			name: "none input suppresses default",
+			inputs: []IdentifiedPlanGram{
+				{ID: "a", PlanGram: scanPG},
+				{ID: "b", PlanGram: NonePlanGram},
+			},
+			expected: "root: _merge; _merge: _merge_a | _merge_b; _merge_a: (Scan); _merge_b: none;",
+		},
+		{
+			name: "all none inputs no default added",
+			inputs: []IdentifiedPlanGram{
+				{ID: "a", PlanGram: NonePlanGram},
+				{ID: "b", PlanGram: NonePlanGram},
+			},
+			expected: "root: _merge; _merge: _merge_a | _merge_b; _merge_a: none; _merge_b: none;",
+		},
+	}
 
-	t.Run("concrete gets fallback", func(t *testing.T) {
-		pg := PlanGram{root: &planGramExpr{op: opt.ScanOp}}
-		result := pg.WithNoneFallback()
-		require.True(t, result.HasAlternates())
-
-		var alternates []PlanGram
-		result.VisitAlternates(func(alt PlanGram) {
-			alternates = append(alternates, alt)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := MergePlanGrams(tc.inputs...)
+			require.Equal(t, tc.expected, result.String())
 		})
-		require.Len(t, alternates, 2)
+	}
 
-		hasNone := false
-		for _, a := range alternates {
-			if a.Equals(NonePlanGram) {
-				hasNone = true
-			}
-		}
-		require.True(t, hasNone)
-	})
-
-	t.Run("double wrap still works", func(t *testing.T) {
-		pg := PlanGram{root: &planGramExpr{op: opt.ScanOp}}
-		result := pg.WithNoneFallback().WithNoneFallback()
-		require.True(t, result.HasAlternates())
-
-		var alternates []PlanGram
-		result.VisitAlternates(func(alt PlanGram) {
-			alternates = append(alternates, alt)
-		})
-		require.GreaterOrEqual(t, len(alternates), 2)
+	t.Run("round-trip", func(t *testing.T) {
+		merged := MergePlanGrams(
+			IdentifiedPlanGram{ID: "x", PlanGram: scanPG},
+			IdentifiedPlanGram{ID: "y", PlanGram: selectPG},
+		)
+		s := merged.String()
+		parsed, err := ParsePlanGram(strings.NewReader(s))
+		require.NoError(t, err)
+		require.Equal(t, s, parsed.String())
 	})
 }
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2379,7 +2379,9 @@ func (ot *OptTester) optimizeExpr(
 	if !ot.Flags.PlanGram.Any() {
 		root := o.Memo().RootExpr()
 		props := *o.Memo().RootProps()
-		props.PlanGram = ot.Flags.PlanGram.WithNoneFallback()
+		props.PlanGram = physical.MergePlanGrams(physical.IdentifiedPlanGram{
+			ID: "stmt", PlanGram: ot.Flags.PlanGram,
+		})
 		o.Memo().SetRoot(root, &props)
 	}
 	root, err := o.Optimize()

--- a/pkg/sql/opt/xform/testdata/physprops/plangram
+++ b/pkg/sql/opt/xform/testdata/physprops/plangram
@@ -121,7 +121,7 @@ scan abc
  ├── key: (1)
  └── fd: (1)-->(2,3)
 
-# WithNoneFallback (graceful fallback to default).
+# MergePlanGrams (graceful fallback to default).
 
 # Default plan for comparison.
 opt format=show-cost


### PR DESCRIPTION
### opt: add fixNames method to PlanGram

Merged PlanGrams could have duplicated production names, so we need to
relax our rules about production names. Instead, we'll try to fix them
before printing. Add a `fixNames` function that generates a renaming map
to make merged PlanGrams suitable for printing. This will be used in the
next few commits.

Informs: #152053

Release note: None

---

### opt: accept rename map in FormatPretty

Add a `renames` parameter to `FormatPretty` so callers can substitute
production names (e.g. from `fixNames`). `Format` and `String` now call
`fixNames` automatically so their output always has valid, unique names
that can safely be parsed again.

Informs: #152053

Release note: None

---

### opt: add MergePlanGrams function

Add MergePlanGrams to combine multiple identified PlanGrams into a
single grammar with labeled alternates and an automatic none fallback.
Replace WithNoneFallback with this more general mechanism.

We'll use the labeled alternates to figure out which PlanGram matched
when there are multiple PlanGrams for a statement.

Informs: #152053

Release note: None