### PR TITLE
license: implement vCPU audit background writer for self-hosted clusters

### DIFF
--- a/pkg/server/license/BUILD.bazel
+++ b/pkg/server/license/BUILD.bazel
@@ -8,13 +8,16 @@ go_library(
         "enforcer.go",
         "license.go",
         "opts.go",
+        "vcpu_audit.go",
         ":gen-lictype-stringer",  # keep
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/license",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/keys",
+        "//pkg/roachpb",
         "//pkg/server/license/licensepb",
+        "//pkg/server/status",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/isql",
@@ -25,6 +28,7 @@ go_library(
         "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
@@ -40,6 +44,7 @@ go_test(
         "license_decode_test.go",
         "license_enforcer_integration_test.go",
         "main_test.go",
+        "vcpu_audit_test.go",
     ],
     embed = [":license"],
     deps = [

--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -96,6 +96,20 @@ type Enforcer struct {
 	// in the metadata accessor. This is set to true during initialization if the
 	// latest timestamp was not received.
 	continueToPollMetadataAccessor atomic.Bool
+
+	// currentLicenseID is the license ID for the currently active license.
+	// Used to write vCPU audit records and detect license rotation.
+	// Stores sentinel value if no license is installed.
+	currentLicenseID atomic.Value
+
+	// auditMu serializes license ID updates and rotation detection in
+	// updateLicenseIDAndMaybeWrite.
+	auditMu syncutil.Mutex
+
+	// nodeID is the node ID used in vCPU audit records. It is set once when
+	// the audit writer starts via StartVCPUAuditWriter. A non-zero value
+	// indicates the writer is active and audit records should be emitted.
+	nodeID atomic.Int32
 }
 
 type TestingKnobs struct {
@@ -124,6 +138,20 @@ type TestingKnobs struct {
 	// OverrideTelemetryStatusReporter, if set, will set the telemetry status
 	// reporter in Start().
 	OverrideTelemetryStatusReporter TelemetryStatusReporter
+
+	// OverrideVCPUAuditInterval if set, overrides the 1-hour vCPU audit interval.
+	// Used for testing to accelerate ticker firing.
+	OverrideVCPUAuditInterval *time.Duration
+
+	// OverrideVCPUCount if set, overrides the value returned by status.GetVCPUs().
+	// Used for testing to provide deterministic vCPU counts.
+	OverrideVCPUCount *float64
+
+	// OnAuditRecordWritten if set, is called each time writeVCPUAuditRecord
+	// fires, both on normal ticker intervals and on immediate writes triggered
+	// by license rotation. Intended for use with an atomic counter or channel
+	// to verify write behavior in tests.
+	OnAuditRecordWritten func()
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
@@ -197,7 +225,7 @@ func (e *Enforcer) Start(ctx context.Context, st *cluster.Settings, opts ...Opti
 	// must be done after setting the cluster init grace period timestamp. And it
 	// is needed for testing that may be running this in isolation to the license
 	// ccl package.
-	e.RefreshForLicenseChange(ctx, LicTypeNone, time.Time{})
+	e.RefreshForLicenseChange(ctx, LicTypeNone, time.Time{}, nil /* licenseID */)
 
 	// Register a callback so that we refresh our state whenever the license
 	// changes. This will also update the state for the current license if not
@@ -455,8 +483,11 @@ func (e *Enforcer) MaybeFailIfThrottled(
 // information to optimize enforcement. Instead of reading the license from the
 // settings, unmarshaling it, and checking its type and expiry each time,
 // caching the information improves efficiency since licenses change infrequently.
+//
+// The licenseID parameter is used to detect license rotation for vCPU audit purposes.
+// Pass nil if no license is installed.
 func (e *Enforcer) RefreshForLicenseChange(
-	ctx context.Context, licType LicType, licenseExpiry time.Time,
+	ctx context.Context, licType LicType, licenseExpiry time.Time, licenseID []byte,
 ) {
 	e.hasLicense.Store(licType != LicTypeNone)
 	e.licenseExpiryTS.Store(licenseExpiry.Unix())
@@ -491,6 +522,9 @@ func (e *Enforcer) RefreshForLicenseChange(
 	}
 	sb.Printf("telemetry required: %t", e.licenseRequiresTelemetry.Load())
 	log.Dev.Infof(ctx, "%s", sb.RedactableString())
+
+	// Detect license rotation and trigger immediate vCPU audit write if needed.
+	e.updateLicenseIDAndMaybeWrite(ctx, licenseID)
 }
 
 // UpdateTrialLicenseExpiry updates the expiration timestamp of trial license

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -288,7 +288,7 @@ func TestThrottle(t *testing.T) {
 				license.WithTelemetryStatusReporter(&mockTelemetryStatusReporter{lastPingTime: &tc.lastTelemetryPingTime}),
 			)
 			require.NoError(t, err)
-			e.RefreshForLicenseChange(ctx, tc.licType, tc.licExpiry)
+			e.RefreshForLicenseChange(ctx, tc.licType, tc.licExpiry, nil /* licenseID */)
 			notice, err := e.TestingMaybeFailIfThrottled(ctx, tc.openTxnsCount)
 			if tc.expectedErrRegex == "" {
 				require.NoError(t, err)
@@ -371,7 +371,7 @@ func TestThrottleErrorMsg(t *testing.T) {
 
 	// Set up a free license that will expire in 30 days
 	licenseEnforcer := srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer
-	licenseEnforcer.RefreshForLicenseChange(ctx, license.LicTypeFree, t30d)
+	licenseEnforcer.RefreshForLicenseChange(ctx, license.LicTypeFree, t30d, nil /* licenseID */)
 
 	for _, tc := range []struct {
 		desc string

--- a/pkg/server/license/license.go
+++ b/pkg/server/license/license.go
@@ -177,10 +177,12 @@ func registerCallbackOnLicenseChange(
 		}
 		var licenseType LicType
 		var licenseExpiry time.Time
+		var licenseID []byte
 		if lic == nil {
 			licenseType = LicTypeNone
 		} else {
 			licenseExpiry = timeutil.Unix(lic.ValidUntilUnixSec, 0)
+			licenseID = lic.LicenseId
 			switch lic.Type {
 			case licensepb.License_Free:
 				licenseType = LicTypeFree
@@ -192,7 +194,7 @@ func registerCallbackOnLicenseChange(
 				licenseType = LicTypeEnterprise
 			}
 		}
-		licenseEnforcer.RefreshForLicenseChange(ctx, licenseType, licenseExpiry)
+		licenseEnforcer.RefreshForLicenseChange(ctx, licenseType, licenseExpiry, licenseID)
 
 		err = licenseEnforcer.UpdateTrialLicenseExpiry(
 			ctx, licenseType, isChange, licenseExpiry.Unix())

--- a/pkg/server/license/vcpu_audit.go
+++ b/pkg/server/license/vcpu_audit.go
@@ -1,0 +1,210 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// This file implements vCPU consumption tracking for self-hosted clusters.
+//
+// Background: CockroachDB's usage-based licensing model requires tracking
+// vCPU-hours consumed by each node. This package writes hourly audit records
+// to system.vcpu_hours_audit for later export via the `cockroach license audit` CLI.
+//
+// The audit system operates independently of license enforcement - it records
+// consumption data even when no license is installed or when licenses expire.
+
+package license
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// defaultVCPUAuditInterval is how often we write vCPU consumption records.
+	defaultVCPUAuditInterval = 1 * time.Hour
+
+	// vcpuAuditShutdownTimeout is the maximum time we wait to write the final
+	// audit record during shutdown.
+	vcpuAuditShutdownTimeout = 5 * time.Second
+
+	// noLicenseID is the sentinel value used when no license is installed.
+	// This matches the CLI behavior matrix in the design doc.
+	noLicenseID = "no-license"
+)
+
+// vcpuAuditData contains the data needed to write a vCPU audit record.
+type vcpuAuditData struct {
+	// licenseID is the unique identifier for the license.
+	licenseID []byte
+
+	// vcpuCount is the number of vCPUs allocated to this node.
+	vcpuCount float64
+}
+
+// getVCPUAuditData collects the current vCPU count and license ID.
+// This is the data needed to write one audit record.
+func (e *Enforcer) getVCPUAuditData(ctx context.Context) vcpuAuditData {
+	data := vcpuAuditData{}
+
+	// Get vCPU count from status package (cgroup-aware).
+	data.vcpuCount = status.GetVCPUs(ctx)
+	// Allow test override for deterministic vCPU counts.
+	if tk := e.GetTestingKnobs(); tk != nil && tk.OverrideVCPUCount != nil {
+		data.vcpuCount = *tk.OverrideVCPUCount
+	}
+
+	licIDRaw := e.currentLicenseID.Load()
+	if licIDRaw != nil {
+		data.licenseID = licIDRaw.([]byte)
+	} else {
+		data.licenseID = []byte(noLicenseID)
+	}
+
+	return data
+}
+
+// getVCPUAuditInterval returns the interval for writing vCPU audit records.
+// Can be overridden for testing.
+func (e *Enforcer) getVCPUAuditInterval() time.Duration {
+	if tk := e.GetTestingKnobs(); tk != nil && tk.OverrideVCPUAuditInterval != nil {
+		return *tk.OverrideVCPUAuditInterval
+	}
+	return defaultVCPUAuditInterval
+}
+
+// TestingGetCurrentLicenseID returns the currently cached license ID.
+// Used for testing license rotation detection.
+func (e *Enforcer) TestingGetCurrentLicenseID() []byte {
+	val := e.currentLicenseID.Load()
+	if val == nil {
+		return nil
+	}
+	return val.([]byte)
+}
+
+// VCPUAuditDataForTest exposes vcpuAuditData for testing.
+type VCPUAuditDataForTest struct {
+	LicenseID []byte
+	VCPUCount float64
+}
+
+// GetVCPUAuditDataForTest returns the current vCPU audit data for testing.
+func (e *Enforcer) GetVCPUAuditDataForTest(ctx context.Context) VCPUAuditDataForTest {
+	data := e.getVCPUAuditData(ctx)
+	return VCPUAuditDataForTest{
+		LicenseID: data.licenseID,
+		VCPUCount: data.vcpuCount,
+	}
+}
+
+// writeVCPUAuditRecord writes a single vCPU consumption record for the given hour.
+// TODO(sadaf-crl): Replace log.Infof with actual SQL INSERT when
+// system.vcpu_hours_audit table is available.
+func (e *Enforcer) writeVCPUAuditRecord(ctx context.Context, hourTimestamp time.Time) {
+	nodeID := roachpb.NodeID(e.nodeID.Load())
+	data := e.getVCPUAuditData(ctx)
+
+	// Round timestamp to hour boundary.
+	hourTimestamp = hourTimestamp.Truncate(time.Hour)
+
+	// TODO(sadaf-crl): Replace this log statement with SQL INSERT:
+	//   INSERT INTO system.vcpu_hours_audit (node_id, license_id, hour_timestamp, num_vcpu)
+	//   VALUES ($1, $2, $3, $4)
+	log.Dev.Infof(ctx,
+		"TODO: write vcpu audit record: node_id=%d license_id=%x hour=%s vcpu_count=%.2f",
+		nodeID, data.licenseID, hourTimestamp.UTC().Format(time.RFC3339), data.vcpuCount)
+
+	if tk := e.GetTestingKnobs(); tk != nil && tk.OnAuditRecordWritten != nil {
+		tk.OnAuditRecordWritten()
+	}
+}
+
+// updateLicenseIDAndMaybeWrite checks if the license ID changed and triggers
+// an immediate vCPU audit write to prevent gaps in consumption tracking.
+// This is called from RefreshForLicenseChange when the license is updated.
+func (e *Enforcer) updateLicenseIDAndMaybeWrite(ctx context.Context, newLicenseID []byte) {
+	var licenseIDCopy []byte
+	if newLicenseID != nil {
+		licenseIDCopy = append([]byte(nil), newLicenseID...)
+	} else {
+		licenseIDCopy = []byte(noLicenseID)
+	}
+
+	// Serialize the read-update-compare cycle so that each license change
+	// triggers at most one immediate write.
+	var shouldWrite bool
+	func() {
+		e.auditMu.Lock()
+		defer e.auditMu.Unlock()
+
+		prevLicenseIDRaw := e.currentLicenseID.Load()
+		var prevLicenseID []byte
+		if prevLicenseIDRaw != nil {
+			prevLicenseID = prevLicenseIDRaw.([]byte)
+		}
+
+		e.currentLicenseID.Store(licenseIDCopy)
+
+		shouldWrite = !bytes.Equal(prevLicenseID, licenseIDCopy) && e.nodeID.Load() != 0
+	}()
+
+	if shouldWrite {
+		log.Dev.Infof(ctx, "license rotation detected, writing immediate vCPU audit record")
+		e.writeVCPUAuditRecord(ctx, timeutil.Now())
+	}
+}
+
+// StartVCPUAuditWriter starts a background goroutine that writes vCPU audit
+// records at regular intervals (default: hourly). The writer will:
+// - Write one record per hour to system.vcpu_hours_audit
+// - Attempt a final write on graceful shutdown (with timeout)
+//
+// This should be called once during enforcer initialization, after Start().
+// Returns an error if called multiple times or with invalid nodeID.
+func (e *Enforcer) StartVCPUAuditWriter(
+	ctx context.Context, stopper *stop.Stopper, nodeID roachpb.NodeID,
+) error {
+	if nodeID == 0 {
+		return errors.AssertionFailedf("invalid nodeID: %d", nodeID)
+	}
+
+	// CAS 0 → nodeID atomically marks the writer as started and publishes the
+	// node ID for concurrent license rotation handlers.
+	if !e.nodeID.CompareAndSwap(0, int32(nodeID)) {
+		return errors.New("vCPU audit writer already started")
+	}
+
+	return stopper.RunAsyncTask(ctx, "vcpu-audit-writer", func(ctx context.Context) {
+		// Write an initial record immediately so the first partial hour
+		// is not lost (e.g. on node restart during a rolling upgrade).
+		e.writeVCPUAuditRecord(ctx, timeutil.Now())
+		ticker := time.NewTicker(e.getVCPUAuditInterval())
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				e.writeVCPUAuditRecord(ctx, timeutil.Now())
+
+			case <-stopper.ShouldQuiesce():
+				// Attempt final write with timeout on shutdown.
+				_ = timeutil.RunWithTimeout(
+					context.Background(), "vcpu-audit-shutdown", vcpuAuditShutdownTimeout,
+					func(ctx context.Context) error {
+						e.writeVCPUAuditRecord(ctx, timeutil.Now())
+						return nil
+					})
+				log.Dev.Infof(ctx, "vcpu audit writer stopped")
+				return
+			}
+		}
+	})
+}

--- a/pkg/server/license/vcpu_audit_test.go
+++ b/pkg/server/license/vcpu_audit_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package license_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/server/license"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// ptrTo is a helper to create pointers to literals for testing.
+func ptrTo[T any](v T) *T {
+	return &v
+}
+
+func TestVCPUAuditWriter_TickerInterval(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var writeCount atomic.Int32
+	interval := 50 * time.Millisecond
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	e := license.NewEnforcer(&license.TestingKnobs{
+		OverrideVCPUAuditInterval: &interval,
+		OverrideVCPUCount:         ptrTo(4.0),
+		OnAuditRecordWritten: func() {
+			writeCount.Add(1)
+		},
+	})
+
+	err := e.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(true),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+	)
+	require.NoError(t, err)
+
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 1)
+	require.NoError(t, err)
+
+	// Wait for the startup write plus at least 2 ticker fires to verify
+	// the ticker loop keeps running.
+	require.Eventually(t, func() bool {
+		return writeCount.Load() >= 3
+	}, 2*time.Second, 10*time.Millisecond, "expected startup write and at least 2 ticker writes")
+}
+
+func TestVCPUAuditWriter_OverrideVCPUCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	expectedVCPU := 8.5
+
+	e := license.NewEnforcer(&license.TestingKnobs{
+		OverrideVCPUCount: &expectedVCPU,
+	})
+
+	// Get vCPU audit data directly without full enforcer.Start()
+	data := e.GetVCPUAuditDataForTest(ctx)
+
+	require.Equal(t, expectedVCPU, data.VCPUCount)
+}
+
+func TestVCPUAuditWriter_LicenseRotation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var writeCount atomic.Int32
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	e := license.NewEnforcer(&license.TestingKnobs{
+		// Long interval so the ticker doesn't fire during this test.
+		OverrideVCPUAuditInterval: ptrTo(1 * time.Hour),
+		OnAuditRecordWritten: func() {
+			writeCount.Add(1)
+		},
+	})
+	err := e.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(true),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+	)
+	require.NoError(t, err)
+
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 1)
+	require.NoError(t, err)
+
+	// Wait for the startup write before testing rotation-triggered writes.
+	require.Eventually(t, func() bool {
+		return writeCount.Load() >= 1
+	}, time.Second, 5*time.Millisecond, "expected startup write")
+	countAfterStartup := writeCount.Load()
+
+	// First license — no previous value, so this is a rotation from "no-license".
+	lic1 := []byte("license-id-1")
+	e.RefreshForLicenseChange(ctx, license.LicTypeEnterprise, time.Now().Add(time.Hour), lic1)
+
+	require.Eventually(t, func() bool {
+		return writeCount.Load() >= countAfterStartup+1
+	}, time.Second, 5*time.Millisecond, "expected immediate write on first license rotation")
+
+	stored := e.TestingGetCurrentLicenseID()
+	require.Equal(t, lic1, stored)
+
+	countAfterFirst := writeCount.Load()
+
+	// Rotate to new license — should trigger a second immediate write.
+	lic2 := []byte("license-id-2")
+	e.RefreshForLicenseChange(ctx, license.LicTypeEnterprise, time.Now().Add(time.Hour), lic2)
+
+	require.Eventually(t, func() bool {
+		return writeCount.Load() >= countAfterFirst+1
+	}, time.Second, 5*time.Millisecond, "expected immediate write on license rotation")
+
+	stored = e.TestingGetCurrentLicenseID()
+	require.Equal(t, lic2, stored)
+}
+
+// TestVCPUAuditWriter_LicenseRotationBeforeStart verifies that license ID changes
+// arriving before StartVCPUAuditWriter are cached (so the first write uses the
+// correct state), but that no audit write is triggered until the writer has started.
+func TestVCPUAuditWriter_LicenseRotationBeforeStart(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var writeCount atomic.Int32
+	e := license.NewEnforcer(&license.TestingKnobs{
+		OnAuditRecordWritten: func() {
+			writeCount.Add(1)
+		},
+	})
+
+	// Call RefreshForLicenseChange BEFORE StartVCPUAuditWriter.
+	lic1 := []byte("license-id-1")
+	e.RefreshForLicenseChange(ctx, license.LicTypeEnterprise, time.Now().Add(time.Hour), lic1)
+
+	// The license ID should be cached so that the first write after startup
+	// uses the correct value.
+	stored := e.TestingGetCurrentLicenseID()
+	require.Equal(t, lic1, stored, "license ID should be cached even before audit writer starts")
+
+	// No audit write should have been triggered yet.
+	require.Zero(t, writeCount.Load(), "no write should fire before audit writer starts")
+}
+
+func TestVCPUAuditWriter_ShutdownWrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	var writeCount atomic.Int32
+	// Long interval so the normal tick won't fire during the test.
+	interval := 1 * time.Hour
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer func() {
+		srv.Stopper().Stop(ctx)
+		// Verify both the startup write and the shutdown write fired.
+		require.GreaterOrEqual(t, writeCount.Load(), int32(2), "expected startup write and shutdown write")
+	}()
+
+	e := license.NewEnforcer(&license.TestingKnobs{
+		OverrideVCPUAuditInterval: &interval,
+		OverrideVCPUCount:         ptrTo(4.0),
+		OnAuditRecordWritten: func() {
+			writeCount.Add(1)
+		},
+	})
+
+	err := e.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(true),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+	)
+	require.NoError(t, err)
+
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 1)
+	require.NoError(t, err)
+}
+
+func TestVCPUAuditWriter_PreventMultipleStarts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	e := license.NewEnforcer(nil)
+	err := e.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(true),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+	)
+	require.NoError(t, err)
+
+	// First call succeeds.
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 1)
+	require.NoError(t, err)
+
+	// Second call fails.
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already started")
+}
+
+func TestVCPUAuditWriter_InvalidNodeID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	e := license.NewEnforcer(nil)
+	err := e.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(true),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+	)
+	require.NoError(t, err)
+
+	// nodeID = 0 should fail.
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid nodeID")
+}
+
+func TestVCPUAuditWriter_NoLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	e := license.NewEnforcer(nil)
+
+	// Don't set any license - get vCPU data directly.
+	data := e.GetVCPUAuditDataForTest(ctx)
+
+	// Should use sentinel value, not nil.
+	require.Equal(t, []byte("no-license"), data.LicenseID)
+}
+
+func TestVCPUAuditWriter_ByteSliceCopyOnRotation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	e := license.NewEnforcer(nil)
+	err := e.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(true),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+	)
+	require.NoError(t, err)
+
+	err = e.StartVCPUAuditWriter(ctx, srv.Stopper(), 1)
+	require.NoError(t, err)
+
+	// Create a mutable byte slice.
+	lic1 := []byte("license-id-1")
+	originalLic1 := string(lic1)
+
+	// Rotate to this license.
+	e.RefreshForLicenseChange(ctx, license.LicTypeEnterprise, time.Now().Add(time.Hour), lic1)
+
+	// Verify stored.
+	stored := e.TestingGetCurrentLicenseID()
+	require.Equal(t, originalLic1, string(stored))
+
+	// Mutate the original slice.
+	lic1[0] = 'X'
+
+	// Verify stored license is unchanged (was copied).
+	stored = e.TestingGetCurrentLicenseID()
+	require.Equal(t, originalLic1, string(stored))
+	require.NotEqual(t, string(lic1), string(stored))
+}

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -2009,6 +2009,16 @@ func (s *SQLServer) startLicenseEnforcer(ctx context.Context, knobs base.Testing
 	if err != nil {
 		log.Dev.Warningf(ctx, "failed to start the license enforcer: %v", err)
 	}
+
+	// TODO(sadaf-crl): Start the vCPU audit writer here once system.vcpu_hours_audit
+	// is created and writeVCPUAuditRecord is wired up with a real SQL INSERT.
+	// Only start for the system tenant since audit records go to a system table.
+	//   if s.execCfg.Codec.ForSystemTenant() {
+	//     nodeID := s.execCfg.NodeInfo.NodeID.SQLInstanceID()
+	//     if err := licenseEnforcer.StartVCPUAuditWriter(ctx, s.stopper, nodeID); err != nil {
+	//       log.Dev.Warningf(ctx, "failed to start vCPU audit writer: %v", err)
+	//     }
+	//   }
 }
 
 func (s *SQLServer) disableLicenseEnforcement(ctx context.Context) {


### PR DESCRIPTION
Add background ticker infrastructure for tracking vCPU consumption in self-hosted clusters.
A background goroutine fires hourly to collect vCPU data from status.GetVCPUs() and prepare it for writing to system.vcpu_hours_audit (table creation in follow-up).

The writer detects license rotation and triggers an immediate write to prevent gaps in consumption tracking. It handles graceful shutdown with a 5-second timeout for a final audit record write.

The actual SQL INSERT logic is stubbed with log.Dev.Infof() until the system table is created in a follow-up commit. (https://github.com/cockroachdb/cockroach/pull/170328/)

Epic: CC-35515
Release note: None