### PR TITLE
backup: teach download job to make progress when nodes are unavailable

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2284,7 +2284,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_do_download_files"); err != nil {
 			return err
 		}
-		return r.doDownloadFilesWithRetry(ctx, p)
+		return r.doDownloadFiles(ctx, p)
 	}
 
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_load_descriptors_from_backup"); err != nil {
@@ -2550,7 +2550,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		// TODO(msbutler): ideally doDownloadFiles would not depend on job details
 		// and is instead passed an execCfg and the download spans and anything else
 		// it needs. If that occured, we would not need to update details above.
-		if err := r.doDownloadFilesWithRetry(ctx, p); err != nil {
+		if err := r.doDownloadFiles(ctx, p); err != nil {
 			return err
 		}
 	}

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -611,45 +611,73 @@ func (r *restoreResumer) maybeCalculateTotalDownloadSpans(
 	return total, nil
 }
 
+// sendDownloadWorker retries sendDownloadSpan with the given backoff
+// until either done is closed (the observer signalled remaining bytes
+// hit zero), the retry budget is exhausted, or ctx is cancelled. The
+// retry counter resets on each successful dispatch, so newly appearing
+// work (e.g. from rebalancing) does not count against the no-progress
+// budget.
 func (r *restoreResumer) sendDownloadWorker(
-	execCtx sql.JobExecContext, spans roachpb.Spans, completionPoller chan struct{},
-) func(context.Context) error {
-	return func(ctx context.Context) error {
-		ctx, tsp := tracing.ChildSpan(ctx, "backup.sendDownloadWorker")
-		defer tsp.Finish()
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	spans roachpb.Spans,
+	done <-chan struct{},
+	retryOpts retry.Options,
+) error {
+	ctx, tsp := tracing.ChildSpan(ctx, "backup.sendDownloadWorker")
+	defer tsp.Finish()
 
-		testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
-		for {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
+	testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
+	logThrottler := util.EveryMono(orDownloadRetryLogRate.Get(&execCtx.ExecCfg().Settings.SV))
 
-			if testingKnobs != nil && testingKnobs.RunBeforeSendingDownloadSpan != nil {
-				if err := testingKnobs.RunBeforeSendingDownloadSpan(); err != nil {
-					return err
-				}
-			}
-
-			if err := sendDownloadSpan(ctx, execCtx, spans); err != nil {
-				return err
-			}
-
-			// Wait for the completion poller to signal that it has checked our work.
-			select {
-			case _, ok := <-completionPoller:
-				if !ok {
-					return nil
-				}
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-
-			// Sleep a bit before sending download requests again to avoid a hot loop.
-			// This will only be hit if after a successful download request, there are
-			// still spans to download (e.g. because of a rabalancing).
-			time.Sleep(10 * time.Second)
+	var lastErr error
+	for rt := retry.StartWithCtx(ctx, retryOpts); rt.Next(); {
+		select {
+		case <-done:
+			return nil
+		default:
 		}
+		if testingKnobs != nil && testingKnobs.RunBeforeSendingDownloadSpan != nil {
+			if err := testingKnobs.RunBeforeSendingDownloadSpan(); err != nil {
+				lastErr = err
+				r.recordDownloadFailure(ctx, execCtx, &logThrottler, err)
+				continue
+			}
+		}
+		if err := sendDownloadSpan(ctx, execCtx, spans); err != nil {
+			lastErr = err
+			r.recordDownloadFailure(ctx, execCtx, &logThrottler, err)
+			continue
+		}
+		lastErr = nil
+		rt.Reset()
 	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return ctx.Err()
+}
+
+// recordDownloadFailure logs a download failure to the job's message
+// log, throttled by the configured rate.
+func (r *restoreResumer) recordDownloadFailure(
+	ctx context.Context, execCtx sql.JobExecContext, throttler *util.EveryN[crtime.Mono], err error,
+) {
+	log.Dev.Warningf(ctx, "failed attempt to download files: %v", err)
+	if !throttler.ShouldProcess(crtime.NowMono()) {
+		return
+	}
+	besteffort.Warning(
+		ctx, "or-download-failed-log",
+		func(ctx context.Context) error {
+			return execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				return r.job.Messages().Record(
+					ctx, txn, "error",
+					fmt.Sprintf("online restore download encountered error: %v", err),
+				)
+			})
+		},
+	)
 }
 
 var useCopy = envutil.EnvOrDefaultBool("COCKROACH_DOWNLOAD_COPY", true)
@@ -671,6 +699,12 @@ func sendDownloadSpan(ctx context.Context, execCtx sql.JobExecContext, spans roa
 		err := errors.DecodeError(ctx, encoded)
 		return errors.Wrapf(err,
 			"failed to download spans on %d nodes; n%d err", len(resp.Errors), n)
+	}
+	if testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs; testingKnobs != nil &&
+		testingKnobs.RunAfterSendingDownloadSpan != nil {
+		if err := testingKnobs.RunAfterSendingDownloadSpan(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -747,14 +781,18 @@ func (r *restoreResumer) maybeWriteDownloadJob(
 	})
 }
 
-// waitForDownloadToComplete waits until there are no more ExternalFileBytes
-// remaining to be downloaded for the restore. It sends a signal on the passed
-// channel each time it polls the span, and closes it when it stops.
+// waitForDownloadToComplete polls until there are no more ExternalFileBytes
+// remaining to be downloaded for the restore, then closes done to tell the
+// dispatch worker it can stop. If the retry budget elapses without any
+// observed decrease in remaining bytes, returns an error and leaves done
+// open — the surrounding ctxgroup will tear down the worker via ctx cancel.
 func (r *restoreResumer) waitForDownloadToComplete(
-	ctx context.Context, execCtx sql.JobExecContext, details jobspb.RestoreDetails, ch chan struct{},
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	details jobspb.RestoreDetails,
+	done chan<- struct{},
+	retryOpts retry.Options,
 ) error {
-	defer close(ch)
-
 	ctx, tsp := tracing.ChildSpan(ctx, "backup.waitForDownloadToComplete")
 	defer tsp.Finish()
 
@@ -762,24 +800,37 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	if err != nil {
 		return errors.Wrap(err, "failed to calculate total number of spans to download")
 	}
+	if knobs := execCtx.ExecCfg().BackupRestoreTestingKnobs; knobs != nil &&
+		knobs.OverrideRemainingBytesFn != nil {
+		total = knobs.OverrideRemainingBytesFn()
+	}
 
 	// Download is already complete or there is nothing to be downloaded, in
 	// either case we can mark the job as done.
 	if total == 0 {
 		r.downloadJobProg = 1.0
+		close(done)
 		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
 		return r.job.DeprecatedNoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 			return 1.0
 		})
 	}
 
+	lastRemaining := total
 	var lastProgressUpdate time.Time
-	for rt := retry.StartWithCtx(
-		ctx, retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second * 10},
-	); rt.Next(); {
+	for rt := retry.StartWithCtx(ctx, retryOpts); rt.Next(); {
 		remaining, err := getExternalBytesOverSpans(ctx, execCtx.ExecCfg(), details.DownloadSpans)
 		if err != nil {
 			return errors.Wrap(err, "failed to get remaining external file bytes")
+		}
+		if knobs := execCtx.ExecCfg().BackupRestoreTestingKnobs; knobs != nil &&
+			knobs.OverrideRemainingBytesFn != nil {
+			remaining = knobs.OverrideRemainingBytesFn()
+		}
+
+		if remaining < lastRemaining {
+			lastRemaining = remaining
+			rt.Reset()
 		}
 
 		// Sometimes a new virtual/external file sneaks in after we count total; the
@@ -803,6 +854,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 
 		if remaining == 0 {
 			r.notifyStatsRefresherOfNewTables(ctx)
+			close(done)
 			return nil
 		}
 
@@ -815,14 +867,11 @@ func (r *restoreResumer) waitForDownloadToComplete(
 			}
 			lastProgressUpdate = timeutil.Now()
 		}
-		// Signal the download job if it is waiting that we've polled and found work
-		// left for it to do.
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
 	}
-	return ctx.Err()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return errors.New("download made no observable progress within retry budget")
 }
 
 func unstickRestoreSpans(
@@ -875,63 +924,22 @@ func getRemainingExternalFileBytes(
 	return remaining, nil
 }
 
-func (r *restoreResumer) doDownloadFilesWithRetry(
-	ctx context.Context, execCtx sql.JobExecContext,
-) error {
-	maxDuration := orDownloadRetryMaxDuration.Get(&execCtx.ExecCfg().Settings.SV)
-	retryOpts := retry.Options{
-		InitialBackoff: time.Millisecond * 100,
-		MaxBackoff:     5 * time.Minute,
-		MaxDuration:    maxDuration,
+// downloadRetryOpts returns the retry options used by both the dispatch
+// worker and the observer in the download phase. The MaxDuration bounds
+// how long either loop will sit without observable forward motion (a
+// successful dispatch for the worker, a decrease in remaining bytes for
+// the observer); both loops reset their counter on each forward step.
+func downloadRetryOpts(execCtx sql.JobExecContext) retry.Options {
+	opts := retry.Options{
+		InitialBackoff: time.Second,
+		MaxBackoff:     10 * time.Second,
+		MaxDuration:    orDownloadRetryMaxDuration.Get(&execCtx.ExecCfg().Settings.SV),
 	}
 	if knobs := execCtx.ExecCfg().BackupRestoreTestingKnobs; knobs != nil &&
 		knobs.DownloadPhaseRetryPolicy != nil {
-		retryOpts = *knobs.DownloadPhaseRetryPolicy
+		opts = *knobs.DownloadPhaseRetryPolicy
 	}
-
-	logRate := orDownloadRetryLogRate.Get(&execCtx.ExecCfg().Settings.SV)
-	logThrottler := util.EveryMono(logRate)
-
-	var err error
-	var lastProgress float32
-	for rt := retry.StartWithCtx(ctx, retryOpts); rt.Next(); {
-		err = r.doDownloadFiles(ctx, execCtx)
-		if err == nil {
-			return nil
-		}
-		log.Dev.Warningf(ctx, "failed attempt to download files: %v", err)
-
-		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
-			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
-		}
-		if jobs.IsPauseSelfError(err) || jobs.IsPermanentJobError(err) {
-			return err
-		}
-
-		if logThrottler.ShouldProcess(crtime.NowMono()) {
-			besteffort.Warning(
-				ctx, "or-download-failed-log",
-				func(ctx context.Context) error {
-					return execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-						return r.job.Messages().Record(
-							ctx, txn, "error",
-							fmt.Sprintf("online restore download encountered error: %v", err),
-						)
-					})
-				},
-			)
-		}
-
-		if lastProgress != r.downloadJobProg {
-			lastProgress = r.downloadJobProg
-			rt.Reset()
-			log.Dev.Infof(ctx, "download progress has advanced since last retry, resetting retry counter")
-		}
-	}
-	if ctx.Err() != nil {
-		return errors.CombineErrors(ctx.Err(), err)
-	}
-	return jobs.MarkPauseRequestError(errors.Wrapf(err, "retries exhausted for downloading files"))
+	return opts
 }
 
 func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExecContext) error {
@@ -941,24 +949,30 @@ func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExe
 		return err
 	}
 
-	grp := ctxgroup.WithContext(ctx)
-	completionPoller := make(chan struct{})
+	retryOpts := downloadRetryOpts(execCtx)
+	done := make(chan struct{})
 
-	grp.GoCtx(r.sendDownloadWorker(execCtx, details.DownloadSpans, completionPoller))
+	grp := ctxgroup.WithContext(ctx)
 	grp.GoCtx(func(ctx context.Context) error {
-		return r.waitForDownloadToComplete(ctx, execCtx, details, completionPoller)
+		return r.sendDownloadWorker(ctx, execCtx, details.DownloadSpans, done, retryOpts)
+	})
+	grp.GoCtx(func(ctx context.Context) error {
+		return r.waitForDownloadToComplete(ctx, execCtx, details, done, retryOpts)
 	})
 
 	if err := grp.Wait(); err != nil {
-		return errors.Wrap(err, "failed to generate and send download spans")
+		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
+			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
+		}
+		if jobs.IsPauseSelfError(err) || jobs.IsPermanentJobError(err) {
+			return err
+		}
+		if ctx.Err() != nil {
+			return errors.CombineErrors(ctx.Err(), err)
+		}
+		return jobs.MarkPauseRequestError(errors.Wrap(err, "download phase"))
 	}
 
-	testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
-	if testingKnobs != nil && testingKnobs.RunBeforeDownloadCleanup != nil {
-		if err := testingKnobs.RunBeforeDownloadCleanup(); err != nil {
-			return errors.Wrap(err, "testing knob RunBeforeDownloadCleanup failed")
-		}
-	}
 	return r.cleanupAfterDownload(ctx, details)
 }
 

--- a/pkg/backup/restore_online_test.go
+++ b/pkg/backup/restore_online_test.go
@@ -635,41 +635,45 @@ func TestOnlineRestoreErrors(t *testing.T) {
 	})
 }
 
+// TestOnlineRestoreRetryingDownloadRequests exercises the two terminal
+// behaviors of the download phase's retry loops end to end. The transient
+// subtest verifies that a bounded run of injected sendDownloadSpan failures
+// is absorbed and the job still succeeds; the permanent subtest verifies
+// that an unrecoverable failure exhausts the retry budget and pauses the
+// job. The retry budget is controlled via the
+// backup.restore.online_download_retry_max_duration cluster setting so each
+// subtest can use a duration appropriate to its expected outcome.
 func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	AllowORDownloadBestEffortFailures(t)
 	backuptestutils.EnableFastRestoreForTest(t)
 
-	rng, seed := randutil.NewPseudoRand()
-	t.Logf("random seed: %d", seed)
-
-	const maxDownloadAttempts = 5
-	downloadRetryPolicy := &retry.Options{
-		InitialBackoff: time.Millisecond * 100,
-		MaxBackoff:     time.Second,
-		MaxRetries:     maxDownloadAttempts - 1,
-	}
-
-	alwaysFail := rng.Intn(2) == 0
-	t.Logf("always fail download requests: %t", alwaysFail)
-	totalFailures := int32(rng.Intn(maxDownloadAttempts-1) + 1)
-	var currentFailures atomic.Int32
+	var (
+		// failuresLeft is decremented on each call; while non-negative the
+		// hook injects a transient failure.
+		failuresLeft atomic.Int32
+		// failuresFired counts injected transient failures so the test can
+		// assert the retry path actually ran.
+		failuresFired atomic.Int32
+		// failPermanent, when set, makes every call inject a failure.
+		failPermanent atomic.Bool
+	)
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				BackupRestore: &sql.BackupRestoreTestingKnobs{
-					DownloadPhaseRetryPolicy: downloadRetryPolicy,
 					RunBeforeSendingDownloadSpan: func() error {
-						if alwaysFail {
-							return errors.Newf("always fail download request")
+						if failPermanent.Load() {
+							return errors.Newf("injected permanent download failure")
 						}
-						if currentFailures.Load() >= totalFailures {
-							return nil
+						if failuresLeft.Add(-1) >= 0 {
+							failuresFired.Add(1)
+							return errors.Newf("injected transient download failure")
 						}
-						currentFailures.Add(1)
-						return errors.Newf("injected download request failure")
+						return nil
 					},
 				},
 			},
@@ -682,85 +686,131 @@ func TestOnlineRestoreRetryingDownloadRequests(t *testing.T) {
 	)
 	defer cleanupFn()
 
-	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB)
-	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
-	sqlDB.Exec(
-		t,
-		fmt.Sprintf(`
-		RESTORE DATABASE data FROM LATEST IN '%s'
-		WITH EXPERIMENTAL DEFERRED COPY, new_db_name=data2
-		`, externalStorage),
+	externalStorage := backuptestutils.GetExternalStorageURI(
+		t, "nodelocal://1/backup", "backup", sqlDB,
 	)
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
 
-	var downloadJobID jobspb.JobID
-	sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
-	if alwaysFail {
-		jobutils.WaitForJobToPause(t, sqlDB, downloadJobID)
-	} else {
-		jobutils.WaitForJobToSucceed(t, sqlDB, downloadJobID)
+	runRestoreAndGetDownloadJob := func(t *testing.T, dbName string) jobspb.JobID {
+		sqlDB.Exec(t, fmt.Sprintf(`
+			RESTORE DATABASE data FROM LATEST IN '%s'
+			WITH EXPERIMENTAL DEFERRED COPY, new_db_name=%s
+		`, externalStorage, dbName))
+		var jobID jobspb.JobID
+		sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&jobID)
+		return jobID
 	}
+
+	t.Run("transient failures succeed", func(t *testing.T) {
+		const want = 4
+		failuresLeft.Store(want)
+		failuresFired.Store(0)
+		failPermanent.Store(false)
+		// Generous duration so the observer's no-progress watchdog has
+		// headroom for the injected failures to clear and bytes to drop,
+		// even when the test runs under --stress.
+		sqlDB.Exec(t,
+			"SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '60s'")
+
+		jobID := runRestoreAndGetDownloadJob(t, "data_transient")
+		jobutils.WaitForJobToSucceed(t, sqlDB, jobID)
+		require.Equal(t, int32(want), failuresFired.Load())
+	})
+
+	t.Run("permanent failures pause", func(t *testing.T) {
+		failuresLeft.Store(0)
+		failuresFired.Store(0)
+		failPermanent.Store(true)
+		// Short duration so retry exhaustion (and the resulting pause)
+		// happens quickly.
+		sqlDB.Exec(t,
+			"SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '5s'")
+
+		jobID := runRestoreAndGetDownloadJob(t, "data_permanent")
+		jobutils.WaitForJobToPause(t, sqlDB, jobID)
+	})
 }
 
+// TestOnlineRestoreDownloadRetryReset verifies that both retry loops in
+// the download phase reset their counters on forward progress. The
+// dispatch worker calls rt.Reset after each successful sendDownloadSpan;
+// the observer calls rt.Reset whenever the remaining-bytes count drops.
+// Both must reset for the job to complete under tight budgets — removing
+// either rt.Reset call will fail this test.
+//
+// The worker is driven through "success, fail*maxRetries, repeat" via
+// RunBeforeSendingDownloadSpan: without the reset on the leading
+// success, the first 5 attempts (one success plus four failures) consume
+// the budget ending on a failure, and the worker returns the last error.
+//
+// The observer is driven through "stuck for maxRetries polls, then
+// decrease, repeat" via OverrideRemainingBytesFn: without the reset on
+// each decrease, the observer exhausts its budget during a stuck
+// stretch and returns "no observable progress within retry budget".
 func TestOnlineRestoreDownloadRetryReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	backuptestutils.EnableFastRestoreForTest(t)
 
-	const maxDownloadAttempts = 5
+	const maxRetries = 4
+	const totalProgressSteps = 5
 
-	var attemptCount int
+	var (
+		observerCalls atomic.Int32
+		workerCalls   atomic.Int32
+	)
+
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				BackupRestore: &sql.BackupRestoreTestingKnobs{
 					DownloadPhaseRetryPolicy: &retry.Options{
-						InitialBackoff: time.Millisecond * 100,
-						MaxBackoff:     time.Second,
-						MaxRetries:     maxDownloadAttempts - 1,
+						InitialBackoff: time.Millisecond,
+						MaxBackoff:     5 * time.Millisecond,
+						MaxRetries:     maxRetries,
 					},
-					// We want the retry loop to fail until its final attempt, and then
-					// succeed on the last attempt. This will allow the download job to
-					// make progress, in which case the retry loop _should_ reset. Then
-					// we continue allowing the retry loop to fail until its last
-					// attempt, in which case it will succeed again.
 					RunBeforeSendingDownloadSpan: func() error {
-						attemptCount++
-						if attemptCount < maxDownloadAttempts {
-							return errors.Newf("injected download request failure")
+						n := workerCalls.Add(1)
+						if n%(maxRetries+1) == 1 {
+							return nil
 						}
-						return nil
+						return errors.Newf("injected worker failure %d", n)
 					},
-					RunBeforeDownloadCleanup: func() error {
-						if attemptCount < maxDownloadAttempts*2 {
-							return errors.Newf("injected download cleanup failure")
+					OverrideRemainingBytesFn: func() uint64 {
+						n := int(observerCalls.Add(1))
+						step := (n - 1) / (maxRetries + 1)
+						if step >= totalProgressSteps {
+							return 0
 						}
-						return nil
+						return uint64(totalProgressSteps - step)
 					},
 				},
 			},
 		},
 	}
-	const numAccounts = 2
+
+	// numAccounts needs to be large enough that maybeCalculateTotalDownloadSpans
+	// observes non-zero external bytes when the observer starts; otherwise the
+	// observer short-circuits and the loops never engage.
+	const numAccounts = 1000
 	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
 		t, singleNode, numAccounts, InitManualReplication, clusterArgs,
 	)
 	defer cleanupFn()
 
-	externalStorage := backuptestutils.GetExternalStorageURI(t, "nodelocal://1/backup", "backup", sqlDB)
+	externalStorage := backuptestutils.GetExternalStorageURI(
+		t, "nodelocal://1/backup", "backup", sqlDB,
+	)
 	sqlDB.Exec(t, fmt.Sprintf("BACKUP INTO '%s'", externalStorage))
-	sqlDB.Exec(
-		t,
-		fmt.Sprintf(`
+	sqlDB.Exec(t, fmt.Sprintf(`
 		RESTORE DATABASE data FROM LATEST IN '%s'
 		WITH EXPERIMENTAL DEFERRED COPY, new_db_name=data2
-		`, externalStorage),
-	)
+	`, externalStorage))
 
 	var downloadJobID jobspb.JobID
 	sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
 	jobutils.WaitForJobToSucceed(t, sqlDB, downloadJobID)
-	require.Equal(t, maxDownloadAttempts*2, attemptCount)
 }
 
 func TestOnlineRestoreFailScatterNonEmptyRanges(t *testing.T) {
@@ -1634,4 +1684,72 @@ func TestOnlineRestoreStatusMessages(t *testing.T) {
 	var restoreRowCount int
 	rSQLDB.QueryRow(t, "SELECT count(*) FROM data.bank").Scan(&restoreRowCount)
 	require.Equal(t, numAccounts, restoreRowCount)
+}
+
+// TestOnlineRestoreDownloadSurvivesSendError injects a failure into
+// sendDownloadSpan after the underlying RPC has run, then verifies that
+// the download job still persists progress before the injection is
+// removed and the job completes cleanly.
+func TestOnlineRestoreDownloadSurvivesSendError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	AllowORDownloadBestEffortFailures(t)
+	backuptestutils.EnableFastRestoreForTest(t)
+
+	var forceError atomic.Bool
+	forceError.Store(true)
+
+	args := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				BackupRestore: &sql.BackupRestoreTestingKnobs{
+					RunAfterSendingDownloadSpan: func() error {
+						if forceError.Load() {
+							return errors.New("injected sendDownloadSpan failure")
+						}
+						return nil
+					},
+				},
+			},
+		},
+	}
+	_, sqlDB, _, cleanupFn := backupRestoreTestSetupWithParams(
+		t, 1 /* numNodes */, 1000 /* numAccounts */, InitManualReplication, args,
+	)
+	defer cleanupFn()
+
+	// Cap the retry budget so that if this regresses, the job pauses and
+	// the test fails quickly instead of waiting out the 72h default.
+	sqlDB.Exec(t, "SET CLUSTER SETTING backup.restore.online_download_retry_max_duration = '1m'")
+
+	externalStorage := backuptestutils.GetExternalStorageURI(
+		t, "nodelocal://1/backup", "backup", sqlDB,
+	)
+	sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE data INTO '%s'", externalStorage))
+
+	var linkJobID jobspb.JobID
+	sqlDB.QueryRow(t, fmt.Sprintf(
+		`RESTORE DATABASE data FROM LATEST IN '%s'
+		 WITH EXPERIMENTAL DEFERRED COPY, new_db_name=data2, detached`, externalStorage,
+	)).Scan(&linkJobID)
+	jobutils.WaitForJobToSucceed(t, sqlDB, linkJobID)
+
+	var downloadJobID jobspb.JobID
+	sqlDB.QueryRow(t, latestDownloadJobIDQuery).Scan(&downloadJobID)
+
+	testutils.SucceedsWithin(t, func() error {
+		var fraction float64
+		sqlDB.QueryRow(t,
+			`SELECT fraction_completed FROM [SHOW JOB $1]`, downloadJobID,
+		).Scan(&fraction)
+		if fraction == 0 {
+			return errors.New("fraction_completed is still zero")
+		}
+		return nil
+	}, 30*time.Second)
+
+	forceError.Store(false)
+	jobutils.WaitForJobToSucceed(t, sqlDB, downloadJobID)
+	sqlDB.CheckQueryResults(t, jobutils.GetExternalBytesForConnectedTenant, [][]string{{"0"}})
 }

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -87,9 +87,17 @@ type BackupRestoreTestingKnobs struct {
 	// download span worker before sending the download span request.
 	RunBeforeSendingDownloadSpan func() error
 
-	// RunBeforeDownloadCleanup is called before we cleanup after all external
-	// files have been download.
-	RunBeforeDownloadCleanup func() error
+	// RunAfterSendingDownloadSpan is called after the download span RPC
+	// completes; a non-nil return value is returned in place of the real
+	// result, allowing tests to inject a failure while letting the
+	// underlying download actually run.
+	RunAfterSendingDownloadSpan func() error
+
+	// OverrideRemainingBytesFn, if set, replaces the value returned by the
+	// remaining-bytes computation inside waitForDownloadToComplete. Tests
+	// use it to drive the observer through deterministic progress patterns
+	// without depending on the actual download's pacing.
+	OverrideRemainingBytesFn func() uint64
 
 	// AfterAddRemoteSST is called after a remote SST is linked to pebble during
 	// the link phase of online restore.


### PR DESCRIPTION
This patch teaches the online restore download job to make
progress in the face of temporary node failures. Previously, the
DownloadSpan rpc returning per-node errors would cause the job's core
context group to be canceled, causing a retry to trigger before the job
could report a progress update based on the SpanStats rpc. This patch
changes the context group to an error group, allowing a failure in one
worker to not impact the other, and deferring a retry decision until
both have ran to completion.

Epic: None

Release note: None