### PR TITLE
crosscluster/logical: handle LWW losers for update/delete with correct prev

### DIFF
--- a/pkg/crosscluster/logical/sqlwriter/sql_row_writer.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_writer.go
@@ -42,27 +42,35 @@ func (s *RowWriter) setOriginTimestamp(ctx context.Context, originTimestamp hlc.
 	})
 }
 
-// DeleteRow deletes a row from the table. It returns errStalePreviousValue
-// if the oldRow argument does not match the value in the local database.
+// DeleteRow deletes a row from the table. It returns ErrStalePreviousValue if
+// the oldRow argument does not match the value in the local database. It
+// returns a ConditionFailedError with OriginTimestampOlderThan set if the
+// previous value matches but the local row has a newer origin timestamp (LWW
+// loser).
 func (s *RowWriter) DeleteRow(
 	ctx context.Context, originTimestamp hlc.Timestamp, oldRow tree.Datums,
 ) error {
-	s.scratchDatums = s.scratchDatums[:0]
-	s.scratchDatums = append(s.scratchDatums, oldRow...)
+	// We use a savepoint because the KV layer may reject the delete with a
+	// ConditionFailedError if the local row has a newer origin timestamp. Without
+	// the savepoint, the rejection would abort the entire transaction.
+	return s.session.Savepoint(ctx, func(ctx context.Context) error {
+		s.scratchDatums = s.scratchDatums[:0]
+		s.scratchDatums = append(s.scratchDatums, oldRow...)
 
-	err := s.setOriginTimestamp(ctx, originTimestamp)
-	if err != nil {
-		return err
-	}
+		err := s.setOriginTimestamp(ctx, originTimestamp)
+		if err != nil {
+			return err
+		}
 
-	rowsAffected, err := s.session.ExecutePrepared(ctx, s.delete, s.scratchDatums)
-	if err != nil {
-		return errors.Wrap(err, "deleting row")
-	}
-	if rowsAffected != 1 {
-		return ErrStalePreviousValue
-	}
-	return nil
+		rowsAffected, err := s.session.ExecutePrepared(ctx, s.delete, s.scratchDatums)
+		if err != nil {
+			return errors.Wrap(err, "deleting row")
+		}
+		if rowsAffected != 1 {
+			return ErrStalePreviousValue
+		}
+		return nil
+	})
 }
 
 // InsertRow inserts a row into the table. It returns a ConditionFailedError
@@ -75,9 +83,7 @@ func (s *RowWriter) InsertRow(
 	// We use a savepoint here because LWW may reject the insert if it conflicts
 	// with a tombstone or an existing row with a more recent origin timestamp.
 	// Without the savepoint, the LWW rejection would abort the entire
-	// transaction. Updates and deletes do not need savepoints because a conflict
-	// results in zero rows modified, which leaves the transaction in a healthy
-	// state.
+	// transaction.
 	err := s.session.Savepoint(ctx, func(ctx context.Context) error {
 		s.scratchDatums = s.scratchDatums[:0]
 		s.scratchDatums = append(s.scratchDatums, row...)
@@ -108,28 +114,36 @@ func (s *RowWriter) InsertRow(
 	return err
 }
 
-// UpdateRow updates a row in the table. It returns errStalePreviousValue
-// if the oldRow argument does not match the value in the local database.
+// UpdateRow updates a row in the table. It returns ErrStalePreviousValue if
+// the oldRow argument does not match the value in the local database. It
+// returns a ConditionFailedError with OriginTimestampOlderThan set if the
+// previous value matches but the local row has a newer origin timestamp (LWW
+// loser).
 func (s *RowWriter) UpdateRow(
 	ctx context.Context, originTimestamp hlc.Timestamp, oldRow tree.Datums, newRow tree.Datums,
 ) error {
-	s.scratchDatums = s.scratchDatums[:0]
-	s.scratchDatums = append(s.scratchDatums, oldRow...)
-	s.scratchDatums = append(s.scratchDatums, newRow...)
+	// We use a savepoint because the KV layer may reject the update with a
+	// ConditionFailedError if the local row has a newer origin timestamp. Without
+	// the savepoint, the rejection would abort the entire transaction.
+	return s.session.Savepoint(ctx, func(ctx context.Context) error {
+		s.scratchDatums = s.scratchDatums[:0]
+		s.scratchDatums = append(s.scratchDatums, oldRow...)
+		s.scratchDatums = append(s.scratchDatums, newRow...)
 
-	err := s.setOriginTimestamp(ctx, originTimestamp)
-	if err != nil {
-		return err
-	}
+		err := s.setOriginTimestamp(ctx, originTimestamp)
+		if err != nil {
+			return err
+		}
 
-	rowsAffected, err := s.session.ExecutePrepared(ctx, s.update, s.scratchDatums)
-	if err != nil {
-		return errors.Wrap(err, "updating row")
-	}
-	if rowsAffected != 1 {
-		return ErrStalePreviousValue
-	}
-	return err
+		rowsAffected, err := s.session.ExecutePrepared(ctx, s.update, s.scratchDatums)
+		if err != nil {
+			return errors.Wrap(err, "updating row")
+		}
+		if rowsAffected != 1 {
+			return ErrStalePreviousValue
+		}
+		return nil
+	})
 }
 
 func NewRowWriter(

--- a/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
@@ -86,14 +86,19 @@ func TestSQLRowWriter(t *testing.T) {
 	// Test UpdateRow
 	updateRow := makeTestRow(t, desc, 1, "updated")
 	updateTimestamp := s.Clock().Now()
-	require.NoError(t, writer.UpdateRow(ctx, updateTimestamp, insertRow, updateRow))
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.UpdateRow(ctx, updateTimestamp, insertRow, updateRow)
+	})
+	require.NoError(t, err)
 	require.Equal(t,
 		[][]string{{"1", "updated", "NULL", hlcToString(updateTimestamp), "1"}},
 		sqlDB.QueryStr(t, "SELECT id, name, is_always_null, crdb_internal_origin_timestamp, crdb_internal_origin_id FROM test_table WHERE id = 1"))
 
 	// Test UpdateRow with stale previous value
 	staleRow := makeTestRow(t, desc, 1, "test") // Using old value
-	err = writer.UpdateRow(ctx, s.Clock().Now(), staleRow, updateRow)
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.UpdateRow(ctx, s.Clock().Now(), staleRow, updateRow)
+	})
 	require.ErrorIs(t, err, ErrStalePreviousValue)
 
 	// Test DeleteRow - first insert a test row to verify origin data before delete
@@ -110,19 +115,27 @@ func TestSQLRowWriter(t *testing.T) {
 		sqlDB.QueryStr(t, "SELECT id, name, is_always_null, crdb_internal_origin_timestamp, crdb_internal_origin_id FROM test_table WHERE id = 2"))
 
 	// Now delete the row
-	require.NoError(t, writer.DeleteRow(ctx, s.Clock().Now(), insertRow2))
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.DeleteRow(ctx, s.Clock().Now(), insertRow2)
+	})
+	require.NoError(t, err)
 	require.Equal(t,
 		[][]string{},
 		sqlDB.QueryStr(t, "SELECT id, name, is_always_null, crdb_internal_origin_timestamp, crdb_internal_origin_id FROM test_table WHERE id = 2"))
 
 	// Also delete the original row to clean up
-	require.NoError(t, writer.DeleteRow(ctx, s.Clock().Now(), updateRow))
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.DeleteRow(ctx, s.Clock().Now(), updateRow)
+	})
+	require.NoError(t, err)
 	require.Equal(t,
 		[][]string{},
 		sqlDB.QueryStr(t, "SELECT id, name, is_always_null, crdb_internal_origin_timestamp, crdb_internal_origin_id FROM test_table WHERE id = 1"))
 
 	// Test DeleteRow with stale value
-	err = writer.DeleteRow(ctx, s.Clock().Now(), staleRow)
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.DeleteRow(ctx, s.Clock().Now(), staleRow)
+	})
 	require.ErrorIs(t, err, ErrStalePreviousValue)
 
 	// Test InsertRow LWW failure against existing row: inserting with an older

--- a/pkg/crosscluster/logical/txnwriter/apply_batch.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch.go
@@ -96,6 +96,10 @@ func (tw *transactionWriter) tryApplyTransaction(
 		switch {
 		case row.IsDeleteRow():
 			err := tableWriter.DeleteRow(ctx, transaction.TxnID.Timestamp, row.PrevRow)
+			if sqlwriter.IsLwwLoser(err) {
+				lwwLosers++
+				continue
+			}
 			if err != nil {
 				return ApplyResult{}, err
 			}
@@ -118,6 +122,10 @@ func (tw *transactionWriter) tryApplyTransaction(
 				row.PrevRow,
 				row.Row,
 			)
+			if sqlwriter.IsLwwLoser(err) {
+				lwwLosers++
+				continue
+			}
 			if err != nil {
 				return ApplyResult{}, err
 			}

--- a/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
@@ -310,6 +310,85 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 				[][]string{{"new-insert"}},
 			)
 		},
+	}, {
+		// Regression test for #170683: an update whose previous value matches the
+		// local row but whose origin timestamp is older should be an LWW loser.
+		// Without the fix, the KV layer returns ConditionFailedError which is not
+		// caught as an LWW loser.
+		name: "update_lww_loser_with_correct_prev",
+		setup: func(t *testing.T, baseID int) {
+			sqlDB.Exec(t, fmt.Sprintf(
+				`INSERT INTO parent (id, payload) VALUES (%d, 'local')`, baseID+1))
+		},
+		buildTxn: func(t *testing.T, baseID int, preSetupTS hlc.Timestamp) ldrdecoder.Transaction {
+			return ldrdecoder.Transaction{
+				TxnID: ldrdecoder.TxnID{Timestamp: preSetupTS},
+				WriteSet: []ldrdecoder.DecodedRow{
+					{
+						Row:     parentRow(baseID+1, "loser"),
+						PrevRow: parentRow(baseID+1, "local"),
+						TableID: parentID,
+					},
+					{
+						Row:     parentRow(baseID+2, "new-insert"),
+						PrevRow: nil,
+						TableID: parentID,
+					},
+				},
+			}
+		},
+		validate: func(t *testing.T, baseID int, result ApplyResult) {
+			require.Equal(t, ApplyResult{AppliedRows: 1, LwwLoserRows: 1}, result)
+			// Original row unchanged.
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT payload FROM parent WHERE id = %d`, baseID+1),
+				[][]string{{"local"}},
+			)
+			// Second insert succeeded.
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT payload FROM parent WHERE id = %d`, baseID+2),
+				[][]string{{"new-insert"}},
+			)
+		},
+	}, {
+		// Regression test for #170683: a delete whose previous value matches the
+		// local row but whose origin timestamp is older should be an LWW loser.
+		name: "delete_lww_loser_with_correct_prev",
+		setup: func(t *testing.T, baseID int) {
+			sqlDB.Exec(t, fmt.Sprintf(
+				`INSERT INTO parent (id, payload) VALUES (%d, 'local')`, baseID+1))
+		},
+		buildTxn: func(t *testing.T, baseID int, preSetupTS hlc.Timestamp) ldrdecoder.Transaction {
+			return ldrdecoder.Transaction{
+				TxnID: ldrdecoder.TxnID{Timestamp: preSetupTS},
+				WriteSet: []ldrdecoder.DecodedRow{
+					{
+						Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
+						PrevRow:  parentRow(baseID+1, "local"),
+						IsDelete: true,
+						TableID:  parentID,
+					},
+					{
+						Row:     parentRow(baseID+2, "new-insert"),
+						PrevRow: nil,
+						TableID: parentID,
+					},
+				},
+			}
+		},
+		validate: func(t *testing.T, baseID int, result ApplyResult) {
+			require.Equal(t, ApplyResult{AppliedRows: 1, LwwLoserRows: 1}, result)
+			// Original row unchanged.
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT payload FROM parent WHERE id = %d`, baseID+1),
+				[][]string{{"local"}},
+			)
+			// Second insert succeeded.
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT payload FROM parent WHERE id = %d`, baseID+2),
+				[][]string{{"new-insert"}},
+			)
+		},
 	}}
 
 	lwwWinners := []applyTestCase{{


### PR DESCRIPTION
Previously, the transaction writer only checked for LWW losers on the INSERT path. When an UPDATE or DELETE had the correct previous value (WHERE clause matched) but an older origin timestamp, the KV layer rejected the write with a ConditionFailedError. This error was not recognized as an LWW loser and instead propagated as a failure.

This was masked when UseSwapMutations was enabled because the swap node swallows all ConditionFailedErrors (including LWW losers) and returns zero rows affected, which causes UpdateRow/DeleteRow to return ErrStalePreviousValue. The refresh path then correctly identifies the LWW loser by comparing timestamps. Since UseSwapMutations is enabled by default and only disabled metamorphically, the bug manifested non-deterministically in tests.

Fix this by adding IsLwwLoser checks to the UPDATE and DELETE paths in tryApplyTransaction, matching the existing INSERT pattern. Also wrap UpdateRow and DeleteRow in savepoints so that the ConditionFailedError does not poison the SQL transaction for subsequent operations in the same batch. The sql_row_writer_test.go changes are mechanical: the savepoint wrapper requires an active transaction around each call.

Fixes: #170683
Epic: CRDB-60163

Release note: None