### PR TITLE
release-25.2: roachtest: skip revision history and zone config in mixed-version backup on pre-24.1 tenants

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -191,7 +191,7 @@ func backupRestoreRoundTrip(
 			t.L().Printf("starting backup %d", i+1)
 			collection, err := d.createBackupCollection(
 				ctx, t.L(), t, testRNG, bspec, bspec, "round-trip-test-backup",
-				true /* internalSystemsJobs */, false, /* isMultitenant */
+				true /* internalSystemsJobs */, false /* isMultitenant */, false, /* skipRevisionHistory */
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -497,10 +497,14 @@ func (ep encryptionPassphrase) String() string {
 // newBackupOptions returns a list of backup options to be used when
 // creating a new backup. Each backup option has a 50% chance of being
 // included.
-func newBackupOptions(rng *rand.Rand, onlineRestoreExpected bool) []backupOption {
+func newBackupOptions(
+	rng *rand.Rand, onlineRestoreExpected, skipRevisionHistory bool,
+) []backupOption {
 	possibleOpts := []backupOption{}
 	if !onlineRestoreExpected {
-		possibleOpts = append(possibleOpts, revisionHistory{})
+		if !skipRevisionHistory {
+			possibleOpts = append(possibleOpts, revisionHistory{})
+		}
 		possibleOpts = append(possibleOpts, newEncryptionPassphrase(rng))
 	}
 
@@ -1641,18 +1645,24 @@ func (mvb *mixedVersionBackup) configureGCPolicies(
 	if err := mvb.waitForDBs(ctx, l, rng, h); err != nil {
 		return err
 	}
-	u, err := mvb.CommonTestUtils(ctx, h)
-	if err != nil {
-		return err
-	}
 	// The bank workload is an update-heavy workload, which means that by the end
 	// of the test, full revision history backups will be slowed significantly due
 	// to the amount of MVCC history. We set a shorter GC TTL for the bank
 	// database to bound the full backup durations.
+	//
+	// Zone configuration is not supported in virtual clusters on versions older
+	// than 24.1, and the bank database only exists in the virtual cluster, so
+	// there is no way to set this. Skip the optimization on those versions.
+	if h.IsMultitenant() &&
+		!h.Context().FromVersion.AtLeast(mixedversion.TenantsAndSystemAlignedSettingsVersion) {
+		l.Printf(
+			"skipping GC TTL config: zone configs not supported in virtual clusters in %s",
+			h.Context().FromVersion,
+		)
+		return nil
+	}
 	const bankTTLSeconds = uint64(2 * time.Hour / time.Second)
-	return u.Exec(
-		ctx, rng, `ALTER DATABASE bank CONFIGURE ZONE USING gc.ttlseconds = $1`, bankTTLSeconds,
-	)
+	return h.Exec(rng, `ALTER DATABASE bank CONFIGURE ZONE USING gc.ttlseconds = $1`, bankTTLSeconds)
 }
 
 // maybeTakePreviousVersionBackup creates a backup collection (full +
@@ -1883,6 +1893,7 @@ func (d *BackupRestoreTestDriver) runBackup(
 	bType fmt.Stringer,
 	internalSystemJobs bool,
 	isMultitenant bool,
+	skipRevisionHistory bool,
 ) (backupCollection, string, error) {
 	pauseAfter := 1024 * time.Hour // infinity
 	var pauseResumeDB *gosql.DB
@@ -1910,7 +1921,7 @@ func (d *BackupRestoreTestDriver) runBackup(
 	case fullBackup:
 		btype := d.newBackupScope(rng, isMultitenant)
 		name := d.backupCollectionName(d.nextBackupID(), b.namePrefix, btype)
-		createOptions := newBackupOptions(rng, d.testUtils.onlineRestore)
+		createOptions := newBackupOptions(rng, d.testUtils.onlineRestore, skipRevisionHistory)
 		collection = newBackupCollection(name, btype, createOptions, d.cluster.IsLocal())
 		l.Printf("creating full backup for %s", collection.name)
 	case incrementalBackup:
@@ -2067,9 +2078,11 @@ func (mvb *mixedVersionBackup) createBackupCollection(
 		return err
 	}
 
+	skipRevisionHistory := h.IsMultitenant() &&
+		!h.Context().FromVersion.AtLeast(mixedversion.TenantsAndSystemAlignedSettingsVersion)
 	collection, err := mvb.backupRestoreTestDriver.createBackupCollection(
 		ctx, l, h, rng, fullBackupSpec, incBackupSpec, backupNamePrefix,
-		internalSystemJobs, h.IsMultitenant(),
+		internalSystemJobs, h.IsMultitenant(), skipRevisionHistory,
 	)
 	if err != nil {
 		return err
@@ -2094,6 +2107,7 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	backupNamePrefix string,
 	internalSystemJobs bool,
 	isMultitenant bool,
+	skipRevisionHistory bool,
 ) (*backupCollection, error) {
 	var collection backupCollection
 	backupEndTimes := make([]string, 0)
@@ -2105,7 +2119,7 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 		var err error
 		collection, fullBackupEndTime, err = d.runBackup(
 			ctx, l, tasker, rng, fullBackupSpec.Plan.Nodes, fullBackupSpec.PauseProbability,
-			fullBackup{backupNamePrefix}, internalSystemJobs, isMultitenant,
+			fullBackup{backupNamePrefix}, internalSystemJobs, isMultitenant, skipRevisionHistory,
 		)
 		return err
 	}); err != nil {
@@ -2125,7 +2139,7 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 			var err error
 			collection, latestIncBackupEndTime, err = d.runBackup(
 				ctx, l, tasker, rng, incBackupSpec.Plan.Nodes, incBackupSpec.PauseProbability,
-				incrementalBackup{collection: collection, incNum: i + 1}, internalSystemJobs, isMultitenant,
+				incrementalBackup{collection: collection, incNum: i + 1}, internalSystemJobs, isMultitenant, skipRevisionHistory,
 			)
 			return err
 		}); err != nil {
@@ -2155,7 +2169,7 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 				var err error
 				collection, latestIncBackupEndTime, err = d.runBackup(
 					ctx, l, tasker, rng, incBackupSpec.Plan.Nodes, incBackupSpec.PauseProbability,
-					compact, internalSystemJobs, isMultitenant)
+					compact, internalSystemJobs, isMultitenant, skipRevisionHistory)
 				return err
 			}); err != nil {
 				return nil, err


### PR DESCRIPTION
Backport 1 of 2 commits from #170069 on behalf of @dt.

(The second commit on the original PR is a CollectionConfig refactor of
infrastructure that does not exist on this branch, so it is omitted.)

Closes #170244.

----

Zone configuration is not supported in virtual clusters on versions
older than 24.1. When the mixed-version backup test runs with a
multitenant deployment starting from a pre-24.1 version, the
"configure gc policies" step fails with "operation is disabled within
a virtual cluster".

Rather than just skipping the GC TTL configuration, also skip
revision_history backups for these pre-24.1 multitenant runs. The GC
TTL only exists to bound MVCC history accumulation for revision history
backups, so if we're not using revision history, we don't need the TTL
either. AOST restore selection already checks withRevisionHistory() so
it correctly avoids picking an AOST when revision history is not
present.

----

Release justification: test-only roachtest fix for mixed-version backup pre-24.1 tenants