### PR TITLE
json: fix AsText() quoting of non-finite float values

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -777,6 +777,44 @@ SELECT jsonb_build_array('+Inf'::FLOAT8, 'NaN'::FLOAT8)::STRING::JSONB
 ----
 ["Infinity", "NaN"]
 
+# Regression for #170623: extracting non-finite float values from JSONB with
+# the ->> operator should return unquoted text, just as it does for normal
+# numbers, so that ::float casts work.
+query R
+SELECT (jsonb_build_object('a', 'NaN'::float) ->> 'a')::float
+----
+NaN
+
+query R
+SELECT (jsonb_build_object('a', '+Inf'::float) ->> 'a')::float
+----
++Inf
+
+query R
+SELECT (jsonb_build_object('a', '-Inf'::float) ->> 'a')::float
+----
+-Inf
+
+query T
+SELECT jsonb_build_object('a', 1.5) ->> 'a'
+----
+1.5
+
+query T
+SELECT jsonb_build_object('a', 'NaN'::float) ->> 'a'
+----
+NaN
+
+query T
+SELECT jsonb_build_object('a', '+Inf'::float) ->> 'a'
+----
+Infinity
+
+query T
+SELECT jsonb_build_object('a', '-Inf'::float) ->> 'a'
+----
+-Infinity
+
 statement error pgcode 2202E array must have even number of elements
 SELECT json_object('{a,b,c}'::TEXT[])
 

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -2563,7 +2563,8 @@ func (j jsonFalse) AsText() (*string, error) {
 	return &s, nil
 }
 func (j jsonNumber) AsText() (*string, error) {
-	s := j.String()
+	dec := apd.Decimal(j)
+	s := dec.String()
 	return &s, nil
 }
 func (j jsonArray) AsText() (*string, error) {


### PR DESCRIPTION
jsonNumber.AsText() was delegating to jsonNumber.String(), which goes through Format() and wraps non-finite values (NaN, +Inf, -Inf) in quotes for valid JSON serialization. This caused the ->> operator to return "NaN" instead of NaN, making (jsonb ->> key)::float fail with "could not parse" errors—a problem hit by the sql activity update job.

Fix by calling apd.Decimal.String() directly in AsText(), bypassing the JSON quoting. This matches jsonString.AsText() which also strips JSON encoding.

Fixes: #170623
Release note (bug fix): Fixed a bug where extracting non-finite float values (NaN, Infinity, -Infinity) from JSONB using the ->> operator returned quoted strings (e.g. "NaN"), causing ::float casts to fail.