### PR TITLE
sql: populate pg_class.relhastriggers

### DIFF
--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -831,7 +831,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 						"CREATE FUNCTION public.trigger_f()",
 						"CREATE TABLE public.trigger_t1",
 						"CREATE TABLE public.trigger_t2",
-						"CREATE TRIGGER trigger_foo AFTER INSERT ON defaultdb.public.trigger_t1"} {
+						"CREATE TRIGGER trigger_foo AFTER INSERT ON public.trigger_t1"} {
 						if !strings.Contains(contents, expected) {
 							return errors.Errorf("could not find %q in schema.sql:\n%s", expected, contents)
 						}

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -1482,13 +1482,13 @@ skipif config local-legacy-schema-changer
 query T
 SELECT pg_get_triggerdef(oid) FROM pg_trigger WHERE tgname = 'test_trig'
 ----
-CREATE TRIGGER test_trig BEFORE INSERT ON test.public.trig_test FOR EACH ROW EXECUTE FUNCTION test.public.trig_fn()
+CREATE TRIGGER test_trig BEFORE INSERT ON public.trig_test FOR EACH ROW EXECUTE FUNCTION public.trig_fn()
 
 skipif config local-legacy-schema-changer
 query T
 SELECT pg_get_triggerdef(oid, true) FROM pg_trigger WHERE tgname = 'test_trig'
 ----
-CREATE TRIGGER test_trig BEFORE INSERT ON test.public.trig_test FOR EACH ROW EXECUTE FUNCTION test.public.trig_fn()
+CREATE TRIGGER test_trig BEFORE INSERT ON public.trig_test FOR EACH ROW EXECUTE FUNCTION public.trig_fn()
 
 # Invalid OID returns NULL.
 query T nosort

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1104,6 +1104,12 @@ select relname, relrowsecurity, relforcerowsecurity from pg_class where relname 
 ----
 roaches  true  true
 
+# pg_tables.rowsecurity should agree with pg_class.relrowsecurity.
+query TB
+select tablename, rowsecurity from pg_tables where tablename = 'roaches';
+----
+roaches  true
+
 skipif config schema-locked-disabled
 query T
 select create_statement from crdb_internal.create_statements where descriptor_name='roaches'

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_triggers
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_triggers
@@ -39,7 +39,7 @@ query T colnames,nosort
 SHOW CREATE ALL TRIGGERS;
 ----
 create_statement
-CREATE TRIGGER t1_trigger AFTER INSERT ON d.public.t1 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
+CREATE TRIGGER t1_trigger AFTER INSERT ON public.t1 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();
 
 statement ok
 CREATE TRIGGER t2_trigger
@@ -51,8 +51,8 @@ query T colnames,nosort
 SHOW CREATE ALL TRIGGERS;
 ----
 create_statement
-CREATE TRIGGER t1_trigger AFTER INSERT ON d.public.t1 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
-CREATE TRIGGER t2_trigger AFTER INSERT ON d.public.t2 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
+CREATE TRIGGER t1_trigger AFTER INSERT ON public.t1 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();
+CREATE TRIGGER t2_trigger AFTER INSERT ON public.t2 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();
 
 statement ok
 CREATE OR REPLACE FUNCTION trigger_func2()
@@ -75,9 +75,9 @@ query T colnames,nosort
 SHOW CREATE ALL TRIGGERS;
 ----
 create_statement
-CREATE TRIGGER t1_trigger AFTER INSERT ON d.public.t1 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
-CREATE TRIGGER t1_trigger2 AFTER INSERT ON d.public.t1 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func2();
-CREATE TRIGGER t2_trigger AFTER INSERT ON d.public.t2 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
+CREATE TRIGGER t1_trigger AFTER INSERT ON public.t1 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();
+CREATE TRIGGER t1_trigger2 AFTER INSERT ON public.t1 FOR EACH ROW EXECUTE FUNCTION public.trigger_func2();
+CREATE TRIGGER t2_trigger AFTER INSERT ON public.t2 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();
 
 statement ok
 DROP TRIGGER t1_trigger2 ON t1;
@@ -86,5 +86,5 @@ query T colnames,nosort
 SHOW CREATE ALL TRIGGERS;
 ----
 create_statement
-CREATE TRIGGER t1_trigger AFTER INSERT ON d.public.t1 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
-CREATE TRIGGER t2_trigger AFTER INSERT ON d.public.t2 FOR EACH ROW EXECUTE FUNCTION d.public.trigger_func();
+CREATE TRIGGER t1_trigger AFTER INSERT ON public.t1 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();
+CREATE TRIGGER t2_trigger AFTER INSERT ON public.t2 FOR EACH ROW EXECUTE FUNCTION public.trigger_func();

--- a/pkg/sql/logictest/testdata/logic_test/triggers
+++ b/pkg/sql/logictest/testdata/logic_test/triggers
@@ -4978,11 +4978,11 @@ WHERE tgrelid = 'test_triggers'::regclass
 ORDER BY tgname;
 ----
 tgname              tgtype  has_func_oid  tgnargs  tgenabled  tgoldtable  tgnewtable
-after_delete_row    9       true          0        A          NULL        NULL
-after_insert_row    5       true          0        A          NULL        NULL
-before_update_row   19      true          0        A          NULL        NULL
-multi_event_trigger 31      true          0        A          NULL        NULL
-trigger_with_args   5       true          3        A          NULL        NULL
+after_delete_row    9       true          0        O          NULL        NULL
+after_insert_row    5       true          0        O          NULL        NULL
+before_update_row   19      true          0        O          NULL        NULL
+multi_event_trigger 31      true          0        O          NULL        NULL
+trigger_with_args   5       true          3        O          NULL        NULL
 
 # Test INSTEAD OF triggers (not yet implemented)
 statement error pgcode 42809 "test_triggers" is a table\nDETAIL: Tables cannot have INSTEAD OF triggers.
@@ -5163,12 +5163,12 @@ CREATE TRIGGER insert_trigger
   FOR EACH ROW
   EXECUTE FUNCTION audit_trigger_func();
 
-# Verify trigger is enabled by default (tgenabled = 'A' for always).
+# Verify trigger is enabled by default (tgenabled = 'O' for origin).
 skipif config local-mixed-25.4 local-mixed-26.1
 query T
 SELECT tgenabled FROM pg_trigger WHERE tgname = 'insert_trigger';
 ----
-A
+O
 
 # SHOW TRIGGERS should also report enabled = true.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5227,7 +5227,7 @@ skipif config local-mixed-25.4 local-mixed-26.1
 query T
 SELECT tgenabled FROM pg_trigger WHERE tgname = 'insert_trigger';
 ----
-A
+O
 
 # Insert another row - trigger should fire again.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5269,7 +5269,7 @@ skipif config local-mixed-25.4 local-mixed-26.1
 query T
 SELECT tgenabled FROM pg_trigger WHERE tgname = 'insert_trigger';
 ----
-A
+O
 
 # Test error when trigger doesn't exist.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5294,8 +5294,8 @@ skipif config local-mixed-25.4 local-mixed-26.1
 query TT rowsort
 SELECT tgname, tgenabled FROM pg_trigger WHERE tgrelid = 'enable_disable_t'::regclass ORDER BY tgname;
 ----
-insert_trigger  A
-update_trigger  A
+insert_trigger  O
+update_trigger  O
 
 # Insert and update - both triggers should fire.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5362,8 +5362,8 @@ skipif config local-mixed-25.4 local-mixed-26.1
 query TT rowsort
 SELECT tgname, tgenabled FROM pg_trigger WHERE tgrelid = 'enable_disable_t'::regclass ORDER BY tgname;
 ----
-insert_trigger  A
-update_trigger  A
+insert_trigger  O
+update_trigger  O
 
 # Both triggers should fire again.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5396,7 +5396,7 @@ query TT rowsort
 SELECT tgname, tgenabled FROM pg_trigger WHERE tgrelid = 'enable_disable_t'::regclass ORDER BY tgname;
 ----
 insert_trigger  D
-update_trigger  A
+update_trigger  O
 
 # Insert and update - only update trigger should fire.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5453,8 +5453,8 @@ skipif config local-mixed-25.4 local-mixed-26.1
 query TT rowsort
 SELECT tgname, tgenabled FROM pg_trigger WHERE tgrelid = 'enable_disable_t'::regclass ORDER BY tgname;
 ----
-insert_trigger  A
-update_trigger  A
+insert_trigger  O
+update_trigger  O
 
 # Test that ALL/USER on a table with no triggers is a no-op.
 skipif config local-mixed-25.4 local-mixed-26.1
@@ -5493,8 +5493,8 @@ skipif config local-mixed-25.4 local-mixed-26.1
 query TT rowsort
 SELECT tgname, tgenabled FROM pg_trigger WHERE tgrelid = 'enable_disable_t'::regclass ORDER BY tgname;
 ----
-insert_trigger  A
-update_trigger  A
+insert_trigger  O
+update_trigger  O
 
 # Test with IF EXISTS on table.
 skipif config local-mixed-25.4 local-mixed-26.1

--- a/pkg/sql/logictest/testdata/logic_test/triggers
+++ b/pkg/sql/logictest/testdata/logic_test/triggers
@@ -5075,6 +5075,28 @@ WHERE tgrelid = 'other_schema.test_table'::regclass;
 tgname                table_name  trigger_func_name
 other_schema_trigger  test_table  trigger_func1
 
+# Test that pg_class.relhastriggers reflects the presence of triggers.
+query TB colnames,rowsort
+SELECT relname, relhastriggers
+FROM pg_catalog.pg_class
+WHERE relname IN ('test_triggers', 'audit_log', 'test_table');
+----
+relname        relhastriggers
+audit_log      false
+test_table     true
+test_triggers  true
+
+# pg_tables.hastriggers should agree with pg_class.relhastriggers.
+query TB colnames,rowsort
+SELECT tablename, hastriggers
+FROM pg_catalog.pg_tables
+WHERE tablename IN ('test_triggers', 'audit_log', 'test_table');
+----
+tablename      hastriggers
+audit_log      false
+test_table     true
+test_triggers  true
+
 # Clean up
 statement ok
 DROP TABLE test_triggers CASCADE;

--- a/pkg/sql/logictest/testdata/logic_test/triggers
+++ b/pkg/sql/logictest/testdata/logic_test/triggers
@@ -4164,19 +4164,19 @@ query TT colnames
 SHOW CREATE TRIGGER tr ON t;
 ----
 trigger_name  create_statement
-tr            CREATE TRIGGER tr AFTER INSERT ON test.public.t FOR EACH ROW EXECUTE FUNCTION test.public.g()
+tr            CREATE TRIGGER tr AFTER INSERT ON public.t FOR EACH ROW EXECUTE FUNCTION public.g()
 
 query TT colnames
 SHOW CREATE TRIGGER tr2 ON t;
 ----
 trigger_name  create_statement
-tr2           CREATE TRIGGER tr2 BEFORE UPDATE ON test.public.t FOR EACH ROW EXECUTE FUNCTION test.public.g()
+tr2           CREATE TRIGGER tr2 BEFORE UPDATE ON public.t FOR EACH ROW EXECUTE FUNCTION public.g()
 
 query TT colnames
 SHOW CREATE TRIGGER tr3 ON t;
 ----
 trigger_name  create_statement
-tr3           CREATE TRIGGER tr3 AFTER INSERT OR UPDATE ON test.public.t FOR EACH ROW WHEN (new).a < 5:::INT8 EXECUTE FUNCTION test.public.g()
+tr3           CREATE TRIGGER tr3 AFTER INSERT OR UPDATE ON public.t FOR EACH ROW WHEN (new).a < 5:::INT8 EXECUTE FUNCTION public.g()
 
 statement ok
 DROP TRIGGER tr ON t;
@@ -4564,7 +4564,7 @@ CREATE OR REPLACE TRIGGER replace_test BEFORE INSERT ON xy FOR EACH ROW EXECUTE 
 query TT
 SHOW CREATE TRIGGER replace_test ON xy;
 ----
-replace_test  CREATE TRIGGER replace_test BEFORE INSERT ON test.public.xy FOR EACH ROW EXECUTE FUNCTION test.public.f()
+replace_test  CREATE TRIGGER replace_test BEFORE INSERT ON public.xy FOR EACH ROW EXECUTE FUNCTION public.f()
 
 # CREATE OR REPLACE TRIGGER when the trigger already exists replaces it.
 statement ok
@@ -4573,7 +4573,7 @@ CREATE OR REPLACE TRIGGER replace_test AFTER UPDATE ON xy FOR EACH ROW EXECUTE F
 query TT
 SHOW CREATE TRIGGER replace_test ON xy;
 ----
-replace_test  CREATE TRIGGER replace_test AFTER UPDATE ON test.public.xy FOR EACH ROW EXECUTE FUNCTION test.public.f()
+replace_test  CREATE TRIGGER replace_test AFTER UPDATE ON public.xy FOR EACH ROW EXECUTE FUNCTION public.f()
 
 # CREATE TRIGGER (without REPLACE) still errors on duplicate.
 statement error pgcode 42710 pq: trigger "replace_test" for relation "xy" already exists

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4254,8 +4254,11 @@ https://www.postgresql.org/docs/16/catalog-pg-trigger.html`,
 						}
 					}
 
-					// tgenabled: O = origin and local, D = disabled, R = replica, A = always
-					tgenabled := tree.NewDString("A")
+					// tgenabled: O = origin and local, D = disabled, R = replica, A = always.
+					// CockroachDB has no session_replication_role equivalent, so a trigger
+					// is either enabled (firing on origin and local, the PostgreSQL default)
+					// or disabled.
+					tgenabled := tree.NewDString("O")
 					if !trigger.Enabled {
 						tgenabled = tree.NewDString("D")
 					}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1024,7 +1024,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			tree.DBoolFalse, // relhasoids
 			tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // relhaspkey
 			tree.DBoolFalse, // relhasrules
-			tree.DBoolFalse, // relhastriggers
+			tree.MakeDBool(tree.DBool(len(table.GetTriggers()) > 0)), // relhastriggers
 			tree.DBoolFalse, // relhassubclass
 			zeroVal,         // relfrozenxid
 			relacl,          // relacl
@@ -4171,8 +4171,8 @@ https://www.postgresql.org/docs/9.5/view-pg-tables.html`,
 					tree.DNull,                     // tablespace
 					tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // hasindexes
 					tree.DBoolFalse, // hasrules
-					tree.DBoolFalse, // hastriggers
-					tree.DBoolFalse, // rowsecurity
+					tree.MakeDBool(tree.DBool(len(table.GetTriggers()) > 0)),      // hastriggers
+					tree.MakeDBool(tree.DBool(table.IsRowLevelSecurityEnabled())), // rowsecurity
 				)
 			})
 	},

--- a/pkg/sql/show_trigger.go
+++ b/pkg/sql/show_trigger.go
@@ -78,15 +78,21 @@ func renderCreateTriggerStatement(
 	}
 
 	// Resolve the fully-qualified names of the trigger function and table.
+	// PostgreSQL's pg_get_triggerdef emits a schema-qualified table name but
+	// no catalog (database) prefix; suppress the catalog here so SHOW CREATE
+	// TRIGGER and pg_get_triggerdef produce schema.table, matching PostgreSQL
+	// and keeping the output reusable across databases.
 	funcName, err := p.GetQualifiedFunctionNameByID(ctx, int64(trigger.FuncID))
 	if err != nil {
 		return "", err
 	}
+	funcName.ExplicitCatalog = false
 
 	tableName, err := p.getQualifiedTableName(ctx, tableDesc)
 	if err != nil {
 		return "", err
 	}
+	tableName.ExplicitCatalog = false
 
 	// Use the trigger descriptor to decompile a CreateTrigger statement that
 	// will be used to produce the SHOW CREATE TRIGGER output.


### PR DESCRIPTION
pg_dump uses relhastriggers as a fast-path filter when collecting triggers — if it's false, the trigger query is skipped for that table. Hard-coding it to false caused pg_dump to silently omit all triggers.

Resolves: #170842
Epic: none

Release note (bug fix): Fixed a bug where pg_class.relhastriggers always reported false, even for tables that had triggers defined.