### PR TITLE
sql: add stable jobs introspection surfaces in information_schema

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3436,6 +3436,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="information_schema.crdb_datums_to_bytes"></a><code>information_schema.crdb_datums_to_bytes(any...) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Converts datums into key-encoded bytes. Supports NULLs and all data types which may be used in index keys</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="information_schema.crdb_job_messages"></a><code>information_schema.crdb_job_messages(job_id: <a href="int.html">int</a>) &rarr; tuple{timestamptz AS recorded, string AS kind, string AS message}</code></td><td><span class="funcdesc"><p>Returns the messages emitted by the specified job, ordered by recorded time descending. Returns no rows if the job does not exist or is not visible to the current user.</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="session_user"></a><code>session_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the session user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="to_regclass"></a><code>to_regclass(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual relation name to its OID</p>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3438,6 +3438,8 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="information_schema.crdb_job_messages"></a><code>information_schema.crdb_job_messages(job_id: <a href="int.html">int</a>) &rarr; tuple{timestamptz AS recorded, string AS kind, string AS message}</code></td><td><span class="funcdesc"><p>Returns the messages emitted by the specified job, ordered by recorded time descending. Returns no rows if the job does not exist or is not visible to the current user.</p>
 </span></td><td>Volatile</td></tr>
+<tr><td><a name="information_schema.crdb_job_progress_history"></a><code>information_schema.crdb_job_progress_history(job_id: <a href="int.html">int</a>) &rarr; tuple{timestamptz AS recorded, float AS progress_fraction, decimal AS resolved}</code></td><td><span class="funcdesc"><p>Returns the progress trajectory of the specified job, ordered by recorded time descending. Returns no rows if the job does not exist or is not visible to the current user. The resolved column is the raw HLC; apply hlc_to_timestamp at the call site for a wall-clock value.</p>
+</span></td><td>Volatile</td></tr>
 <tr><td><a name="session_user"></a><code>session_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the session user. This function is provided for compatibility with PostgreSQL.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="to_regclass"></a><code>to_regclass(text: <a href="string.html">string</a>) &rarr; regtype</code></td><td><span class="funcdesc"><p>Translates a textual relation name to its OID</p>

--- a/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
@@ -45,7 +45,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Look for "toastable" types that aren't varlena.
  SELECT t1.oid, t1.typname
-@@ -67,15 +81,378 @@
+@@ -67,15 +81,379 @@
       WHERE t2.typname = ('_' || t1.typname)::name AND
             t2.typelem = t1.oid and t1.typarray = t2.oid)
  ORDER BY t1.oid;
@@ -91,6 +91,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 +     100198 | interval_tbl
 +     100213 | timestamp_tbl
 +     100214 | timestamptz_tbl
++ 4294966952 | crdb_jobs_with_progress
 + 4294966953 | crdb_jobs
 + 4294966954 | crdb_cluster_active_session_history
 + 4294966955 | crdb_node_active_session_history
@@ -429,7 +430,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 + 4294967292 | builtin_functions
 + 4294967293 | node_build_info
 + 4294967294 | backward_dependencies
-+(369 rows)
++(370 rows)
  
  -- Make sure typarray points to a "true" array type of our own base
  SELECT t1.oid, t1.typname as basetype, t2.typname as arraytype,

--- a/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
@@ -45,7 +45,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Look for "toastable" types that aren't varlena.
  SELECT t1.oid, t1.typname
-@@ -67,15 +81,377 @@
+@@ -67,15 +81,378 @@
       WHERE t2.typname = ('_' || t1.typname)::name AND
             t2.typelem = t1.oid and t1.typarray = t2.oid)
  ORDER BY t1.oid;
@@ -91,6 +91,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 +     100198 | interval_tbl
 +     100213 | timestamp_tbl
 +     100214 | timestamptz_tbl
++ 4294966953 | crdb_jobs
 + 4294966954 | crdb_cluster_active_session_history
 + 4294966955 | crdb_node_active_session_history
 + 4294966956 | spatial_ref_sys
@@ -428,7 +429,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 + 4294967292 | builtin_functions
 + 4294967293 | node_build_info
 + 4294967294 | backward_dependencies
-+(368 rows)
++(369 rows)
  
  -- Make sure typarray points to a "true" array type of our own base
  SELECT t1.oid, t1.typname as basetype, t2.typname as arraytype,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -160,6 +160,7 @@ var informationSchema = virtualSchema{
 		catconstants.InformationSchemaCrdbNodeActiveSessionHistoryTableID:    informationSchemaCrdbNodeActiveSessionHistoryTable,
 		catconstants.InformationSchemaCrdbClusterActiveSessionHistoryTableID: informationSchemaCrdbClusterActiveSessionHistoryTable,
 		catconstants.InformationSchemaCrdbJobsViewID:                         informationSchemaCrdbJobsView,
+		catconstants.InformationSchemaCrdbJobsWithProgressViewID:             informationSchemaCrdbJobsWithProgressView,
 	},
 	tableValidator:             validateInformationSchemaTable,
 	validWithNoDatabaseContext: true,
@@ -2618,6 +2619,28 @@ var informationSchemaCrdbJobsView = virtualSchemaView{
 		{Name: "finished", Typ: types.TimestampTZ},
 		{Name: "state", Typ: types.String},
 		{Name: "error", Typ: types.String},
+	},
+}
+
+var informationSchemaCrdbJobsWithProgressView = virtualSchemaView{
+	comment: `crdb_jobs extended with the current progress reading and ` +
+		`user-visible status message. resolved is the raw HLC decimal; ` +
+		`apply hlc_to_timestamp at the call site for a wall-clock value. ` +
+		`last_updated combines progress and status write timestamps.`,
+	schema: vtable.CRDBJobsWithProgress,
+	resultColumns: colinfo.ResultColumns{
+		{Name: "job_id", Typ: types.Int},
+		{Name: "job_type", Typ: types.String},
+		{Name: "owner", Typ: types.String},
+		{Name: "description", Typ: types.String},
+		{Name: "created", Typ: types.TimestampTZ},
+		{Name: "finished", Typ: types.TimestampTZ},
+		{Name: "state", Typ: types.String},
+		{Name: "error", Typ: types.String},
+		{Name: "progress_fraction", Typ: types.Float},
+		{Name: "resolved", Typ: types.Decimal},
+		{Name: "status_message", Typ: types.String},
+		{Name: "last_updated", Typ: types.TimestampTZ},
 	},
 }
 

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -159,6 +159,7 @@ var informationSchema = virtualSchema{
 		catconstants.InformationSchemaCrdbIndexUsageStatsiticsTableID:        informationSchemaCrdbIndexUsageStatsTable,
 		catconstants.InformationSchemaCrdbNodeActiveSessionHistoryTableID:    informationSchemaCrdbNodeActiveSessionHistoryTable,
 		catconstants.InformationSchemaCrdbClusterActiveSessionHistoryTableID: informationSchemaCrdbClusterActiveSessionHistoryTable,
+		catconstants.InformationSchemaCrdbJobsViewID:                         informationSchemaCrdbJobsView,
 	},
 	tableValidator:             validateInformationSchemaTable,
 	validWithNoDatabaseContext: true,
@@ -2600,6 +2601,23 @@ var informationSchemaCrdbClusterActiveSessionHistoryTable = virtualSchemaView{
 		{Name: "work_event_type", Typ: types.String},
 		{Name: "work_event", Typ: types.String},
 		{Name: "goroutine_id", Typ: types.Int},
+	},
+}
+
+var informationSchemaCrdbJobsView = virtualSchemaView{
+	comment: `per-job metadata from system.jobs without the truncation or column ` +
+		`omission applied by SHOW JOBS. Rows are filtered by ` +
+		`crdb_internal.can_view_job(owner).`,
+	schema: vtable.CRDBJobs,
+	resultColumns: colinfo.ResultColumns{
+		{Name: "job_id", Typ: types.Int},
+		{Name: "job_type", Typ: types.String},
+		{Name: "owner", Typ: types.String},
+		{Name: "description", Typ: types.String},
+		{Name: "created", Typ: types.TimestampTZ},
+		{Name: "finished", Typ: types.TimestampTZ},
+		{Name: "state", Typ: types.String},
+		{Name: "error", Typ: types.String},
 	},
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -51,6 +51,7 @@ test           information_schema  constraint_table_usage                 table 
 test           information_schema  crdb_cluster_active_session_history    table        public   SELECT          false
 test           information_schema  crdb_index_usage_statistics            table        public   SELECT          false
 test           information_schema  crdb_jobs                              table        public   SELECT          false
+test           information_schema  crdb_jobs_with_progress                table        public   SELECT          false
 test           information_schema  crdb_node_active_session_history       table        public   SELECT          false
 test           information_schema  data_type_privileges                   table        public   SELECT          false
 test           information_schema  domain_constraints                     table        public   SELECT          false

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -50,6 +50,7 @@ test           information_schema  constraint_column_usage                table 
 test           information_schema  constraint_table_usage                 table        public   SELECT          false
 test           information_schema  crdb_cluster_active_session_history    table        public   SELECT          false
 test           information_schema  crdb_index_usage_statistics            table        public   SELECT          false
+test           information_schema  crdb_jobs                              table        public   SELECT          false
 test           information_schema  crdb_node_active_session_history       table        public   SELECT          false
 test           information_schema  data_type_privileges                   table        public   SELECT          false
 test           information_schema  domain_constraints                     table        public   SELECT          false

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -39,6 +39,7 @@ information_schema  constraint_table_usage                 table  node  NULL  NU
 information_schema  crdb_cluster_active_session_history    view   node  NULL  NULL
 information_schema  crdb_index_usage_statistics            table  node  NULL  NULL
 information_schema  crdb_jobs                              view   node  NULL  NULL
+information_schema  crdb_jobs_with_progress                view   node  NULL  NULL
 information_schema  crdb_node_active_session_history       view   node  NULL  NULL
 information_schema  data_type_privileges                   table  node  NULL  NULL
 information_schema  domain_constraints                     table  node  NULL  NULL
@@ -257,6 +258,7 @@ information_schema  constraint_table_usage                 table  node  NULL  NU
 information_schema  crdb_cluster_active_session_history    view   node  NULL  NULL
 information_schema  crdb_index_usage_statistics            table  node  NULL  NULL
 information_schema  crdb_jobs                              view   node  NULL  NULL
+information_schema  crdb_jobs_with_progress                view   node  NULL  NULL
 information_schema  crdb_node_active_session_history       view   node  NULL  NULL
 information_schema  data_type_privileges                   table  node  NULL  NULL
 information_schema  domain_constraints                     table  node  NULL  NULL
@@ -426,6 +428,7 @@ information_schema  constraint_table_usage
 information_schema  crdb_cluster_active_session_history
 information_schema  crdb_index_usage_statistics
 information_schema  crdb_jobs
+information_schema  crdb_jobs_with_progress
 information_schema  crdb_node_active_session_history
 information_schema  data_type_privileges
 information_schema  domain_constraints
@@ -701,6 +704,7 @@ constraint_table_usage
 crdb_cluster_active_session_history
 crdb_index_usage_statistics
 crdb_jobs
+crdb_jobs_with_progress
 crdb_node_active_session_history
 data_type_privileges
 domain_constraints
@@ -1022,6 +1026,7 @@ system         information_schema  constraint_table_usage                 SYSTEM
 system         information_schema  crdb_cluster_active_session_history    SYSTEM VIEW  NO
 system         information_schema  crdb_index_usage_statistics            SYSTEM VIEW  NO
 system         information_schema  crdb_jobs                              SYSTEM VIEW  NO
+system         information_schema  crdb_jobs_with_progress                SYSTEM VIEW  NO
 system         information_schema  crdb_node_active_session_history       SYSTEM VIEW  NO
 system         information_schema  data_type_privileges                   SYSTEM VIEW  NO
 system         information_schema  domain_constraints                     SYSTEM VIEW  NO
@@ -2478,6 +2483,7 @@ NULL     public   system         information_schema  constraint_table_usage     
 NULL     public   system         information_schema  crdb_cluster_active_session_history    SELECT          NO            YES
 NULL     public   system         information_schema  crdb_index_usage_statistics            SELECT          NO            YES
 NULL     public   system         information_schema  crdb_jobs                              SELECT          NO            YES
+NULL     public   system         information_schema  crdb_jobs_with_progress                SELECT          NO            YES
 NULL     public   system         information_schema  crdb_node_active_session_history       SELECT          NO            YES
 NULL     public   system         information_schema  data_type_privileges                   SELECT          NO            YES
 NULL     public   system         information_schema  domain_constraints                     SELECT          NO            YES
@@ -2724,6 +2730,7 @@ NULL     public   system         information_schema  constraint_table_usage     
 NULL     public   system         information_schema  crdb_cluster_active_session_history    SELECT          NO            YES
 NULL     public   system         information_schema  crdb_index_usage_statistics            SELECT          NO            YES
 NULL     public   system         information_schema  crdb_jobs                              SELECT          NO            YES
+NULL     public   system         information_schema  crdb_jobs_with_progress                SELECT          NO            YES
 NULL     public   system         information_schema  crdb_node_active_session_history       SELECT          NO            YES
 NULL     public   system         information_schema  data_type_privileges                   SELECT          NO            YES
 NULL     public   system         information_schema  domain_constraints                     SELECT          NO            YES

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -38,6 +38,7 @@ information_schema  constraint_column_usage                table  node  NULL  NU
 information_schema  constraint_table_usage                 table  node  NULL  NULL
 information_schema  crdb_cluster_active_session_history    view   node  NULL  NULL
 information_schema  crdb_index_usage_statistics            table  node  NULL  NULL
+information_schema  crdb_jobs                              view   node  NULL  NULL
 information_schema  crdb_node_active_session_history       view   node  NULL  NULL
 information_schema  data_type_privileges                   table  node  NULL  NULL
 information_schema  domain_constraints                     table  node  NULL  NULL
@@ -255,6 +256,7 @@ information_schema  constraint_column_usage                table  node  NULL  NU
 information_schema  constraint_table_usage                 table  node  NULL  NULL
 information_schema  crdb_cluster_active_session_history    view   node  NULL  NULL
 information_schema  crdb_index_usage_statistics            table  node  NULL  NULL
+information_schema  crdb_jobs                              view   node  NULL  NULL
 information_schema  crdb_node_active_session_history       view   node  NULL  NULL
 information_schema  data_type_privileges                   table  node  NULL  NULL
 information_schema  domain_constraints                     table  node  NULL  NULL
@@ -423,6 +425,7 @@ information_schema  constraint_column_usage
 information_schema  constraint_table_usage
 information_schema  crdb_cluster_active_session_history
 information_schema  crdb_index_usage_statistics
+information_schema  crdb_jobs
 information_schema  crdb_node_active_session_history
 information_schema  data_type_privileges
 information_schema  domain_constraints
@@ -697,6 +700,7 @@ constraint_column_usage
 constraint_table_usage
 crdb_cluster_active_session_history
 crdb_index_usage_statistics
+crdb_jobs
 crdb_node_active_session_history
 data_type_privileges
 domain_constraints
@@ -1017,6 +1021,7 @@ system         information_schema  constraint_column_usage                SYSTEM
 system         information_schema  constraint_table_usage                 SYSTEM VIEW  NO
 system         information_schema  crdb_cluster_active_session_history    SYSTEM VIEW  NO
 system         information_schema  crdb_index_usage_statistics            SYSTEM VIEW  NO
+system         information_schema  crdb_jobs                              SYSTEM VIEW  NO
 system         information_schema  crdb_node_active_session_history       SYSTEM VIEW  NO
 system         information_schema  data_type_privileges                   SYSTEM VIEW  NO
 system         information_schema  domain_constraints                     SYSTEM VIEW  NO
@@ -2472,6 +2477,7 @@ NULL     public   system         information_schema  constraint_column_usage    
 NULL     public   system         information_schema  constraint_table_usage                 SELECT          NO            YES
 NULL     public   system         information_schema  crdb_cluster_active_session_history    SELECT          NO            YES
 NULL     public   system         information_schema  crdb_index_usage_statistics            SELECT          NO            YES
+NULL     public   system         information_schema  crdb_jobs                              SELECT          NO            YES
 NULL     public   system         information_schema  crdb_node_active_session_history       SELECT          NO            YES
 NULL     public   system         information_schema  data_type_privileges                   SELECT          NO            YES
 NULL     public   system         information_schema  domain_constraints                     SELECT          NO            YES
@@ -2717,6 +2723,7 @@ NULL     public   system         information_schema  constraint_column_usage    
 NULL     public   system         information_schema  constraint_table_usage                 SELECT          NO            YES
 NULL     public   system         information_schema  crdb_cluster_active_session_history    SELECT          NO            YES
 NULL     public   system         information_schema  crdb_index_usage_statistics            SELECT          NO            YES
+NULL     public   system         information_schema  crdb_jobs                              SELECT          NO            YES
 NULL     public   system         information_schema  crdb_node_active_session_history       SELECT          NO            YES
 NULL     public   system         information_schema  data_type_privileges                   SELECT          NO            YES
 NULL     public   system         information_schema  domain_constraints                     SELECT          NO            YES

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -352,3 +352,106 @@ statement ok
 DROP ROLE jobcontroller
 
 subtest end
+
+subtest information_schema_crdb_jobs
+
+user root
+
+# Set up a schema-change job we can predict on. The CREATE INDEX is named to
+# include a long enough description to verify the view does not truncate.
+statement ok
+CREATE TABLE crdb_jobs_long_named_test_table (x INT)
+
+statement ok
+CREATE INDEX a_descriptively_named_index_for_truncation_assertions
+  ON crdb_jobs_long_named_test_table (x)
+
+let $job_id
+SELECT job_id FROM information_schema.crdb_jobs
+WHERE job_type = 'SCHEMA CHANGE'
+  AND description LIKE 'CREATE INDEX a_descriptively_named_index_for_truncation_assertions%'
+
+# Column shape — exact column names, types, ordering. This is the stable contract.
+query TT colnames
+SELECT column_name, data_type
+  FROM information_schema.columns
+ WHERE table_schema = 'information_schema' AND table_name = 'crdb_jobs'
+ ORDER BY ordinal_position
+----
+column_name  data_type
+job_id       bigint
+job_type     text
+owner        text
+description  text
+created      timestamp with time zone
+finished     timestamp with time zone
+state        text
+error        text
+
+# The full description appears un-truncated.
+query T
+SELECT description FROM information_schema.crdb_jobs WHERE job_id = $job_id
+----
+CREATE INDEX a_descriptively_named_index_for_truncation_assertions ON test.public.crdb_jobs_long_named_test_table (x)
+
+# Compare with crdb_internal.jobs: error there is coalesced to '', here it is NULL
+# when the job has no error. We use length() rather than comparing strings so the
+# difference is unambiguous (NULL length() returns NULL, '' length() returns 0).
+query II
+SELECT length(error), (SELECT length(error) FROM crdb_internal.jobs WHERE job_id = $job_id)
+  FROM information_schema.crdb_jobs WHERE job_id = $job_id
+----
+NULL  0
+
+# The lifecycle column is named `state`, not `status` (which the underlying
+# system.jobs column was named, and which we reserve for granular phase strings
+# in the with-progress surface).
+query T
+SELECT state FROM information_schema.crdb_jobs WHERE job_id = $job_id
+----
+succeeded
+
+# Row-level access control mirrors crdb_internal.jobs: a non-admin user that
+# does not own a job and lacks VIEWJOB does not see it.
+user testuser
+
+query I
+SELECT count(*) FROM information_schema.crdb_jobs WHERE job_id = $job_id
+----
+0
+
+# Granting VIEWJOB exposes the row.
+user root
+
+statement ok
+GRANT SYSTEM VIEWJOB TO testuser
+
+user testuser
+
+query I
+SELECT count(*) FROM information_schema.crdb_jobs WHERE job_id = $job_id
+----
+1
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWJOB FROM testuser
+
+# allow_unsafe_internals = false (the post-unsafesql default for ordinary
+# sessions) must not block this surface. This is the entire point of the change.
+statement ok
+SET allow_unsafe_internals = false
+
+query I
+SELECT count(*) FROM information_schema.crdb_jobs WHERE job_id = $job_id
+----
+1
+
+statement ok
+RESET allow_unsafe_internals
+
+statement ok
+DROP TABLE crdb_jobs_long_named_test_table
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -455,3 +455,119 @@ statement ok
 DROP TABLE crdb_jobs_long_named_test_table
 
 subtest end
+
+subtest information_schema_crdb_jobs_with_progress
+
+user root
+
+# Drive a schema change so we have a job with progress/status entries we can
+# query through the joined view.
+statement ok
+CREATE TABLE crdb_jobs_wp_test (x INT)
+
+statement ok
+CREATE INDEX a_descriptively_named_idx_for_with_progress_assertions
+  ON crdb_jobs_wp_test (x)
+
+let $job_id
+SELECT job_id FROM information_schema.crdb_jobs
+WHERE job_type = 'SCHEMA CHANGE'
+  AND description LIKE 'CREATE INDEX a_descriptively_named_idx_for_with_progress_assertions%'
+
+# Column shape — exact column names, types, ordering. Stable contract.
+query TT colnames
+SELECT column_name, data_type
+  FROM information_schema.columns
+ WHERE table_schema = 'information_schema' AND table_name = 'crdb_jobs_with_progress'
+ ORDER BY ordinal_position
+----
+column_name        data_type
+job_id             bigint
+job_type           text
+owner              text
+description        text
+created            timestamp with time zone
+finished           timestamp with time zone
+state              text
+error              text
+progress_fraction  double precision
+resolved           numeric
+status_message     text
+last_updated       timestamp with time zone
+
+# The first eight columns return the same values as crdb_jobs.
+query TTTTBB
+SELECT v.job_type, v.owner, v.description, v.state,
+       v.error IS NULL,
+       v.created = j.created
+  FROM information_schema.crdb_jobs_with_progress v
+  JOIN information_schema.crdb_jobs              j USING (job_id)
+ WHERE job_id = $job_id
+----
+SCHEMA CHANGE  root  CREATE INDEX a_descriptively_named_idx_for_with_progress_assertions ON test.public.crdb_jobs_wp_test (x)  succeeded  true  true
+
+# progress_fraction reaches 1.0 on a successful schema change.
+query R
+SELECT progress_fraction FROM information_schema.crdb_jobs_with_progress WHERE job_id = $job_id
+----
+1
+
+# resolved is the raw HLC decimal or NULL for jobs that don't report a
+# high-water. Successful schema changes typically don't. Apply
+# hlc_to_timestamp at the call site to get a wall-clock value.
+query I
+SELECT count(*) FROM information_schema.crdb_jobs_with_progress
+WHERE job_id = $job_id
+  AND (resolved IS NULL OR hlc_to_timestamp(resolved) <= now())
+----
+1
+
+# last_updated is non-NULL for any job that reported progress at least once.
+query B
+SELECT last_updated IS NOT NULL FROM information_schema.crdb_jobs_with_progress
+WHERE job_id = $job_id
+----
+true
+
+# Row-level access control matches crdb_jobs.
+user testuser
+
+query I
+SELECT count(*) FROM information_schema.crdb_jobs_with_progress WHERE job_id = $job_id
+----
+0
+
+user root
+
+statement ok
+GRANT SYSTEM VIEWJOB TO testuser
+
+user testuser
+
+query I
+SELECT count(*) FROM information_schema.crdb_jobs_with_progress WHERE job_id = $job_id
+----
+1
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWJOB FROM testuser
+
+# Works under the unsafe-internals gate (the whole point of putting it in
+# information_schema rather than crdb_internal).
+statement ok
+SET allow_unsafe_internals = false
+
+query I
+SELECT count(*) FROM information_schema.crdb_jobs_with_progress WHERE job_id = $job_id
+----
+1
+
+statement ok
+RESET allow_unsafe_internals
+
+statement ok
+DROP TABLE crdb_jobs_wp_test
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -659,3 +659,97 @@ statement ok
 DROP TABLE crdb_jobs_msg_test
 
 subtest end
+
+subtest information_schema_crdb_job_progress_history
+
+user root
+
+statement ok
+CREATE TABLE crdb_jobs_ph_test (x INT)
+
+statement ok
+CREATE INDEX a_descriptively_named_idx_for_progress_history_assertions
+  ON crdb_jobs_ph_test (x)
+
+let $job_id
+SELECT job_id FROM information_schema.crdb_jobs
+WHERE job_type = 'SCHEMA CHANGE'
+  AND description LIKE 'CREATE INDEX a_descriptively_named_idx_for_progress_history_assertions%'
+
+# Function exists and returns the right column shape.
+query TRT colnames
+SELECT * FROM information_schema.crdb_job_progress_history($job_id) LIMIT 0
+----
+recorded  progress_fraction  resolved
+
+# A completed schema change writes at least one progress entry.
+query B
+SELECT count(*) > 0 FROM information_schema.crdb_job_progress_history($job_id)
+----
+true
+
+# Rows are ordered by recorded time descending.
+query B
+SELECT bool_and(prev IS NULL OR prev >= recorded)
+  FROM (
+    SELECT recorded, lag(recorded) OVER (ORDER BY recorded DESC) AS prev
+      FROM information_schema.crdb_job_progress_history($job_id)
+  )
+----
+true
+
+# resolved is the raw HLC decimal or NULL — never a TIMESTAMPTZ. Callers
+# wanting wall-clock apply hlc_to_timestamp at the call site.
+query B
+SELECT bool_and(resolved IS NULL OR hlc_to_timestamp(resolved) <= now())
+  FROM information_schema.crdb_job_progress_history($job_id)
+----
+true
+
+# Non-existent job: zero rows, no error.
+query I
+SELECT count(*) FROM information_schema.crdb_job_progress_history(-1)
+----
+0
+
+# Row-level access.
+user testuser
+
+query I
+SELECT count(*) FROM information_schema.crdb_job_progress_history($job_id)
+----
+0
+
+user root
+
+statement ok
+GRANT SYSTEM VIEWJOB TO testuser
+
+user testuser
+
+query B
+SELECT count(*) > 0 FROM information_schema.crdb_job_progress_history($job_id)
+----
+true
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWJOB FROM testuser
+
+# Unsafe-internals gate.
+statement ok
+SET allow_unsafe_internals = false
+
+query B
+SELECT count(*) > 0 FROM information_schema.crdb_job_progress_history($job_id)
+----
+true
+
+statement ok
+RESET allow_unsafe_internals
+
+statement ok
+DROP TABLE crdb_jobs_ph_test
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -571,3 +571,91 @@ statement ok
 DROP TABLE crdb_jobs_wp_test
 
 subtest end
+
+subtest information_schema_crdb_job_messages
+
+user root
+
+statement ok
+CREATE TABLE crdb_jobs_msg_test (x INT)
+
+statement ok
+CREATE INDEX a_descriptively_named_idx_for_messages_assertions
+  ON crdb_jobs_msg_test (x)
+
+let $job_id
+SELECT job_id FROM information_schema.crdb_jobs
+WHERE job_type = 'SCHEMA CHANGE'
+  AND description LIKE 'CREATE INDEX a_descriptively_named_idx_for_messages_assertions%'
+
+# Function exists and returns the right column shape.
+query TTT colnames
+SELECT * FROM information_schema.crdb_job_messages($job_id) LIMIT 0
+----
+recorded  kind  message
+
+# A schema-change job emits at least one state-transition message during its
+# lifecycle. We don't pin the exact message text or kind set because those are
+# documented as informational/extensible.
+query B
+SELECT count(*) > 0 FROM information_schema.crdb_job_messages($job_id)
+----
+true
+
+# Messages are returned ordered by recorded time descending.
+query B
+SELECT bool_and(prev IS NULL OR prev >= recorded)
+  FROM (
+    SELECT recorded, lag(recorded) OVER (ORDER BY recorded DESC) AS prev
+      FROM information_schema.crdb_job_messages($job_id)
+  )
+----
+true
+
+# Non-existent job: zero rows, no error.
+query I
+SELECT count(*) FROM information_schema.crdb_job_messages(-1)
+----
+0
+
+# Row-level access: a non-admin user sees no messages for jobs they cannot view.
+user testuser
+
+query I
+SELECT count(*) FROM information_schema.crdb_job_messages($job_id)
+----
+0
+
+user root
+
+statement ok
+GRANT SYSTEM VIEWJOB TO testuser
+
+user testuser
+
+query B
+SELECT count(*) > 0 FROM information_schema.crdb_job_messages($job_id)
+----
+true
+
+user root
+
+statement ok
+REVOKE SYSTEM VIEWJOB FROM testuser
+
+# Unsafe-internals gate.
+statement ok
+SET allow_unsafe_internals = false
+
+query B
+SELECT count(*) > 0 FROM information_schema.crdb_job_messages($job_id)
+----
+true
+
+statement ok
+RESET allow_unsafe_internals
+
+statement ok
+DROP TABLE crdb_jobs_msg_test
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -753,3 +753,97 @@ statement ok
 DROP TABLE crdb_jobs_ph_test
 
 subtest end
+
+subtest information_schema_crdb_jobs_owner_subset
+
+user root
+
+# Set up a root-owned job and a testuser-owned job, then verify that testuser
+# (a non-admin with no VIEWJOB) sees their own job but not the root-owned one
+# across all four surfaces: crdb_jobs, crdb_jobs_with_progress,
+# crdb_job_messages, and crdb_job_progress_history.
+statement ok
+CREATE TABLE crdb_jobs_owner_root_test (x INT)
+
+statement ok
+CREATE INDEX a_descriptively_named_idx_owned_by_root
+  ON crdb_jobs_owner_root_test (x)
+
+let $root_job_id
+SELECT job_id FROM information_schema.crdb_jobs
+WHERE job_type = 'SCHEMA CHANGE'
+  AND description LIKE 'CREATE INDEX a_descriptively_named_idx_owned_by_root%'
+
+statement ok
+GRANT CREATE ON DATABASE test TO testuser
+
+user testuser
+
+statement ok
+CREATE TABLE crdb_jobs_owner_testuser_test (x INT)
+
+statement ok
+CREATE INDEX a_descriptively_named_idx_owned_by_testuser
+  ON crdb_jobs_owner_testuser_test (x)
+
+let $own_job_id
+SELECT job_id FROM information_schema.crdb_jobs
+WHERE owner = 'testuser'
+  AND description LIKE 'CREATE INDEX a_descriptively_named_idx_owned_by_testuser%'
+
+# crdb_jobs: testuser sees their own job but not the root-owned one.
+query II
+SELECT
+  (SELECT count(*) FROM information_schema.crdb_jobs WHERE job_id = $own_job_id),
+  (SELECT count(*) FROM information_schema.crdb_jobs WHERE job_id = $root_job_id)
+----
+1  0
+
+# crdb_jobs_with_progress: same.
+query II
+SELECT
+  (SELECT count(*) FROM information_schema.crdb_jobs_with_progress WHERE job_id = $own_job_id),
+  (SELECT count(*) FROM information_schema.crdb_jobs_with_progress WHERE job_id = $root_job_id)
+----
+1  0
+
+# crdb_job_messages: testuser sees messages for their own job; the SRF returns
+# zero rows for jobs they cannot view.
+query BB
+SELECT
+  (SELECT count(*) > 0 FROM information_schema.crdb_job_messages($own_job_id)),
+  (SELECT count(*) > 0 FROM information_schema.crdb_job_messages($root_job_id))
+----
+true  false
+
+# crdb_job_progress_history: same.
+query BB
+SELECT
+  (SELECT count(*) > 0 FROM information_schema.crdb_job_progress_history($own_job_id)),
+  (SELECT count(*) > 0 FROM information_schema.crdb_job_progress_history($root_job_id))
+----
+true  false
+
+# An admin sweeping all four surfaces still sees every job — owner-based
+# filtering only narrows the view for non-admins.
+user root
+
+query IIBB
+SELECT
+  (SELECT count(*) FROM information_schema.crdb_jobs WHERE job_id IN ($own_job_id, $root_job_id)),
+  (SELECT count(*) FROM information_schema.crdb_jobs_with_progress WHERE job_id IN ($own_job_id, $root_job_id)),
+  (SELECT count(*) > 0 FROM information_schema.crdb_job_messages($own_job_id)),
+  (SELECT count(*) > 0 FROM information_schema.crdb_job_progress_history($own_job_id))
+----
+2  2  true  true
+
+statement ok
+DROP TABLE crdb_jobs_owner_testuser_test
+
+statement ok
+REVOKE CREATE ON DATABASE test FROM testuser
+
+statement ok
+DROP TABLE crdb_jobs_owner_root_test
+
+subtest end

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -373,6 +373,20 @@ func (b *Builder) buildView(
 			b.skipSelectPrivilegeChecks = true
 			defer func() { b.skipSelectPrivilegeChecks = false }()
 		}
+		// System views are authored by the node user and are part of the
+		// supported customer surface; mirror the privilege-check skip above
+		// for the unsafe-internals guard so that table and builtin gates are
+		// symmetric inside a system-view definer context. Without this, a
+		// system view body in (e.g.) information_schema could reference
+		// system tables (since the SELECT check is skipped) but could not
+		// invoke a crdb_internal builtin in its WHERE clause, forcing every
+		// such view to alias each crdb_internal builtin it depends on.
+		// Restricted to actual system views so the cluster-setting bypass
+		// (skipUnderlyingPrivilegeChecks) does not re-expose user-created
+		// views to unsafe builtins.
+		if view.IsSystemView() {
+			defer b.DisableUnsafeInternalCheck()()
+		}
 	} else {
 		if !view.IsSecurityInvoker() {
 			defer func(dataSourcePrivilegeUserOverride username.SQLUsername) {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2961,6 +2961,7 @@ var builtinOidsArray = []string{
 	3006: `pg_indexes_size(relation_oid: oid) -> int`,
 	3007: `crdb_internal.tsdb_query(name: string, start_time: timestamptz, end_time: timestamptz) -> tuple{timestamptz AS timestamp, float AS value, string AS source}`,
 	3008: `crdb_internal.tsdb_query(name: string, start_time: timestamptz, end_time: timestamptz, options: jsonb) -> tuple{timestamptz AS timestamp, float AS value, string AS source}`,
+	3009: `information_schema.crdb_job_messages(job_id: int) -> tuple{timestamptz AS recorded, string AS kind, string AS message}`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2962,6 +2962,7 @@ var builtinOidsArray = []string{
 	3007: `crdb_internal.tsdb_query(name: string, start_time: timestamptz, end_time: timestamptz) -> tuple{timestamptz AS timestamp, float AS value, string AS source}`,
 	3008: `crdb_internal.tsdb_query(name: string, start_time: timestamptz, end_time: timestamptz, options: jsonb) -> tuple{timestamptz AS timestamp, float AS value, string AS source}`,
 	3009: `information_schema.crdb_job_messages(job_id: int) -> tuple{timestamptz AS recorded, string AS kind, string AS message}`,
+	3010: `information_schema.crdb_job_progress_history(job_id: int) -> tuple{timestamptz AS recorded, float AS progress_fraction, decimal AS resolved}`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
@@ -797,6 +798,21 @@ The output can be used to recreate a database.'
 			sessionPendingJobsType,
 			makeSessionPendingJobsGenerator,
 			`Returns rows of information about all pending jobs created in the session txn.`,
+			volatility.Volatile,
+		),
+	),
+	"information_schema.crdb_job_messages": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
+		makeGeneratorOverload(
+			tree.ParamTypes{{Name: "job_id", Typ: types.Int}},
+			jobMessagesGeneratorType,
+			makeJobMessagesGenerator,
+			`Returns the messages emitted by the specified job, ordered by `+
+				`recorded time descending. Returns no rows if the job does not `+
+				`exist or is not visible to the current user.`,
 			volatility.Volatile,
 		),
 	),
@@ -3320,6 +3336,11 @@ var sessionPendingJobsType = types.MakeLabeledTuple(
 	[]string{"job_id", "job_type", "description", "user_name"},
 )
 
+var jobMessagesGeneratorType = types.MakeLabeledTuple(
+	[]*types.T{types.TimestampTZ, types.String, types.String},
+	[]string{"recorded", "kind", "message"},
+)
+
 // Phase is used to determine if CREATE statements or ALTER statements
 // are being generated for showCreateAllTables.
 type Phase int
@@ -3861,6 +3882,106 @@ func (s *sessionPendingJobsGenerator) Values() (tree.Datums, error) {
 
 // Close implements the eval.ValueGenerator interface.
 func (s *sessionPendingJobsGenerator) Close(ctx context.Context) {
+}
+
+// jobMessagesGenerator backs information_schema.crdb_job_messages(job_id).
+// It fetches the per-job message history from system.job_message via the
+// internal SQL executor, after verifying that the caller can view the job's
+// owner (matching the access semantics used by information_schema.crdb_jobs).
+// If the job does not exist or is not visible, no rows are returned.
+type jobMessagesGenerator struct {
+	jobID   jobspb.JobID
+	evalCtx *eval.Context
+	rows    eval.InternalRows
+}
+
+func makeJobMessagesGenerator(
+	_ context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	return &jobMessagesGenerator{
+		jobID:   jobspb.JobID(int64(tree.MustBeDInt(args[0]))),
+		evalCtx: evalCtx,
+	}, nil
+}
+
+// ResolvedType implements the eval.ValueGenerator interface.
+func (g *jobMessagesGenerator) ResolvedType() *types.T {
+	return jobMessagesGeneratorType
+}
+
+// Start implements the eval.ValueGenerator interface.
+func (g *jobMessagesGenerator) Start(ctx context.Context, _ *kv.Txn) error {
+	// Start may be called again to restart the generator; release any iterator
+	// from a prior run before opening a new one.
+	if g.rows != nil {
+		_ = g.rows.Close()
+		g.rows = nil
+	}
+	owner, ok, err := lookupJobOwner(ctx, g.evalCtx, g.jobID)
+	if err != nil {
+		return err
+	}
+	if !ok || !g.evalCtx.SessionAccessor.HasViewAccessToJob(ctx, owner) {
+		return nil
+	}
+	rows, err := g.evalCtx.Planner.QueryIteratorEx(ctx,
+		"crdb-job-messages",
+		sessiondata.NodeUserSessionDataOverride,
+		"SELECT written, kind, message FROM system.job_message "+
+			"WHERE job_id = $1 ORDER BY written DESC",
+		int64(g.jobID))
+	if err != nil {
+		return err
+	}
+	g.rows = rows
+	return nil
+}
+
+// Next implements the eval.ValueGenerator interface.
+func (g *jobMessagesGenerator) Next(ctx context.Context) (bool, error) {
+	if g.rows == nil {
+		return false, nil
+	}
+	return g.rows.Next(ctx)
+}
+
+// Values implements the eval.ValueGenerator interface.
+func (g *jobMessagesGenerator) Values() (tree.Datums, error) {
+	return g.rows.Cur(), nil
+}
+
+// Close implements the eval.ValueGenerator interface.
+func (g *jobMessagesGenerator) Close(_ context.Context) {
+	if g.rows != nil {
+		_ = g.rows.Close()
+	}
+}
+
+// lookupJobOwner fetches the owner of the specified job. The boolean return
+// is false if no such job exists; the error return is set only if the lookup
+// itself fails.
+func lookupJobOwner(
+	ctx context.Context, evalCtx *eval.Context, jobID jobspb.JobID,
+) (username.SQLUsername, bool, error) {
+	it, err := evalCtx.Planner.QueryIteratorEx(ctx,
+		"crdb-job-owner-lookup",
+		sessiondata.NodeUserSessionDataOverride,
+		"SELECT owner FROM system.public.jobs WHERE id = $1",
+		int64(jobID))
+	if err != nil {
+		return username.SQLUsername{}, false, err
+	}
+	defer func() { _ = it.Close() }()
+	ok, err := it.Next(ctx)
+	if err != nil || !ok {
+		return username.SQLUsername{}, false, err
+	}
+	ownerDatum := it.Cur()[0]
+	if ownerDatum == tree.DNull {
+		return username.SQLUsername{}, false, nil
+	}
+	return username.MakeSQLUsernameFromPreNormalizedString(
+		string(tree.MustBeDString(ownerDatum))), true, nil
 }
 
 // identGenerator supports the execution of

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -816,6 +816,23 @@ The output can be used to recreate a database.'
 			volatility.Volatile,
 		),
 	),
+	"information_schema.crdb_job_progress_history": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
+		makeGeneratorOverload(
+			tree.ParamTypes{{Name: "job_id", Typ: types.Int}},
+			jobProgressHistoryGeneratorType,
+			makeJobProgressHistoryGenerator,
+			`Returns the progress trajectory of the specified job, ordered by `+
+				`recorded time descending. Returns no rows if the job does not `+
+				`exist or is not visible to the current user. The resolved `+
+				`column is the raw HLC; apply hlc_to_timestamp at the call `+
+				`site for a wall-clock value.`,
+			volatility.Volatile,
+		),
+	),
 	"crdb_internal.decode_plan_gist": makeBuiltin(
 		tree.FunctionProperties{
 			Category:         builtinconstants.CategorySystemInfo,
@@ -3341,6 +3358,11 @@ var jobMessagesGeneratorType = types.MakeLabeledTuple(
 	[]string{"recorded", "kind", "message"},
 )
 
+var jobProgressHistoryGeneratorType = types.MakeLabeledTuple(
+	[]*types.T{types.TimestampTZ, types.Float, types.Decimal},
+	[]string{"recorded", "progress_fraction", "resolved"},
+)
+
 // Phase is used to determine if CREATE statements or ALTER statements
 // are being generated for showCreateAllTables.
 type Phase int
@@ -3952,6 +3974,80 @@ func (g *jobMessagesGenerator) Values() (tree.Datums, error) {
 
 // Close implements the eval.ValueGenerator interface.
 func (g *jobMessagesGenerator) Close(_ context.Context) {
+	if g.rows != nil {
+		_ = g.rows.Close()
+	}
+}
+
+// jobProgressHistoryGenerator backs
+// information_schema.crdb_job_progress_history(job_id). Same access semantics
+// as jobMessagesGenerator (visible-job-only, empty otherwise). The resolved
+// column is returned as the raw HLC decimal stored in
+// system.job_progress_history; callers wanting a wall-clock value apply
+// hlc_to_timestamp at the call site.
+type jobProgressHistoryGenerator struct {
+	jobID   jobspb.JobID
+	evalCtx *eval.Context
+	rows    eval.InternalRows
+}
+
+func makeJobProgressHistoryGenerator(
+	_ context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	return &jobProgressHistoryGenerator{
+		jobID:   jobspb.JobID(int64(tree.MustBeDInt(args[0]))),
+		evalCtx: evalCtx,
+	}, nil
+}
+
+// ResolvedType implements the eval.ValueGenerator interface.
+func (g *jobProgressHistoryGenerator) ResolvedType() *types.T {
+	return jobProgressHistoryGeneratorType
+}
+
+// Start implements the eval.ValueGenerator interface.
+func (g *jobProgressHistoryGenerator) Start(ctx context.Context, _ *kv.Txn) error {
+	// Start may be called again to restart the generator; release any iterator
+	// from a prior run before opening a new one.
+	if g.rows != nil {
+		_ = g.rows.Close()
+		g.rows = nil
+	}
+	owner, ok, err := lookupJobOwner(ctx, g.evalCtx, g.jobID)
+	if err != nil {
+		return err
+	}
+	if !ok || !g.evalCtx.SessionAccessor.HasViewAccessToJob(ctx, owner) {
+		return nil
+	}
+	rows, err := g.evalCtx.Planner.QueryIteratorEx(ctx,
+		"crdb-job-progress-history",
+		sessiondata.NodeUserSessionDataOverride,
+		"SELECT written, fraction, resolved FROM system.job_progress_history "+
+			"WHERE job_id = $1 ORDER BY written DESC",
+		int64(g.jobID))
+	if err != nil {
+		return err
+	}
+	g.rows = rows
+	return nil
+}
+
+// Next implements the eval.ValueGenerator interface.
+func (g *jobProgressHistoryGenerator) Next(ctx context.Context) (bool, error) {
+	if g.rows == nil {
+		return false, nil
+	}
+	return g.rows.Next(ctx)
+}
+
+// Values implements the eval.ValueGenerator interface.
+func (g *jobProgressHistoryGenerator) Values() (tree.Datums, error) {
+	return g.rows.Cur(), nil
+}
+
+// Close implements the eval.ValueGenerator interface.
+func (g *jobProgressHistoryGenerator) Close(_ context.Context) {
 	if g.rows != nil {
 		_ = g.rows.Close()
 	}

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -482,6 +482,7 @@ const (
 	InformationSchemaCrdbNodeActiveSessionHistoryTableID
 	InformationSchemaCrdbClusterActiveSessionHistoryTableID
 	InformationSchemaCrdbJobsViewID
+	InformationSchemaCrdbJobsWithProgressViewID
 	CrdbInternalClusterHeldAdvisoryLocksTableID
 	MinVirtualID = CrdbInternalClusterHeldAdvisoryLocksTableID
 )

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -481,6 +481,7 @@ const (
 	PgExtensionSpatialRefSysTableID
 	InformationSchemaCrdbNodeActiveSessionHistoryTableID
 	InformationSchemaCrdbClusterActiveSessionHistoryTableID
+	InformationSchemaCrdbJobsViewID
 	CrdbInternalClusterHeldAdvisoryLocksTableID
 	MinVirtualID = CrdbInternalClusterHeldAdvisoryLocksTableID
 )

--- a/pkg/sql/vtable/information_schema_crdb.go
+++ b/pkg/sql/vtable/information_schema_crdb.go
@@ -43,3 +43,23 @@ CREATE VIEW information_schema.crdb_cluster_active_session_history AS
            work_event,
            goroutine_id
     FROM crdb_internal.cluster_active_session_history`
+
+// CRDBJobs describes the schema of the information_schema view that exposes
+// per-job metadata from system.jobs without the truncation or column omission
+// that SHOW JOBS applies for human readability. The column set is intentionally
+// scoped to what is useful to customers programmatically: internal execution
+// detail (claim session/instance), retry bookkeeping (num_runs, last_run), and
+// creator coupling (created_by_*) are deliberately excluded so the contract
+// does not depend on those implementation choices.
+const CRDBJobs = `
+CREATE VIEW information_schema.crdb_jobs AS
+    SELECT id                  AS job_id,
+           job_type,
+           owner,
+           description,
+           created::TIMESTAMPTZ AS created,
+           finished,
+           status               AS state,
+           error_msg            AS error
+    FROM system.public.jobs
+    WHERE crdb_internal.can_view_job(owner)`

--- a/pkg/sql/vtable/information_schema_crdb.go
+++ b/pkg/sql/vtable/information_schema_crdb.go
@@ -63,3 +63,32 @@ CREATE VIEW information_schema.crdb_jobs AS
            error_msg            AS error
     FROM system.public.jobs
     WHERE crdb_internal.can_view_job(owner)`
+
+// CRDBJobsWithProgress describes the schema of the information_schema view
+// that extends crdb_jobs with the current progress reading and the current
+// user-visible status message. The `resolved` column is exposed as the raw
+// HLC decimal it is stored as, matching the underlying system.job_progress
+// column. Callers wanting a wall-clock timestamp can apply hlc_to_timestamp
+// at the call site; exposing the raw HLC avoids baking a lossy conversion
+// (loss of the HLC logical component) into the stable contract.
+// `last_updated` collapses the job_progress.written and job_status.written
+// timestamps into one column so the surface does not commit to the internal
+// split between the two tables.
+const CRDBJobsWithProgress = `
+CREATE VIEW information_schema.crdb_jobs_with_progress AS
+    SELECT j.id                              AS job_id,
+           j.job_type,
+           j.owner,
+           j.description,
+           j.created::TIMESTAMPTZ            AS created,
+           j.finished,
+           j.status                          AS state,
+           j.error_msg                       AS error,
+           p.fraction                        AS progress_fraction,
+           p.resolved                        AS resolved,
+           s.status                          AS status_message,
+           greatest(p.written, s.written)    AS last_updated
+    FROM system.public.jobs AS j
+    LEFT OUTER JOIN system.public.job_progress AS p ON j.id = p.job_id
+    LEFT OUTER JOIN system.public.job_status   AS s ON j.id = s.job_id
+    WHERE crdb_internal.can_view_job(j.owner)`


### PR DESCRIPTION
Adds four customer-facing surfaces under `information_schema.crdb_*` for programmatic visibility into the jobs system. The existing surfaces (`crdb_internal.jobs`, `SHOW JOBS`) are either internal (now blocked for ordinary sessions by `unsafesql.CheckInternalsAccess`) or lossy by design (description truncated to 70 chars, statement conflated with description, no message history, no progress history).

The column sets below are deliberately scoped to fields with stable customer meaning; internal execution detail (claim_session_id, claim_instance_id), dead bookkeeping (num_runs, last_run), and creator coupling (created_by_*) are excluded. Each row is filtered by `crdb_internal.can_view_job(owner)`, so callers only see jobs they own or have `VIEWJOB` for.

### `information_schema.crdb_jobs` (view)

Per-job metadata from `system.jobs` without the truncation or column omission applied by `SHOW JOBS`.

| Column        | Type                       | Notes                                                                    |
|---------------|----------------------------|--------------------------------------------------------------------------|
| `job_id`      | `BIGINT`                   | system.jobs.id                                                           |
| `job_type`    | `TEXT`                     |                                                                          |
| `owner`       | `TEXT`                     |                                                                          |
| `description` | `TEXT`                     | full text — `SHOW JOBS` truncates this to 70 chars                       |
| `created`     | `TIMESTAMPTZ`              |                                                                          |
| `finished`    | `TIMESTAMPTZ`              |                                                                          |
| `state`       | `TEXT`                     | lifecycle state (`succeeded`, `failed`, `running`, …); renamed from the underlying `status` column so `status_message` can carry the granular phase string in `crdb_jobs_with_progress` |
| `error`       | `TEXT`                     | `NULL` when the job has no error; `crdb_internal.jobs` coalesces this to `''` |

### `information_schema.crdb_jobs_with_progress` (view)

Extends `crdb_jobs` with progress and status-message fields by joining `system.job_progress` and `system.job_status`. Same first 8 columns as `crdb_jobs`, plus:

| Column              | Type               | Notes                                                                              |
|---------------------|--------------------|------------------------------------------------------------------------------------|
| `progress_fraction` | `DOUBLE PRECISION` | 0.0 – 1.0                                                                          |
| `resolved`          | `NUMERIC`          | raw HLC decimal from `system.job_progress.resolved`; apply `hlc_to_timestamp(resolved)` at the call site for wall-clock. Exposed as HLC so callers feeding it into `AS OF SYSTEM TIME` or changefeed cursors don't lose the logical component |
| `status_message`    | `TEXT`             | current user-visible phase string (e.g. `"backfilling"`)                           |
| `last_updated`      | `TIMESTAMPTZ`      | `greatest(job_progress.written, job_status.written)` — collapses the two internal `written` columns into one so the surface doesn't commit to the two-table split |

### `information_schema.crdb_job_messages(job_id BIGINT)` (set-returning function)

Per-job message history from `system.job_message`. Modeled as a function rather than a view so a caller's `SELECT * FROM ...` can't accidentally materialize every message across every job; the `job_id` argument is required.

Returns rows ordered by `recorded` DESC:

| Column     | Type          | Notes                                                          |
|------------|---------------|----------------------------------------------------------------|
| `recorded` | `TIMESTAMPTZ` |                                                                |
| `kind`     | `TEXT`        | message category (informational/extensible — not pinned)       |
| `message`  | `TEXT`        |                                                                |

Unknown or invisible `job_id` → zero rows (no error).

### `information_schema.crdb_job_progress_history(job_id BIGINT)` (set-returning function)

Per-job progress trajectory from `system.job_progress_history`. Same access shape as `crdb_job_messages`.

Returns rows ordered by `recorded` DESC:

| Column              | Type               | Notes                                                                                       |
|---------------------|--------------------|---------------------------------------------------------------------------------------------|
| `recorded`          | `TIMESTAMPTZ`      |                                                                                             |
| `progress_fraction` | `DOUBLE PRECISION` | 0.0 – 1.0                                                                                   |
| `resolved`          | `NUMERIC`          | raw HLC decimal (same reasoning as `crdb_jobs_with_progress.resolved`); may be `NULL` for jobs that don't report a high-water |

Unknown or invisible `job_id` → zero rows (no error).

---

Each surface has a logictest that exercises it with `SET allow_unsafe_internals = false` to lock in the post-unsafesql access path, and a `GRANT SYSTEM VIEWJOB` round-trip to verify the row-level access control.

The view bodies call `crdb_internal.can_view_job(owner)` for row-level visibility, which required the first commit on the branch: the optbuilder's system-view path was already skipping the SELECT privilege check on underlying tables but was not skipping the unsafe-builtin guard on builtins referenced in the body. The two gates are now symmetric for system views.

Commit map (each is independently reviewable):

0. optbuilder: skip the unsafe-builtin guard inside system view bodies (plumbing prerequisite)
1. `crdb_jobs` view
2. `crdb_jobs_with_progress` view
3. `crdb_job_messages` SRF
4. `crdb_job_progress_history` SRF

Epic: none
