### PR TITLE
ci: declare workflow-level `contents: read` on essential-ci and check-pebble-dep

### DIFF
--- a/.github/workflows/check-pebble-dep.yml
+++ b/.github/workflows/check-pebble-dep.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 8 * * *' # Every day at 8:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-pebble-dep:
     if: github.repository == 'cockroachdb/cockroach'

--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -53,6 +53,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   acceptance:
     runs-on: [self-hosted, ubuntu_big_2404]


### PR DESCRIPTION
Both workflows are pure checks: `github-actions-essential-ci` runs the essential CI suite, `check-pebble-dep` validates the pebble dependency reference. No GitHub API writes from the workflows.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.