### PR TITLE
backup: add architecture reference docs

### DIFF
--- a/pkg/backup/README.md
+++ b/pkg/backup/README.md
@@ -1,0 +1,138 @@
+# pkg/backup
+
+This package implements BACKUP and RESTORE: planning, job
+coordination, distributed execution, on-disk format, and the three
+RESTORE modes (legacy / fast / online). The architecture is covered
+in depth in two reference documents:
+
+- **[backup.md](backup.md)** — what BACKUP produces, what is and isn't
+  captured, how planning and job execution work, the distributed export
+  flow, on-disk layout, encryption, multi-region, and compaction.
+- **[restore.md](restore.md)** — the three restore modes, what RESTORE
+  does and doesn't carry over, partial-graph reconciliation, tenant
+  restore specifics, and the mechanics of each ingestion path including
+  the KV APIs involved.
+
+The two documents cross-reference each other where the backup-side
+format informs restore-side mechanics (notably prefix elision and
+revision-history layers).
+
+## About these docs
+
+These docs describe the *intended* design of BACKUP and RESTORE —
+not the current implementation, for which the code is always the
+source of truth. They are written for humans building a mental
+model of the subsystem and, more so, for AI agents asked to change
+or debug it.
+
+Two workflows shape what goes here:
+
+- **Changing the subsystem.** Propose the change as a diff to these
+  docs first, iterate with a reviewer on the intended behavior, then
+  implement against the agreed design. The doc is the contract; the
+  code follows.
+- **Debugging.** Read these docs for how the subsystem was *supposed*
+  to work, then compare to what the code does. A divergence is a
+  finding — bug, stale doc, or intentional change that wasn't
+  reflected back.
+
+Contributions should describe principles, contracts, and the *why*
+behind design choices. Enumerative detail about specific functions
+and files belongs in the code: it rots if duplicated here.
+
+## What BACKUP and RESTORE are for
+
+The goal is to recover *user-created state* on a different cluster
+from the one that created it, including when the original cluster
+is gone.
+
+"User-created state" means what a user put into the system: tables
+and the rows they hold, schemas, types, roles, the cluster
+configuration the user expressed. It is *not* cluster-internal
+operational state — timeseries about CPU usage, the range log,
+in-flight jobs, the source cluster's UUID — which is only
+meaningful in the cluster that produced it.
+
+Because the source cluster may no longer exist at restore time, two
+properties are load-bearing:
+
+- **Backups are self-describing.** Keys, schema metadata, encryption
+  material, and version information all live in the backup files
+  themselves. A restoring cluster talks only to object storage,
+  never to the source.
+- **Restore tolerates version drift.** A backup can be restored
+  into a cluster of a different version, region topology, tenant
+  model, or node count, within the same version-compatibility
+  window as upgrades (see
+  [restore.md § Mixed-version contract](restore.md#mixed-version-contract)).
+
+## Package map
+
+Files in this directory mostly follow a few naming conventions:
+
+- `x_planning.go` — translates a user's SQL statement into a
+  machine-readable, persisted, resumable job: target resolution,
+  destination resolution, encryption setup, etc.
+- `x_job.go` — entry point and coordination of that job's execution.
+- `x_processor.go` — DistSQL processor definitions used during job
+  execution.
+- `x_processor_planning.go` — how processors are placed and work is
+  distributed across the cluster for a given job.
+
+A few specific files worth knowing about: `system_schema.go`
+(per-system-table backup/restore policy), `show.go` (`SHOW BACKUP`),
+`key_rewriter.go` (descriptor-ID and tenant-prefix rewriting plus
+per-key skip filtering during restore ingest),
+`generative_split_and_scatter_processor.go` (the split-and-scatter
+stage that runs before any restore ingest).
+
+Shared infrastructure lives in subpackages: `backupsink/`,
+`backupencryption/`, `backupinfo/`, `backupdest/`, `backupresolver/`,
+`backupbase/`, `backuputils/`.
+
+## Glossary
+
+- **Layer** — a single BACKUP run within an incremental chain
+  (one full plus zero or more incrementals).
+- **Chain** — a full backup and all incrementals stacked on top of it.
+- **Manifest** — the metadata file (`BACKUP_MANIFEST`) describing a
+  layer's contents: spans, descriptors, SST file index, etc.
+- **Span covering** — restore-side algorithm that groups backup SST
+  files into per-destination-range "restore span entries," each a
+  unit of work for a restore processor.
+- **External storage** — cloud/blob storage holding backup files
+  (S3, GCS, Azure, nodelocal, etc.).
+- **Above-raft** — writing data through the normal SQL → KV → raft
+  path, so the SST bytes traverse the raft log (e.g. `AddSSTable`).
+- **Below-raft** — registering a file in each replica's local
+  storage engine through a replicated apply-time hook
+  (e.g. `LinkExternalSSTable`). The backup SST's URL is replicated,
+  not the SST's (restore-processed) contents.
+- **Link** — register an external SST in Pebble's LSM without
+  copying its contents; see "Below-raft" above.
+- **Excise** — bulk-delete a range of keys from Pebble's LSM in a
+  single metadata operation; faster than range tombstones for large
+  clears.
+- **PTS** — protected timestamp; prevents MVCC GC from collecting
+  versions a backup still needs to read.
+- **Locality-aware backup** — partitioned destination URIs; each
+  leaseholder writes its SSTs to the URI matching its locality.
+- **Exec locality** — `EXECUTION LOCALITY = '…'`; restricts which SQL
+  instances participate as backup/restore processors.
+
+## Debugging starting points
+
+- **Job state**: `SHOW JOB <id>`, `SELECT * FROM crdb_internal.jobs
+  WHERE job_type IN ('BACKUP','RESTORE','RESTORE-ONLINE')`,
+  `crdb_internal.system_jobs` for the raw payload/progress.
+- **Manifest and checkpoint files** in the destination URI:
+  `BACKUP_MANIFEST`, `BACKUP_MANIFEST_CHECKPOINT`,
+  `BACKUP-CHECKPOINT-*`, `encryption-info`.
+- **Traces**: backup/restore jobs record traces accessible through the
+  jobs UI or `crdb_internal.cluster_inflight_traces`.
+- **Logs**: filter by job ID; the `backup`, `restore`, and
+  `restore-online` log channels carry most of the interesting events.
+- **Cluster settings**: `bulkio.backup.*`, `bulkio.restore.*`,
+  `kv.bulk_io_write.*` govern most knobs that affect throughput and
+  retry behavior.
+

--- a/pkg/backup/backup.md
+++ b/pkg/backup/backup.md
@@ -1,0 +1,430 @@
+# BACKUP
+
+BACKUP captures the contents of a set of SQL objects (tables, databases,
+the whole cluster, or a tenant) at a chosen MVCC timestamp into immutable
+files in external storage. A backup consists of a metadata **manifest**
+plus a set of **SST files** containing the data; together they constitute
+a single **layer**. Layers can be stacked: an incremental backup writes a
+new layer on top of an existing **chain**, capturing changes since the
+chain's most recent end time. Backups live in a **collection** — a
+destination directory holding one or more chains, usually maintained by
+a schedule.
+
+## Content of a backup
+
+### Backup scope
+
+A single table is the smallest restorable unit in CockroachDB. A
+`BACKUP` statement targets one of three scopes:
+
+- **A specific table or set of tables**, possibly through database
+  wildcards. Captures only the listed descriptors and their span
+  data.
+- **A "cluster"** — `BACKUP INTO '…'` with no targets. Despite the
+  name, this is not a snapshot of a running cluster: it's a backup
+  of all tables in the system tenant plus a curated set of cluster
+  configuration that a *user* expressed (zones, comments, role
+  memberships, certain system tables). It does *not* include
+  internal execution state like running jobs, the range log, or
+  timeseries data — those are specific to a physical cluster and
+  not meaningful in a restored one. User-created state in, internal
+  execution state out.
+- **A tenant** — `BACKUP TENANT …`, available from the system
+  tenant. Captures the entire keyspace of one secondary tenant
+  *opaquely*: every KV is included without semantic processing of
+  what those KVs mean. This is deliberate. Operating opaquely lets
+  a tenant be backed up and restored across versions, settings, and
+  configurations of the host cluster, and keeps the host's backup
+  logic free of tenant-version-specific knowledge. Tenant backups
+  therefore capture *more* than cluster backups — every system
+  table the tenant has, including `system.jobs` — and the result is
+  enough to re-hydrate the tenant as a full SQL universe (see
+  [restore.md § Tenant restore specifics](restore.md#tenant-restore-specifics)).
+
+### What's captured
+
+Within the chosen scope, a backup layer captures:
+
+- **Descriptors** — tables, types, schemas, databases, functions, at
+  the backup's `EndTime`. Descriptors are captured *with their
+  in-flight schema-change state* (mutation queues, etc.); restoring
+  them carries that state into the destination, where it is
+  reconciled post-restore.
+- **Span data** — the rows behind those descriptors, exported as SST
+  files (see §"DistSQL flow & KV APIs"). An incremental layer
+  *excludes* spans for tables that are OFFLINE during its read
+  interval (e.g. an in-progress IMPORT or RESTORE); when the table
+  later returns to PUBLIC, the next incremental re-introduces its
+  full span from time zero so that any data written while it was
+  OFFLINE is captured. This is why incremental span computation
+  branches on table state, not just on changed-key timestamps.
+- **Stats, zone configs, comments, role memberships** — pulled from
+  the relevant system tables and included in the manifest or as side
+  data.
+- **System tables** — per `system_schema.go`, each system table is
+  classified for how (or whether) it participates in a cluster /
+  tenant backup. `system.jobs` is excluded from cluster backups; a
+  restored cluster always starts with no live jobs from the source.
+
+#### Exclude data from backup
+
+A table can opt out of having its data backed up while still having
+its descriptor captured:
+
+```sql
+ALTER TABLE t SET (exclude_data_from_backup = true);
+```
+
+The intended use case is high-churn ephemeral tables (queue tables,
+large staging tables). The real cost being avoided isn't the backup
+work itself but the PTS protection that backup needs while reading
+the table: keeping its old versions alive long enough to be backed
+up would block their prompt GC. Excluding the table from the backup
+is a downstream consequence — the actual motivation is letting that
+high-churn data GC promptly even while a long-running backup is in
+flight.
+
+The flag is stored on the `TableDescriptor` and propagated to KV via
+SpanConfig. BACKUP honors it in two places:
+
+- **Planning** (`backup_job.go`): excluded tables' spans are
+  pre-marked completed so they never appear in the export plan.
+- **KV server-side** (`batcheval/cmd_export.go`): an `ExportRequest`
+  overlapping an excluded span returns empty.
+
+The flag flows through SpanConfig (not just a planning-time filter)
+because tenant backups operate opaquely on KV spans and don't
+enumerate per-table flags themselves: each KV server checks its
+local SpanConfig and elides exports for excluded ranges on its own.
+
+PTS records also exclude these spans, so the GC of high-churn data
+is not held up by an in-progress backup. RESTORE leaves the
+descriptor in place but the table is empty.
+
+Tables referenced by inbound foreign keys cannot be marked excluded
+(this would otherwise yield FK violations on restore).
+
+### Revision-history layers
+
+`BACKUP … WITH revision_history` causes export to use
+`MVCCFilter_All` instead of the default `MVCCFilter_Latest`. The
+resulting SSTs contain the full MVCC history within the layer's time
+interval — densely packed multi-version entries, not a single-version
+snapshot. Such SSTs can't be linked directly into a fresh cluster's
+LSM (see
+[restore.md § Why fast/online still need above-raft for revision-history layers](restore.md#why-fastonline-still-need-above-raft-for-revision-history-layers));
+fast/online restore falls back to above-raft ingest for these layers.
+
+Revision-history chains also support `RESTORE … AS OF SYSTEM TIME` to
+reconstruct state at any timestamp within the chain's coverage.
+
+Revision-history backups have historically been more prone to bugs
+than ordinary backups. They get less testing, and the widely-used
+`Span` type representing key ranges is typically only the user-key
+range without an MVCC suffix — which led to past bugs around mid-row
+resume-span representation. Their SSTs are also incompatible with
+fast/online restore. Future work may deprecate revision-history
+backups in favor of point-in-time backups paired with a "revision
+log" that restore replays to serve the same point-in-time-recovery
+use case with lower RPO (today's revision-history backups are still
+periodic and can't reliably run more often than every few minutes).
+
+### Encryption
+
+Backups can be encrypted with a passphrase or one or more KMS keys
+(`WITH encryption_passphrase = …` or `WITH kms = …`). A per-chain
+data key is generated once and stored in the `encryption-info` file
+alongside the manifest, encrypted under each provided KMS or derived
+from the passphrase. SST file contents and the manifest itself are
+encrypted; the destination path layout is not.
+
+Multiple KMS URIs may be supplied for redundancy or rotation: any one
+suffices to decrypt the data key. The data key itself is not rotated
+within a chain — re-encryption requires starting a new full backup.
+
+KV-side export does not see the encryption key; the
+`ExportRequest` evaluator explicitly rejects any encryption parameters
+from clients. Encryption happens at the sink, after KV returns the
+plaintext SST (§"Sink and on-disk layout").
+
+### Protected timestamps & schedules
+
+A running backup holds a **protected timestamp** (PTS) record covering
+its target spans across the backup's read interval. PTS prevents MVCC
+garbage collection from removing versions the backup still needs to
+read. The record is released when the backup completes (or fails
+terminally).
+
+`CREATE SCHEDULE … FOR BACKUP` runs backups on a cron schedule.
+Scheduled chains use **PTS chaining**: between scheduled incrementals,
+the existing PTS record's timestamp is updated in place
+(`pts.UpdateTimestamp` in `schedule_pts_chaining.go`) to cover the
+next incremental's read interval, with no release-and-recreate gap.
+A new full backup instead allocates a fresh PTS record and releases
+the chain's prior PTS once the new full has begun reading.
+
+The full chaining protocol — why scheduled chains hold a PTS in
+addition to the job's, and how records hand off across incrementals
+and successive fulls without ever leaving a gap — is documented in
+the file-level comment in `schedule_pts_chaining.go`.
+
+### Multi-region: locality-aware destinations & exec-locality
+
+Two orthogonal multi-region knobs that compose freely:
+
+- **Locality-aware partitioned backups** control *where* SSTs land.
+  The destination URI list pairs URIs with locality patterns:
+  `('s3://default/…', 's3://east/?COCKROACH_LOCALITY=region%3Dus-east1', …)`.
+  Each leaseholder writes its SSTs to the URI matching its locality,
+  falling back to the default. The manifest records the multi-URI
+  layout so restore knows where each file lives.
+- **Exec-locality constraints** (`EXECUTION LOCALITY = '…'`) control
+  *which* SQL instances participate as backup processors. The planner
+  restricts processor placement to instances matching the locality
+  filter, independent of where data is written.
+
+A backup can use neither, one, or both. A common pattern is to
+constrain execution to a single region's nodes while still writing to
+multi-region storage.
+
+## Execution
+
+### Flow at a glance
+
+A BACKUP statement runs in two stages:
+
+1. **Planning** (synchronous, within the SQL session): resolves
+   destination URIs and encryption, evaluates authorization, resolves
+   descriptor targets, and constructs the `BackupDetails` payload
+   that will be persisted with the job.
+2. **Job execution** (asynchronous, distributed across nodes):
+   `Resume()` finalizes destination resolution, prepares the
+   manifest, acquires PTS, plans per-node DistSQL processors, drives
+   the distributed export, writes the final manifest, and releases
+   PTS.
+
+The deferred design exists so that a long-running backup can
+reliably complete across client disconnects and node restarts:
+state lives on the job, not in a SQL session, and a restart can
+resume from the last checkpoint without losing minutes or hours of
+work.
+
+Within that split, the dividing line between planning and Resume
+is: planning captures what the *user* asked for and persists it
+once; Resume does everything that depends on the cluster's state at
+execution time, and must be safe to re-enter after a restart.
+
+- Planning runs once, synchronously in the SQL session. Its output
+  is a serialized `BackupDetails` payload describing the user's
+  request — targets, destination, encryption configuration,
+  options. Errors here surface as statement errors.
+- Resume runs repeatedly. A node restart, a leaseholder change, or
+  an explicit `PAUSE` / `RESUME` re-enters it; every Resume step
+  must therefore be idempotent or checkpoint-protected. Destination
+  finalization (the chain may have grown since planning), processor
+  placement (depends on the current topology), the actual export,
+  and PTS management all happen here.
+
+Keep this rule in mind when adding new work to either side: if it
+depends on cluster state that can change between submission and
+execution, or could need to re-run after a crash, it belongs in
+Resume.
+
+### Planning
+
+`backup_planning.go` registers `backupPlanHook` with the SQL planner.
+The hook:
+
+- Evaluates SQL expressions (destination URIs, encryption parameters,
+  options).
+- Resolves descriptor targets (`backupresolver`).
+- Performs privilege checks (`checkPrivilegesForBackup`).
+- Builds the initial `jobspb.BackupDetails`: targets, destination
+  URIs, encryption configuration, full-cluster flag, schedule linkage
+  if any.
+- Creates the job record and either runs it (default) or returns
+  control to the session (`WITH DETACHED`).
+
+Destination resolution against `LATEST` (and auto-naming a subdir for
+a new full) is deferred to the job so that a backup can be re-planned
+on resume against the same logical destination.
+
+### Job coordinator
+
+`backupResumer.Resume()` in `backup_job.go` walks these phases:
+
+1. **Destination resolution** — `backupdest.ResolveDest` finalizes
+   the URI list and the subdir (incrementals locate the chain root;
+   fulls allocate a fresh path).
+2. **Lock file** — `BACKUP-LOCK-<jobID>` is written to the
+   destination at job start to prevent concurrent backups racing on
+   the same path. The lock file is not removed on success; subsequent
+   attempts scan existing lock files and reject planning if any
+   belong to a still-running job.
+3. **Manifest preparation** — `prepBackupMeta` reads prior layer
+   manifests, computes the spans to export (filtering
+   `exclude_data_from_backup` spans into `completedSpans` so they
+   are not requested), and builds the initial `BackupManifest`.
+4. **Protected timestamp** — `writePTSRecordOnBackup` writes the PTS
+   record covering the read interval; from this point GC will not
+   remove versions in the target spans before `EndTime`.
+5. **Checkpoint** — the in-progress manifest is written to external
+   storage so a resumed job can identify already-exported spans.
+6. **Distributed export** — `backup()` plans per-node processor
+   specs and drives the DistSQL flow with concurrent checkpoint
+   and progress loops.
+7. **Finalization** — `backupinfo.WriteBackupMetadata` writes the
+   final manifest and side files; PTS is released; if scheduled, the
+   schedule's PTS is rolled forward and a compaction may be queued
+   (§"Compaction").
+
+Resume-from-failure relies on the checkpoint manifest: on `Resume()`
+after a crash, `getCompletedSpans` reads the checkpoint and filters
+already-exported spans out of the export plan, so retries do not
+redo finished work.
+
+### DistSQL flow & KV APIs
+
+`backup_processor_planning.go`'s `distBackupPlanSpecs` partitions the
+spans to export across SQL instances. Span-to-instance assignment uses
+`PartitionSpans`, which maps each range to its leaseholder's node so
+that exports run locally where possible. `EXECUTION LOCALITY` is
+applied here to restrict the candidate instance set.
+
+Each node runs a `backupDataProcessor` (`backup_processor.go`). For
+each assigned span it issues `kvpb.ExportRequest` against
+`NonTransactionalSender` with admission control (`BulkNormalPri`,
+`FROM_SQL`). The notable request fields:
+
+- **`MVCCFilter`** — `_Latest` for ordinary backups, `_All` for
+  revision history. Determined at planning time from the job's
+  `RevisionHistory` flag.
+- **`StartTime` / `RequestHeader`** — the time interval and key span
+  for this request. For "introduced" spans in an incremental (spans
+  not covered by prior layers), `StartTime` is empty so all
+  historical versions are read.
+- **`SplitMidKey: true`** — KV may chunk the response in the middle
+  of a row's MVCC history to respect `TargetFileSize`. The processor
+  resumes from `ResumeSpan` + `ResumeKeyTS` without skipping or
+  duplicating any version.
+- **`TargetFileSize`** — set from a cluster setting; controls
+  server-side SST chunking.
+- **`IncludeMVCCValueHeader`** — set so value headers survive
+  round-trip.
+
+`ExportRequest` always returns SSTs (there is no raw-KV mode for
+backup). Encryption is *not* requested via the KV API; the returned
+SSTs are plaintext from KV's perspective, and the sink encrypts them.
+
+### Sink and on-disk layout
+
+The processor hands each response to a `FileSSTSink`
+(`backupsink/file_sst_sink.go`). The sink:
+
+- Buffers KVs into in-memory SST writers.
+- Flushes a file when it hits the target size threshold or a span
+  completes.
+- Applies prefix elision (below) and encryption.
+- Uploads to the locality-appropriate external storage URI.
+- Records the file's spans, entry counts, encryption header, and
+  size in the per-file metadata that joins the manifest.
+
+On disk, a backup layer is laid out as:
+
+- `BACKUP_METADATA` — the modern slim manifest. The same
+  `BackupManifest` protobuf as below, but with the large fields
+  (file index, descriptors, descriptor changes) externalized into
+  companion SST files referenced by the manifest. Restore reads this
+  file first when present.
+- `BACKUP_MANIFEST` — the legacy full manifest, retained for
+  back-compat with older readers. Modern backups write both; restore
+  falls back to it only when `BACKUP_METADATA` is absent.
+- `BACKUP-STATISTICS` — table statistics for restored tables.
+- `BACKUP_PARTITION_DESCRIPTOR_*` — one file per locality partition,
+  when the backup is partitioned.
+- `encryption-info` — the encrypted data-key wrapping, when the
+  backup is encrypted.
+- `data/` — the actual SST files exported by the processors.
+
+During execution the manifest is written as a checkpoint variant
+(`BACKUP_MANIFEST_CHECKPOINT`, `BACKUP-CHECKPOINT-*`) and replaced
+by the final files on completion. A resumed job reads the checkpoint
+to identify already-exported spans and skip them on retry.
+
+The `BackupManifest` proto (defined in `backuppb/backup.proto`) is
+versioned via `format_version` and `cluster_version` fields that
+restore-time planning validates against the current cluster's binary
+version. The file index records each file's key span and timestamp
+range so restore can build span coverings without scanning the SSTs
+themselves.
+
+**Key prefix elision**. Rather than storing each key with its full
+prefix (e.g. `/Tenant/5/Table/52/1/…` for rows of table 52 in
+tenant 5), the sink strips a shared prefix from every key in an SST
+it writes and records the elided prefix in the file's metadata. The
+file then holds keys relative to that prefix only. This shrinks file contents
+and lets restore re-prefix at link time without rewriting the file. See
+[restore.md § Ingest — below-raft (fast/online)](restore.md#ingest--below-raft-fastonline)
+for how restore consumes the elided prefix to produce a synthetic
+prefix on the linked file.
+
+### Backup collections
+
+Backups are organized at the destination into **collections**. A
+collection is a directory in external storage holding one or more
+chains: each chain is a full backup plus zero or more incrementals
+stacked on top. A new full within a collection starts a new chain;
+a new incremental adds a layer to the most recent chain.
+
+A `LATEST` pointer at the root of the collection names the most
+recent full's subdirectory. RESTORE reads it to find what to
+restore; BACKUP planning reads it to discover the chain an
+incremental will extend. Picking the new incremental's `StartTime`
+is then a chain walk: the prior layer's `EndTime` becomes the new
+layer's `StartTime`, so an incremental captures exactly the changes
+since the previous one.
+
+Compaction (below) discovers its inputs the same way — it reads the
+chain via the collection, picks a contiguous run of layers to merge,
+and writes a single replacement layer.
+
+`CREATE SCHEDULE … FOR BACKUP` is what produces this structure in
+practice: the schedule runs configured incrementals against the
+same collection between periodic fulls, generating the chain
+structure the rest of the pipeline assumes.
+
+### Compaction
+
+`compaction_*.go` implements optional compaction of an incremental
+chain: it merges several adjacent layers' SSTs into a single
+replacement layer so the chain has fewer files for restore to read.
+Compaction is triggered automatically after scheduled incrementals
+when the chain length exceeds `backup.compaction.threshold`; it runs
+as a separate job type with its own DistSQL flow
+(`compaction_processor.go`). A completed compaction writes a new
+manifest marked `IsCompacted = true` covering the merged time range.
+When RESTORE walks the chain it sees the compacted manifest as a
+single layer; the original layers' files may be deleted depending on
+the schedule's retention configuration. Compaction is transparent to
+RESTORE.
+
+Beyond just "fewer files to read," compaction is load-bearing for
+online restore in general, not only for revision-history chains.
+Online restore registers each backup layer's files into the
+destination LSM, and the LSM has only ~6 levels below L0; L0 itself
+absorbs sublevels, but registering dozens of layers there would
+push read amplification well into "unusable query performance"
+territory. That caps the layer count online restore can accept far
+below what schedules normally produce — BACKUP allows chains of
+dozens of incrementals — so online restore rejects chains longer
+than `onlineRestoreLayerLimit` at planning time
+([restore.md § Mode compatibility checks](restore.md#mode-compatibility-checks)).
+Compaction is what keeps a long-running schedule's chain short
+enough for online restore to stay viable; the alternative — taking
+more frequent fulls to cap chain length — is expensive enough that
+operators have asked for higher layer limits over time.
+
+Revision-history chains have an additional reason to compact: each
+revision-history layer also forces fast/online restore to fall
+back to above-raft for that layer's files, on top of counting
+against the layer limit.

--- a/pkg/backup/restore.md
+++ b/pkg/backup/restore.md
@@ -1,0 +1,468 @@
+# RESTORE
+
+RESTORE reads one or more BACKUP layers from external storage and
+re-creates SQL objects and their data in the current cluster.
+CockroachDB supports three execution modes for the data-ingestion
+portion of restore — **legacy** (above-raft), **fast** (below-raft,
+with user traffic gated), and **online** (below-raft, with user
+traffic enabled immediately) — that trade restore wall-clock time
+against when the restored data becomes queryable.
+
+## Mixed-version contract
+
+Restore inherits the cross-version compatibility window from
+upgrades: if a destination cluster can be upgraded from version X,
+it can restore a backup taken at X. A backup taken at v25.4 can be
+restored into v26.2 (whose minimum supported version is v25.4); a
+backup taken at v25.2 cannot, because v25.2 is below v26.2's
+minimum and the destination would have no upgrade path from it
+either.
+
+The window is inherited rather than independently designed. The
+backup format itself
+([backup.md § Sink and on-disk layout](backup.md#sink-and-on-disk-layout)
+covers the manifest's `format_version` / `cluster_version` fields)
+and most of what it contains — catalog descriptors in particular —
+are already versioned and already expected to obey the upgrade
+interop rules. Restore reads them through the same upgrade-time
+paths the rest of the cluster uses; whatever invariants those paths
+hold for live upgrades also hold for restore.
+
+This window is unusual in CockroachDB. Most mixed-version reasoning
+concerns RPCs between cluster nodes during a relatively short
+upgrade transition. A backup written to object storage, by
+contrast, may sit for months before being read by a different
+cluster — the interop window must hold for that whole gap, not just
+for the duration of an upgrade. Tenant backups carry this further
+with less machinery: tenant data is captured opaquely
+([backup.md § Backup scope](backup.md#backup-scope)), so the host
+moves KVs across the gap without interpreting them, leaving any
+version-specific logic inside the tenant.
+
+The supported upgrade paths — and therefore the supported
+backup-then-restore version pairs — are exercised by roachtests on
+the upgrade matrix.
+
+## What restore does
+
+### Restorable units
+
+A `RESTORE` statement targets one of:
+
+- **A specific table or set of tables**, possibly through database
+  wildcards. Re-creates the listed descriptors and their data in the
+  current cluster, remapping descriptor IDs as needed.
+- **A "cluster"** — re-creates the system tenant's SQL state into
+  an empty destination cluster (the destination must have no user
+  objects). See [backup.md § Backup scope](backup.md#backup-scope)
+  for what "cluster" actually means.
+- **A tenant** — `RESTORE TENANT …` re-hydrates a secondary tenant's
+  entire keyspace from a tenant backup, opaquely. Unlike other
+  restores, this carries the tenant's `system.jobs` table (see
+  §"Tenant restore specifics").
+- **System users** — `RESTORE SYSTEM USERS FROM …` re-creates only
+  the role records and their memberships from a backup, leaving
+  everything else untouched. Used to recover identity state without
+  disturbing user data.
+
+The restore unit must be compatible with what the backup was *taken
+at*: a cluster backup can be used to restore individual tables, but
+restoring a tenant requires a tenant backup.
+
+### The three modes
+
+The three modes differ in how SST data is placed into the destination
+cluster's LSM and when user traffic can read it.
+
+| Mode | KV write path | User traffic enabled |
+|---|---|---|
+| Legacy | Above-raft (`AddSSTable`) | After ingest completes |
+| Fast (`WITH EXPERIMENTAL DEFERRED COPY`) | Below-raft (`LinkExternalSSTable`) | After download completes |
+| Online (`WITH EXPERIMENTAL ONLINE`) | Below-raft (`LinkExternalSSTable`) | Immediately after link |
+
+Above-raft and below-raft are defined in the
+[README glossary](README.md#glossary). The three modes share the
+same split-and-scatter and post-restore phases; they differ only in
+how data lands in the LSM and when descriptors flip from `OFFLINE`
+to `PUBLIC`.
+
+Fast restore is faster than legacy because below-raft linking has
+dramatically better hardware utilization than streaming SST bytes
+through raft. Online restore goes a step further and enables user
+reads immediately after link: when a read intersects a linked file,
+Pebble fetches the needed SST blocks from external storage to
+satisfy it, so reads pay external-storage latency until the file is
+materialized locally by the background download (see §"Background
+download (fast/online)").
+
+### Mode compatibility checks
+
+Planning rejects fast/online restore for several configurations:
+
+- **Encryption** — encrypted backups cannot be restored
+  online/fast. `LinkExternalSSTable` has no decryption hook, so
+  encrypted external SSTs cannot be served on the fly. Use legacy
+  restore instead.
+- **Range keys** — backups containing MVCC range keys are not
+  supported for online restore.
+- **Too many layers** — chains longer than
+  `onlineRestoreLayerLimit` are rejected at planning time. The
+  destination LSM can only absorb so many registered file layers
+  before read amplification gets unworkable; compaction
+  ([backup.md § Compaction](backup.md#compaction)) is the mechanism
+  that keeps long-running schedules under this cap.
+- **`verify_backup_table_data`** — incompatible with online restore.
+- **`userfile` storage** — `userfile://` URIs are resolved through a
+  SQL session, so replicas can't open them during node startup. The
+  link path needs every replica to be able to re-open the external
+  file long after the restore job finishes (e.g. on a future node
+  restart), so `userfile` URIs are rejected.
+
+The full set of checks lives in `restore_planning.go` and
+`checkManifestsForOnlineCompat` in `restore_online.go`.
+
+### Why fast/online still need above-raft for revision-history layers
+
+Linked SSTs are interpreted by Pebble as plain LSM data: at most one
+version per key per file, optionally with all timestamps rewritten
+on read to a single uniform restore-time value (the "synthetic
+suffix"; fully described in §"Ingest — below-raft (fast/online)").
+Revision-history layers
+([backup.md § Revision-history layers](backup.md#revision-history-layers))
+contain dense multi-version MVCC blocks that cannot be represented as
+a plain LSM file with a synthetic suffix.
+
+Both fast and online restore therefore fall back to the legacy
+above-raft path *for those specific layers only*: revision-history
+SSTs are read, rekeyed, and ingested via `AddSSTable`, while
+non-history layers in the same restore use the link path. See
+§"Above-raft fallback for revision-history layers" for how the two
+paths are coordinated within a single restore.
+
+### Partial-graph restore: what has to be reconciled
+
+A RESTORE rarely restores a self-contained graph. Targets typically
+have references to objects outside the restore set, and planning must
+reconcile each kind of edge before the job can run:
+
+- **Descriptor ID remapping** — backup IDs are reallocated in the
+  destination. All in-payload references (FK columns, type
+  references, view dependencies, sequence ownership, function
+  references) must be rewritten to the new IDs.
+- **Torn dependencies** — FKs pointing to a table outside the
+  restore set, views referencing missing tables, sequences
+  referenced by columns whose owning table isn't included. The
+  `skip_missing_foreign_keys`, `skip_missing_sequences`,
+  `skip_missing_views`, etc. options govern whether such edges are
+  silently dropped, the dependent object is excluded, or planning
+  errors out.
+- **Type and UDF rewrites** — enum types and user-defined functions
+  are rewritten to new IDs and validated against the destination's
+  catalog.
+- **Multi-region** — restoring into a cluster with a different
+  region topology requires translating REGIONAL BY ROW partitions
+  and database-level multi-region configuration to the destination's
+  available regions.
+
+`restore_planning.go` performs these reconciliations before any data
+is touched; the resulting rewrites are persisted in `RestoreDetails`
+and consumed by the ingest processors.
+
+### What is and isn't carried over
+
+This section applies to table / database / cluster restores. Tenant
+restores have additional carry-over of jobs and other tenant-internal
+state — see §"Tenant restore specifics".
+
+- **Descriptors** — restored, with IDs rewritten. Descriptors are
+  restored *including* in-flight schema-change state: a table that
+  was mid-add-column at backup time has its mutation queue restored
+  verbatim. The schema-change job that was driving that mutation is
+  *not* restored, so the destination cluster surfaces and reconciles
+  these in-flight mutations post-restore (typically by adopting the
+  mutation as a new schema-change job).
+- **Data** — restored, except for tables that opted out of backup
+  via `exclude_data_from_backup`
+  ([backup.md § Exclude data from backup](backup.md#exclude-data-from-backup)):
+  their descriptors are restored but the tables come back empty.
+- **System tables** — restored selectively per `system_schema.go`.
+  Each system table is classified for how (or whether) it
+  participates in a cluster or tenant restore. `system.jobs` is
+  excluded for cluster restore: the destination cluster always
+  starts with no running jobs from the source.
+- **Stats, zone configs, comments, role memberships** — restored
+  from manifest side data into the destination's corresponding
+  system tables.
+- **In-progress IMPORTs** — if the backup captured a table mid-IMPORT
+  (the import had written some KVs before the backup ran), restore
+  spawns a child `IMPORT ROLLBACK` job after ingest to unwind the
+  partial-import data in the destination. The import job itself
+  isn't restored, but the partial KV state it left in the table
+  needs cleaning up — this is the mechanism.
+
+### Tenant restore specifics
+
+Tenant restore differs from table / database / cluster restore in
+that it re-hydrates a full SQL universe: the destination tenant
+should be indistinguishable from the source tenant at the backup's
+`EndTime`. This requires carrying over `system.jobs` and other
+tenant-internal state that other restores skip.
+
+#### Detecting restoration in a job's `Resume()`
+
+Every job's `Payload` stores a `CreationClusterID` populated by
+`jobs.Registry` at creation. When a tenant is restored into a new
+cluster, the restored job records carry the *source* cluster's ID.
+Each job type compares `Payload().CreationClusterID` against the
+current `LogicalClusterID()` in its `Resume()`; on mismatch, the job
+terminates or refuses to act on stale external state. Examples:
+changefeed jobs (`ensureClusterIDMatches` in
+`changefeedccl/changefeed_stmt.go`), spanconfig jobs
+(`spanconfigjob/job.go`), and BACKUP itself (`backup_job.go`).
+There is no central "this is a restored job" flag — every job type
+that has external dependencies is responsible for performing the
+check.
+
+#### Tenant-prefix shift
+
+The restored tenant occupies a different tenant-ID prefix in the
+destination cluster's keyspace. KV data is re-prefixed by the
+`KeyRewriter` during ingest. For most jobs the shift is transparent.
+Their state references descriptors; descriptors are read fresh on
+`Resume()`; spans are produced through the destination's codec (e.g.
+`PrimaryIndexSpan(execCfg.Codec)`), automatically picking up the
+new prefix. Jobs that persist raw key spans in their progress —
+uncommon in the current codebase and discouraged for new code — must
+rewrite manually if they want to survive a tenant restore.
+
+## Execution
+
+### Flow at a glance
+
+The job execution phases run in this order, with per-mode
+divergences called out within each phase:
+
+1. **Schema creation** — descriptors written in `OFFLINE` state so
+   user queries cannot see partially-restored tables.
+2. **Pre-data ingest** — system tables that affect ingest (zone
+   configs, etc.) are restored first.
+3. **Split & scatter** — the destination keyspace is pre-split into
+   ranges aligned with the backup's data layout and scattered across
+   nodes for parallel ingest.
+4. **Data ingest** — per-mode: above-raft (legacy) or below-raft
+   (fast/online), plus the above-raft fallback for revision-history
+   layers running concurrently.
+5. **Background download** (fast/online only) — materializes linked
+   external SSTs into local storage.
+6. **Traffic gate** — online publishes immediately after link; fast
+   waits for download to complete before publishing.
+7. **Post-restore** — FK validation, descriptor publish
+   (`OFFLINE` → `PUBLIC`), stats restoration.
+
+### Planning
+
+`restore_planning.go`'s `restorePlanHook` handles `RESTORE`
+statements. Planning:
+
+- Resolves and reads the backup manifests in the chain.
+- Resolves descriptor targets and applies `skip_missing_*` options.
+- Computes ID rewrites and any descriptor mutations needed for the
+  destination (see §"Partial-graph restore").
+- Builds the **restore span covering** (`restore_span_covering.go`):
+  the set of `RestoreSpanEntry` units that group backup files into
+  chunks of work for processors, taking into account file count and
+  target size limits.
+- Picks the mode from the `WITH EXPERIMENTAL ONLINE` /
+  `WITH EXPERIMENTAL DEFERRED COPY` options, stored in
+  `RestoreDetails` as `ExperimentalOnline` / `ExperimentalCopy`.
+- Computes `DownloadSpans` for below-raft modes: the destination
+  spans whose linked data will need post-link download.
+- Persists `RestoreDetails` with the job record.
+
+### Job coordinator
+
+`restoreResumer.Resume()` in `restore_job.go` dispatches between the
+legacy path and the fast/online path (`restore_online.go`) based on
+`details.OnlineImpl()`. The phases below run in the order shown;
+mode-specific differences are called out within each.
+
+#### Schema creation
+
+`createImportingDescriptors` writes restored descriptors to the
+catalog in `OFFLINE` state and reserves their new IDs.
+`OFFLINE` makes them invisible to user queries while data is being
+loaded. Pre-data system tables (zones in particular) are restored at
+this point so their effects are in place before user data lands.
+
+#### Split & scatter
+
+Before any data ingest, the destination keyspace is pre-split into
+ranges matching the backup's data layout and the ranges are
+scattered across the cluster to spread the ingest load.
+
+The implementation is the `GenerativeSplitAndScatterProcessor` — a
+DistSQL stage running on all participating nodes that issues
+`AdminSplit` and `AdminScatter` RPCs for chunks of the destination
+span covering, and emits `RestoreSpanEntry` rows downstream to the
+data processors. Splitting is "generative" in that span entries are
+computed on the fly from the backup manifest rather than
+materialized up-front.
+
+`RestoreSpanEntry` rows are routed from this stage to the data
+processors using range-based routing
+(`restore_processor_planning.go`): each entry goes to the SQL
+instance hosting the leaseholder of its destination span, so ingest
+work runs local to the data it produces.
+
+**Mid-row split safety**. Splits must not fall in the middle of a
+SQL row (a row spans multiple KVs across column families and
+secondary index entries; a split inside a row would break atomicity
+of MVCC operations on it). The split processor calls
+`keys.EnsureSafeSplitKey` on every candidate split key, which
+advances the key forward to the next safe row boundary if necessary.
+
+#### Ingest — above-raft (legacy)
+
+`restore_processor_planning.go`'s `distRestore` plans
+`RestoreDataProcessor` instances across nodes, taking
+`RestoreSpanEntry` rows as input from the upstream split-scatter
+stage. Each processor:
+
+- Opens the SST files in the entry via `storage.ExternalSSTReader`,
+  which transparently handles decryption via the job's encryption
+  context.
+- Iterates KVs, rewriting keys through `KeyRewriter` (descriptor
+  IDs, and tenant prefix when applicable).
+- Buffers rewritten KVs into a destination-side SST and ingests via
+  `AddSSTable`.
+
+#### Per-key elision during ingest
+
+The `KeyRewriter` skips certain keys during ingest by returning
+`(_, false, _)` from `RewriteKey`; the processor loop drops these.
+Skipped keys are those whose source-cluster values would be actively
+misleading in the destination:
+
+- `keys.SqllivenessID` — SQL instance liveness heartbeats
+  (per-instance, ephemeral).
+- `keys.LeaseTableID` — distributed leases (would point at
+  source-cluster instance IDs).
+- `keys.SQLInstancesTableID` — SQL instance registry.
+- In-progress IMPORT keys.
+
+**Asymmetry worth knowing**. This filtering runs only on the
+above-raft ingest path. The below-raft link path (next section) does
+*not* filter per KV: the link RPC takes whole files as units and has
+no equivalent of "skip this key." Stale ephemeral keys in linked
+SSTs are therefore accepted into the LSM. They are shadowed by
+fresh writes once the destination cluster's own liveness, lease, and
+sqlinstances subsystems begin operating; both paths end up correct,
+but by different mechanisms. Worth recognizing when debugging
+unexpected post-restore state.
+
+#### Ingest — below-raft (fast/online)
+
+For fast and online modes, the same `RestoreDataProcessor` runs but
+takes the `useLink` branch. Per restore span entry, it builds a
+`kvpb.LinkExternalSSTableRequest` per file and dispatches via the
+KV client. The request carries:
+
+- The file's external-storage `Locator` + `Path` and size hints
+  (`BackingFileSize`, `ApproximatePhysicalSize`).
+- A **`SyntheticPrefix`** — bytes Pebble prepends to every key read
+  from this file. Suppose the backup file held rows of table 52 in
+  tenant 5 (the file stored its keys with `/Tenant/5/Table/52`
+  elided; see
+  [backup.md § Sink and on-disk layout](backup.md#sink-and-on-disk-layout)).
+  Restoring it as table 73 in tenant 8, the synthetic prefix is
+  `/Tenant/8/Table/73`; Pebble prepends it on read so the same
+  on-disk bytes serve correctly in the destination's keyspace
+  without anyone having to rewrite the file. This is the consumer of
+  the backup-side prefix elision.
+- **`UseSyntheticSuffix`** — makes linked KVs appear to have been
+  written at restore time rather than at their original backup
+  timestamps. When set, Pebble rewrites every key's MVCC timestamp
+  suffix on read; the suffix bytes are computed server-side
+  (`replica_proposal.go`) from the request's
+  `RemoteRewriteTimestamp`.
+- **`MVCCStats`** — range-level statistics for the linked file's
+  contribution, pre-computed during planning.
+
+**Relationship to Excise**. The destination ranges have just been
+split out by the split-and-scatter phase and are typically empty,
+so no separate `Excise` is needed before link. The link RPC also
+supports an `MVCCHistoryMutation` side-effect for callers that need
+it; RESTORE itself doesn't use that path. The evaluator lives at
+`pkg/kv/kvserver/batcheval/cmd_link_external_sstable.go`.
+
+**Encryption at link time**. `LinkExternalSSTableRequest` carries
+no encryption field, and Pebble's `ExternalFile` representation has
+no decryption hook. Encrypted external SSTs therefore cannot be read
+in place by Pebble: queries against encrypted linked spans depend on
+the background download (next section), which fetches files through
+`storage.ExternalSSTReader` with the job's encryption context and
+materializes them locally.
+
+#### Background download (fast/online)
+
+After link, the restore job spawns a separate download job
+(`maybeWriteDownloadJob` in `restore_online.go`) that drives the
+materialization of linked external SSTs into local storage. It
+dispatches `serverpb.DownloadSpanRequest`s via the
+`TenantStatusServer.DownloadSpan` API. Each request carries a batch
+of spans to materialize and a `ViaBackingFileDownload` flag that
+controls whether the receiving node copies the file or hard-links it
+into its store directory (copy is required for backing files that
+were not already local).
+
+Progress is persisted on the download job via `TotalDownloadRequired`
+and `ExternalBytesRemaining`. Failures retry with exponential
+backoff (initial 100ms, capped at 5 minutes); the retry counter
+resets when progress advances. Exhausted retries pause the job for
+operator attention; `RESUME JOB` continues from where it left off,
+since download progress persists.
+
+The link phase is checkpointed via a span frontier: a pause mid-link
+records which entries have been linked, and resume processes only
+the un-linked entries. Download progress likewise persists across
+pause/resume.
+
+**Traffic gate — fast vs. online**:
+
+- **Online**: the restore job publishes descriptors
+  (`OFFLINE` → `PUBLIC`) immediately after link completes. User
+  queries against restored spans are served on the fly from linked
+  external files; downloads proceed in the background.
+- **Fast**: the restore job waits on `waitForDownloadToComplete`
+  before publishing descriptors. The destination is "off" until
+  download finishes; once it does, the cluster sees fully-local
+  data when descriptors flip to `PUBLIC`.
+
+Both modes share the same link and download mechanisms; they differ
+only in when the traffic gate releases.
+
+#### Above-raft fallback for revision-history layers
+
+When fast/online detects revision-history layers in the chain (see
+§"Why fast/online still need above-raft for revision-history layers"),
+those layers' files are routed through the legacy above-raft path:
+same `RestoreDataProcessor`, same `KeyRewriter`, same `AddSSTable`
+call. Below-raft link runs in parallel against the same destination
+ranges for non-history layers in the same restore. The splits and
+scatters from the earlier phase prepared range boundaries; both
+ingest paths land within the same ranges.
+
+#### Post-restore
+
+After all ingestion completes (and, for fast mode, after the
+download gate releases):
+
+- **FK validation** runs on the restored tables in a post-data
+  flow, ensuring no FK violations were introduced by the restore.
+- **Descriptors publish**: `OFFLINE` → `PUBLIC`, in dependency
+  order, making the restored objects visible to user queries.
+- **Stats restoration**: backed-up table statistics are restored
+  into `system.table_statistics`.
+
+(Compacted chains restore the same way as uncompacted ones; see
+[backup.md § Compaction](backup.md#compaction).)


### PR DESCRIPTION
Adds three reference documents to `pkg/backup` describing how BACKUP and RESTORE work end-to-end:

- **`README.md`** indexes the package, provides a glossary, and points at debugging entry points and the test layout.
- **`backup.md`** covers what backup produces (units, captured state, `exclude_data_from_backup`, revision-history layers, encryption, PTS chaining, multi-region) and the mechanics (planning, job phases, DistSQL flow, `ExportRequest` knobs, on-disk layout, compaction).
- **`restore.md`** covers what restore is (units, the three modes with their compatibility constraints, partial-graph reconciliation, what is and isn't carried over, tenant restore specifics) and the mechanics in chronological order (planning, schema creation, split & scatter, above-raft ingest with the `KeyRewriter` elision asymmetry, below-raft link with the `SyntheticPrefix`/`SyntheticSuffix` mechanism, background download, revision-history fallback, post-restore).

Goal: future readers (humans and AI agents) can build a working mental model of the subsystem without re-deriving the architecture from scratch every time a bug demands deep context.

Epic: none
Release note: None