### PR TITLE
release-26.2: roachtest: deflake OR recovery

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -1209,6 +1209,19 @@ func WithClusterScope() CollectionConfig {
 	}
 }
 
+func WithTableScope() CollectionConfig {
+	return func(cb *CollectionBuilder) {
+		cb.cfg.scope = newTableBackup(cb.rng, cb.driver.dbs, cb.driver.tables)
+	}
+}
+
+func WithDatabaseScope() CollectionConfig {
+	return func(cb *CollectionBuilder) {
+		cb.cfg.scope = newDatabaseBackup(cb.rng, cb.driver.dbs, cb.driver.tables)
+	}
+}
+
+
 type (
 	// backupOption is an option passed to the `BACKUP` command (i.e.,
 	// `WITH ...` portion).

--- a/pkg/cmd/roachtest/tests/backup_restore_driver.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_driver.go
@@ -1190,15 +1190,16 @@ func (cb *CollectionBuilder) initCollCfg(cfgs ...CollectionConfig) {
 	}
 
 	if cb.cfg.options == nil {
-		cb.cfg.options = newBackupOptions(cb.rng, cb.driver.testUtils.onlineRestore)
+		cb.cfg.options = newBackupOptions(cb.rng, cb.driver.testUtils.onlineRestore, cb.cfg.skipRevisionHistory)
 	}
 }
 
 // collCfg holds the backup configuration for the backup collection and is used
 // to build the BACKUP statement when taking backups.
 type collCfg struct {
-	scope   backupScope
-	options []backupOption
+	scope               backupScope
+	options             []backupOption
+	skipRevisionHistory bool
 }
 
 type CollectionConfig func(*CollectionBuilder)
@@ -1221,6 +1222,16 @@ func WithDatabaseScope() CollectionConfig {
 	}
 }
 
+// WithSkipRevisionHistory excludes the revision_history option from the
+// randomized set of backup options. Used when revision_history backups are
+// known to be incompatible with the test (e.g., the OR recovery test relies
+// on the link phase not ingesting SSTs, which a revision_history backup
+// would cause).
+func WithSkipRevisionHistory() CollectionConfig {
+	return func(cb *CollectionBuilder) {
+		cb.cfg.skipRevisionHistory = true
+	}
+}
 
 type (
 	// backupOption is an option passed to the `BACKUP` command (i.e.,
@@ -1544,8 +1555,13 @@ func (rh revisionHistory) String() string {
 // newBackupOptions returns a list of backup options to be used when
 // creating a new backup. Each backup option has a 50% chance of being
 // included.
-func newBackupOptions(rng *rand.Rand, onlineRestoreExpected bool) []backupOption {
-	possibleOpts := []backupOption{revisionHistory{}}
+func newBackupOptions(
+	rng *rand.Rand, onlineRestoreExpected, skipRevisionHistory bool,
+) []backupOption {
+	var possibleOpts []backupOption
+	if !skipRevisionHistory {
+		possibleOpts = append(possibleOpts, revisionHistory{})
+	}
 	if !onlineRestoreExpected {
 		possibleOpts = append(possibleOpts, newEncryptionPassphrase(rng))
 	}

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -296,6 +296,27 @@ func WaitForFailed(
 		}, maxWait)
 }
 
+// WaitForCanceled waits for a job to reach the canceled state.
+func WaitForCanceled(
+	ctx context.Context, db *gosql.DB, jobID jobspb.JobID, maxWait time.Duration,
+) error {
+	return WaitForState(ctx, db, jobID,
+		func(state jobs.State) (success bool, unexpected bool) {
+			switch state {
+			case jobs.StateCanceled:
+				return true, false
+			case jobs.StateCancelRequested:
+				return false, false
+			case jobs.StateReverting:
+				return false, false
+			case jobs.StateRunning:
+				return false, false
+			default:
+				return false, true
+			}
+		}, maxWait)
+}
+
 type jobRecord struct {
 	status   string
 	payload  jobspb.Payload

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -871,7 +871,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 
 	dbs := []string{"bank", "tpcc", schemaChangeDB}
 	d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
-		ctx, t, c, testRNG, workloadSeed, testUtils, dbs, nil, /* excludedWorkloads */
+		ctx, t, c, testRNG, workloadSeed, testUtils, dbs,
 	)
 	require.NoError(t, err)
 
@@ -912,6 +912,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 		"online-restore-recovery",
 		bspec, bspec,
 		true /* internalSystemsJobs */, false, /* isMultitenant */
+		WithSkipRevisionHistory(),
 		scopes[rand.Intn(len(scopes))],
 	)
 	t.L().Printf("building backup collection")

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -859,142 +859,140 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 	t.L().Printf("random seed: %d", seed)
 
 	c.Start(ctx, t.L(), roachtestutil.MaybeUseMemoryBudget(t, 50), install.MakeClusterSettings(), c.CRDBNodes())
-	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	const jobStatusWait = time.Minute * 5
 
-	m.Go(func(ctx context.Context) error {
-		testUtils, err := setupBackupRestoreTestUtils(
-			ctx, t, c, testRNG,
-			withOnlineRestore(true), withCompaction(true),
+	testUtils, err := setupBackupRestoreTestUtils(
+		ctx, t, c, testRNG,
+		withOnlineRestore(true), withCompaction(true),
+	)
+	require.NoError(t, err)
+	defer testUtils.CloseConnections()
+
+	dbs := []string{"bank", "tpcc", schemaChangeDB}
+	d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
+		ctx, t, c, testRNG, workloadSeed, testUtils, dbs, nil, /* excludedWorkloads */
+	)
+	require.NoError(t, err)
+
+	stopBackgroundCommands, err := runBackgroundWorkload()
+	require.NoError(t, err)
+	defer stopBackgroundCommands()
+
+	dbConn := c.Conn(ctx, t.L(), c.CRDBNodes().RandNode()[0])
+	defer dbConn.Close()
+
+	allNodes := labeledNodes{Nodes: c.CRDBNodes(), Version: clusterupgrade.CurrentVersion().String()}
+	bspec := backupSpec{
+		Plan:    allNodes,
+		Execute: allNodes,
+	}
+
+	// Since we are intentionally failing the download job by deleting a file,
+	// we reduce the retry duration for the job to speed up the test.
+	_, err = dbConn.ExecContext(
+		ctx, "SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '5s'",
+	)
+	require.NoError(t, err, "failed to set download phase retry duration")
+
+	// We set this pausepoint so that the download job is paused before it
+	// begins downloading external files. This allows us to delete the backup
+	// SSTs before the download job attempts to read them.
+	// We also must set this BEFORE taking backups. In the event of a full
+	// cluster backup, the link phase of OR will reset the pausepoints back to
+	// the point of the backup, which means this pausepoint will be wiped if it
+	// is set after the backups.
+	_, err = dbConn.ExecContext(
+		ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_do_download_files'",
+	)
+	require.NoError(t, err, "failed to set pausepoint for online restore")
+
+	builder := d.NewCollectionBuilder(
+		t.L(), t,
+		testRNG,
+		"online-restore-recovery",
+		bspec, bspec,
+		true /* internalSystemsJobs */, false, /* isMultitenant */
+	)
+	t.L().Printf("building backup collection")
+	_, err = builder.TakeFullSync(ctx)
+	require.NoError(t, err)
+	for range 3 {
+		d.randomWait(t.L(), testRNG)
+		_, err = builder.TakeIncSync(ctx)
+		require.NoError(t, err)
+	}
+	if testRNG.Intn(2) == 0 {
+		_, err = builder.TakeCompactedSync(ctx, 1, 3)
+		require.NoError(t, err)
+	}
+	collection, err := builder.Finalize(ctx)
+	require.NoError(t, err)
+
+	// If we're running a cluster backup, we need to reset the cluster
+	// to restore it. We also intentionally stop background commands so
+	// the workloads don't report errors.
+	if _, ok := collection.btype.(*clusterBackup); ok {
+		t.L().Printf("resetting cluster before restoring full cluster backup")
+		stopBackgroundCommands()
+		t.Monitor().ExpectProcessDead(c.CRDBNodes())
+
+		// Between each reset grab a debug zip from the cluster.
+		zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
+		if err := testUtils.cluster.FetchDebugZip(ctx, t.L(), zipPath); err != nil {
+			t.L().Printf("failed to fetch a debug zip: %v", err)
+		}
+		err := testUtils.resetCluster(
+			ctx, t.L(), clusterupgrade.CurrentVersion(),
+			nil /* expectDeathsFn */, []install.ClusterSettingOption{},
 		)
-		if err != nil {
-			return err
-		}
-		defer testUtils.CloseConnections()
+		require.NoError(t, err, "failed to reset cluster before restore")
+	}
 
-		dbs := []string{"bank", "tpcc", schemaChangeDB}
-		d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
-			ctx, t, c, testRNG, workloadSeed, testUtils, dbs,
-		)
-		if err != nil {
-			return err
-		}
+	t.L().Printf("performing online restore of backup")
+	_, _, err = d.runRestore(
+		ctx, t.L(), testRNG, collection,
+		false /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
+	)
+	require.NoError(t, err, "failed to execute online restore link phase")
 
-		stopBackgroundCommands, err := runBackgroundWorkload()
-		if err != nil {
-			return err
-		}
-		defer stopBackgroundCommands()
+	downloadJobID, err := d.getORDownloadJobID(ctx, t.L(), testRNG)
+	require.NoError(t, err, "failed to get online restore download job ID")
 
-		dbConn := c.Conn(ctx, t.L(), c.CRDBNodes().RandNode()[0])
-		defer dbConn.Close()
+	// Delete the backup SSTs as soon as possible after the link phase
+	// completes to minimize the window in which regular LSM compaction
+	// could download and incorporate the external SSTs, which would cause
+	// the download job to see 0 external bytes and succeed immediately.
+	err = d.deleteSSTFromBackupLayers(ctx, t.L(), dbConn, collection)
+	require.NoError(t, err, "failed to delete SSTs from backup layers")
 
-		allNodes := labeledNodes{Nodes: c.CRDBNodes(), Version: clusterupgrade.CurrentVersion().String()}
-		bspec := backupSpec{
-			Plan:    allNodes,
-			Execute: allNodes,
-		}
+	err = WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait)
+	require.NoError(t, err, "download job did not pause after deleting SSTs")
 
-		// We set this pausepoint so that the download job is paused before it
-		// begins downloading external files. This allows us to delete the backup
-		// SSTs before the download job attempts to read them.
-		// We also must set this BEFORE taking backups. In the event of a full
-		// cluster backup, the link phase of OR will reset the pausepoints back to
-		// the point of the backup, which means this pausepoint will be wiped if it
-		// is set after the backups.
-		if _, err := dbConn.ExecContext(
-			ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_do_download_files'",
-		); err != nil {
-			return errors.Wrap(err, "failed to set pausepoint for online restore")
-		}
+	// defaultdb is going to be set offline by the failed download job, so we
+	// need to switch to the system database first to avoid any errors.
+	_, err = dbConn.ExecContext(ctx, "USE system")
+	require.NoError(t, err)
 
-		t.L().Printf("starting backup")
-		collection, err := d.createBackupCollection(
-			ctx, t.L(), t, testRNG, bspec, bspec, "online-restore-recovery-backup",
-			true /* internalSystemsJobs */, false, /* isMultitenant */
-		)
-		if err != nil {
-			return err
-		}
+	_, err = dbConn.ExecContext(
+		ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = ''",
+	)
+	require.NoError(t, err, "failed to remove pausepoint for online restore")
 
-		// If we're running a cluster backup, we need to reset the cluster
-		// to restore it. We also intentionally stop background commands so
-		// the workloads don't report errors.
-		if _, ok := collection.btype.(*clusterBackup); ok {
-			t.L().Printf("resetting cluster before restoring full cluster backup")
-			stopBackgroundCommands()
-			expectDeathsFn := func(n int) {
-				m.ExpectDeaths(int32(n))
-			}
+	_, err = dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID)
+	require.NoError(t, err, "failed to resume download job after deleting SSTs")
 
-			// Between each reset grab a debug zip from the cluster.
-			zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
-			if err := testUtils.cluster.FetchDebugZip(ctx, t.L(), zipPath); err != nil {
-				t.L().Printf("failed to fetch a debug zip: %v", err)
-			}
-			if err := testUtils.resetCluster(
-				ctx, t.L(), clusterupgrade.CurrentVersion(), expectDeathsFn, []install.ClusterSettingOption{},
-			); err != nil {
-				return err
-			}
-		}
+	err = WaitForResume(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait)
+	require.NoError(t, err, "download job did not resume after being resumed")
 
-		t.L().Printf("performing online restore of backup")
-		if _, _, err := d.runRestore(
-			ctx, t.L(), testRNG, collection,
-			false /* checkFiles */, true /* internalSystemJobs */, nil, /* mvHelper */
-		); err != nil {
-			return err
-		}
-		downloadJobID, err := d.getORDownloadJobID(ctx, t.L(), testRNG)
-		if err != nil {
-			return err
-		}
+	err = WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait)
+	require.NoError(t, err, "download job did not pause after resuming")
 
-		// Delete the backup SSTs as soon as possible after the link phase
-		// completes to minimize the window in which regular LSM compaction
-		// could download and incorporate the external SSTs, which would cause
-		// the download job to see 0 external bytes and succeed immediately.
-		if err := d.deleteSSTFromBackupLayers(ctx, t.L(), dbConn, collection); err != nil {
-			return err
-		}
+	_, err = dbConn.ExecContext(ctx, "CANCEL JOB $1", downloadJobID)
+	require.NoError(t, err, "failed to cancel download job after it paused")
 
-		if err := WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
-			return errors.Wrapf(
-				err, "waiting for download job %v to reach paused state", downloadJobID,
-			)
-		}
+	err = WaitForCanceled(ctx, dbConn, jobspb.JobID(downloadJobID), 10*time.Minute)
+	require.NoError(t, err, "download job did not reach canceled state")
 
-		// defaultdb is going to be set offline by the failed download job, so we
-		// need to switch to the system database first to avoid any errors.
-		if _, err := dbConn.ExecContext(ctx, "USE system"); err != nil {
-			return err
-		}
-
-		if _, err := dbConn.ExecContext(
-			ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = ''",
-		); err != nil {
-			return errors.Wrap(err, "failed to remove pausepoint for online restore")
-		}
-		if _, err := dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID); err != nil {
-			return errors.Wrapf(
-				err, "failed to resume download job %v after deleting sst", downloadJobID,
-			)
-		}
-		if err := WaitForResume(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
-			return errors.Wrapf(
-				err, "waiting for download job %v to reach resumed state", downloadJobID,
-			)
-		}
-		if err := WaitForFailed(ctx, dbConn, jobspb.JobID(downloadJobID), 10*time.Minute); err != nil {
-			return errors.Wrapf(
-				err, "waiting for download job %v to reach failed state", downloadJobID,
-			)
-		}
-		return errors.Wrapf(
-			checkNoExternalBytesRemaining(ctx, dbConn),
-			"cluster did not cleanup all external files after download phase failure",
-		)
-	})
-	m.Wait()
+	err = checkNoExternalBytesRemaining(ctx, dbConn)
+	require.NoError(t, err, "external bytes still remain after download job failure")
 }

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -894,24 +895,24 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 	)
 	require.NoError(t, err, "failed to set download phase retry duration")
 
-	// We set this pausepoint so that the download job is paused before it
-	// begins downloading external files. This allows us to delete the backup
-	// SSTs before the download job attempts to read them.
-	// We also must set this BEFORE taking backups. In the event of a full
-	// cluster backup, the link phase of OR will reset the pausepoints back to
-	// the point of the backup, which means this pausepoint will be wiped if it
-	// is set after the backups.
-	_, err = dbConn.ExecContext(
-		ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_do_download_files'",
-	)
-	require.NoError(t, err, "failed to set pausepoint for online restore")
-
+	// A cluster backup will not allow deleting SSTs before the link phase
+	// completes, as it reads from the SSTs to restore the system tables. #170225
+	// outlines a bug where linked SSTs are being ingested into L0, which triggers
+	// a Pebble compaction that downloads the SSTs before the download job
+	// attempts to download them, which breaks this test. Until that issue is
+	// resolved, we will only run database/table backups so that we can delete the
+	// SSTs before the link phase, preventing Pebble compaction.
+	scopes := []CollectionConfig{
+		WithDatabaseScope(),
+		WithTableScope(),
+	}
 	builder := d.NewCollectionBuilder(
 		t.L(), t,
 		testRNG,
 		"online-restore-recovery",
 		bspec, bspec,
 		true /* internalSystemsJobs */, false, /* isMultitenant */
+		scopes[rand.Intn(len(scopes))],
 	)
 	t.L().Printf("building backup collection")
 	_, err = builder.TakeFullSync(ctx)
@@ -928,25 +929,17 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 	collection, err := builder.Finalize(ctx)
 	require.NoError(t, err)
 
-	// If we're running a cluster backup, we need to reset the cluster
-	// to restore it. We also intentionally stop background commands so
-	// the workloads don't report errors.
-	if _, ok := collection.btype.(*clusterBackup); ok {
-		t.L().Printf("resetting cluster before restoring full cluster backup")
-		stopBackgroundCommands()
-		t.Monitor().ExpectProcessDead(c.CRDBNodes())
+	// Delete the backup SSTs as soon as possible after the link phase
+	// completes to minimize the window in which regular LSM compaction
+	// could download and incorporate the external SSTs, which would cause
+	// the download job to see 0 external bytes and succeed immediately.
+	err = d.deleteSSTFromBackupLayers(ctx, t.L(), dbConn, collection)
+	require.NoError(t, err, "failed to delete SSTs from backup layers")
 
-		// Between each reset grab a debug zip from the cluster.
-		zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
-		if err := testUtils.cluster.FetchDebugZip(ctx, t.L(), zipPath); err != nil {
-			t.L().Printf("failed to fetch a debug zip: %v", err)
-		}
-		err := testUtils.resetCluster(
-			ctx, t.L(), clusterupgrade.CurrentVersion(),
-			nil /* expectDeathsFn */, []install.ClusterSettingOption{},
-		)
-		require.NoError(t, err, "failed to reset cluster before restore")
-	}
+	// defaultdb is going to be set offline by the failed download job, so we
+	// need to switch to the system database first to avoid any errors.
+	_, err = dbConn.ExecContext(ctx, "USE system")
+	require.NoError(t, err)
 
 	t.L().Printf("performing online restore of backup")
 	_, _, err = d.runRestore(
@@ -958,34 +951,8 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 	downloadJobID, err := d.getORDownloadJobID(ctx, t.L(), testRNG)
 	require.NoError(t, err, "failed to get online restore download job ID")
 
-	// Delete the backup SSTs as soon as possible after the link phase
-	// completes to minimize the window in which regular LSM compaction
-	// could download and incorporate the external SSTs, which would cause
-	// the download job to see 0 external bytes and succeed immediately.
-	err = d.deleteSSTFromBackupLayers(ctx, t.L(), dbConn, collection)
-	require.NoError(t, err, "failed to delete SSTs from backup layers")
-
 	err = WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait)
-	require.NoError(t, err, "download job did not pause after deleting SSTs")
-
-	// defaultdb is going to be set offline by the failed download job, so we
-	// need to switch to the system database first to avoid any errors.
-	_, err = dbConn.ExecContext(ctx, "USE system")
-	require.NoError(t, err)
-
-	_, err = dbConn.ExecContext(
-		ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = ''",
-	)
-	require.NoError(t, err, "failed to remove pausepoint for online restore")
-
-	_, err = dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID)
-	require.NoError(t, err, "failed to resume download job after deleting SSTs")
-
-	err = WaitForResume(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait)
-	require.NoError(t, err, "download job did not resume after being resumed")
-
-	err = WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait)
-	require.NoError(t, err, "download job did not pause after resuming")
+	require.NoError(t, err, "download job did not pause due to deleted SSTs")
 
 	_, err = dbConn.ExecContext(ctx, "CANCEL JOB $1", downloadJobID)
 	require.NoError(t, err, "failed to cancel download job after it paused")


### PR DESCRIPTION
Backport:
  * 2/2 commits from "roachtest: deflake OR recovery " (#170148)
  * 1/1 commits from "roachtest: skip revision history in OR recovery test" (#170682)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: test-only changes
