### PR TITLE
roachtest: disable drpc for `kv/gracefuldraining`

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -205,6 +205,10 @@ type TestSpec struct {
 	// PostProcessPerfMetrics can be used to custom aggregated metrics
 	// from the histogram metrics that are emitted by the roachtest
 	PostProcessPerfMetrics func(string, *roachtestutil.HistogramMetric) (roachtestutil.AggregatedPerfMetrics, error)
+
+	// SkipDRPC opts this test out of metamorphic DRPC enablement. The test
+	// will always run with gRPC unless --force-drpc is set.
+	SkipDRPC bool
 }
 
 // SetStats sets the stats for the test

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1176,7 +1176,7 @@ func (r *testRunner) runWorker(
 					c.SetUseDRPC(true)
 					c.status("Enabling DRPC")
 					t.AddParam("forceDRPC", "true")
-				} else if !testSpec.Benchmark && !isMixedVersion && prng.Intn(2) == 0 {
+				} else if !testSpec.Benchmark && !isMixedVersion && !testSpec.SkipDRPC && prng.Intn(2) == 0 {
 					c.SetUseDRPC(true)
 					c.status("Enabling DRPC")
 					t.AddParam("metamorphicDRPC", "true")

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -573,6 +573,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
+		SkipDRPC:         true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			nodes := c.Spec().NodeCount - 1
 			t.Status("starting cluster")


### PR DESCRIPTION
The roachtest `kv/gracefuldraining` is currently failing. Although it is also failing without drpc but to reduce noise disabling it. For more details - https://github.com/cockroachdb/cockroach/issues/169630#issuecomment-4501424537

Epic: None
Informs: #169630
Release note: None