### PR TITLE
rpc: bound interceptor slice capacity in drpcDialOptsCommon

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -133,7 +133,11 @@ func (rpcCtx *Context) drpcDialOptsCommon(
 		drpcDialOpts = append(drpcDialOpts, drpcclient.WithPerRPCMetadata(map[string]string{key: value}))
 	}
 
+	// Bound capacity so that the append below cannot race with concurrent
+	// dials on the same rpcCtx by writing into a shared backing array. The
+	// gRPC sibling in dialOptsCommon does the same.
 	unaryInterceptors := rpcCtx.clientUnaryInterceptorsDRPC
+	unaryInterceptors = unaryInterceptors[:len(unaryInterceptors):len(unaryInterceptors)]
 	if rpcCtx.Knobs.UnaryClientInterceptorDRPC != nil {
 		interceptor := rpcCtx.Knobs.UnaryClientInterceptorDRPC(target, class)
 		if interceptor != nil {
@@ -144,6 +148,7 @@ func (rpcCtx *Context) drpcDialOptsCommon(
 	drpcDialOpts = append(drpcDialOpts, drpcclient.WithChainUnaryInterceptor(unaryInterceptors...))
 
 	streamInterceptors := rpcCtx.clientStreamInterceptorsDRPC
+	streamInterceptors = streamInterceptors[:len(streamInterceptors):len(streamInterceptors)]
 	if rpcCtx.Knobs.StreamClientInterceptorDRPC != nil {
 		interceptor := rpcCtx.Knobs.StreamClientInterceptorDRPC(target, class)
 		if interceptor != nil {


### PR DESCRIPTION
The local `unaryInterceptors` / `streamInterceptors` slices in `drpcDialOptsCommon` shared their backing array with the corresponding fields on `rpcCtx`. When a `UnaryClientInterceptorDRPC` or `StreamClientInterceptorDRPC` knob was set, two concurrent dials on the same `rpcCtx` would both `append` into the same element of the shared array, racing under `-race`.

Cap the slice capacity with `[:len:len]` before the optional append, mirroring the guard already present in the gRPC sibling at `pkg/rpc/context.go:1836`.

Fixes #170725.

Release note: None
Epic: none