### PR TITLE
server: log DRPC enabled status at startup

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -227,7 +227,7 @@ func NewDemoCluster(
 
 func (c *transientCluster) Start(ctx context.Context) (err error) {
 	ctx = logtags.AddTag(ctx, "start-demo-cluster", nil)
-
+	log.Ops.Infof(ctx, "DRPC enabled: %t", c.demoCtx.UseDRPC)
 	// Initialize the connection database.
 	// We can't do this earlier as this depends on which generator is used.
 	c.defaultDB = catalogkeys.DefaultDatabaseName

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -666,6 +666,7 @@ func (cfg *Config) SafeFormat(sp redact.SafePrinter, _ rune) {
 	fmt.Fprintln(w, "scan min idle time\t", cfg.ScanMinIdleTime)
 	fmt.Fprintln(w, "scan max idle time\t", cfg.ScanMaxIdleTime)
 	fmt.Fprintln(w, "event log enabled\t", cfg.EventLogEnabled)
+	fmt.Fprintln(w, "DRPC enabled\t", cfg.UseDRPC)
 	if cfg.Linearizable {
 		fmt.Fprintln(w, "linearizable\t", cfg.Linearizable)
 	}


### PR DESCRIPTION
Log whether DRPC is enabled during server startup alongside the existing listen address logs. This runs in the common server start path, so it appears for both `cockroach start` and `cockroach demo`.

Epic: None
Fixes: #170886
Release note: None