### PR TITLE
sql: reject DDL in PL/pgSQL procedure bodies when late binding is off

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/procedure_dcl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_dcl
@@ -1,5 +1,11 @@
 # LogicTest: !local-mixed-25.4 !local-mixed-26.1 !local-mixed-26.2
 
+# DDL in PL/pgSQL procedure bodies requires late binding; DCL on its own does
+# not, but enabling it here keeps the mixed DDL/DCL subtests below uniform
+# with procedure_ddl.
+statement ok
+SET CLUSTER SETTING sql.procedures.plpgsql.late_binding.enabled = true
+
 statement ok
 CREATE ROLE r1;
 CREATE ROLE r2;
@@ -209,9 +215,9 @@ subtest end
 
 subtest mixed_ddl_and_dcl
 
-# DDL and DCL freely mix in the same procedure body, but DCL targets are
-# early-bound: a GRANT cannot reference a table created in the same body.
-# This procedure grants on a pre-existing table and then creates a new one.
+# DDL and DCL mix in the same procedure body. Late-binding behavior for
+# DCL targets that reference a table created earlier in the same body is
+# covered by the grant_on_newly_created_table subtest below.
 statement ok
 CREATE PROCEDURE p_mixed() LANGUAGE PLpgSQL AS $$
 BEGIN
@@ -244,20 +250,26 @@ DROP PROCEDURE p_mixed;
 subtest end
 
 
-subtest early_binding_limitations
+subtest grant_on_newly_created_table
 
-# GRANT targets are resolved when the procedure body is built (at CREATE
-# PROCEDURE time), not when CALL executes, so a GRANT cannot refer to a
-# table created earlier in the same body. This test pins the early-binding
-# behavior so a future late-binding change for stored procedures will
-# visibly flip it.
-statement error pgcode 42P01 relation "t_grant_target" does not exist
+# With late binding CREATE PROCEDURE accepts a body that creates a table
+# and then GRANTs on it — references are not resolved until CALL time. CALL
+# still fails today because body statements are built (AST -> RelExpr)
+# eagerly at CALL plan time, before the preceding CREATE TABLE has
+# executed. See the analogous CREATE TABLE + INSERT case in procedure_ddl.
+statement ok
 CREATE PROCEDURE p_grant_on_new_table() LANGUAGE PLpgSQL AS $$
 BEGIN
   CREATE TABLE t_grant_target (a INT PRIMARY KEY);
   GRANT SELECT ON t_grant_target TO r1;
 END
 $$;
+
+statement error pgcode 42P01 relation "t_grant_target" does not exist
+CALL p_grant_on_new_table();
+
+statement ok
+DROP PROCEDURE p_grant_on_new_table;
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/procedure_ddl
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_ddl
@@ -9,6 +9,10 @@
 # back to the in-routine safety net (txnSchemaChangeErr) and must explicitly
 # use SERIALIZABLE.
 
+# DDL in PL/pgSQL procedure bodies requires late binding.
+statement ok
+SET CLUSTER SETTING sql.procedures.plpgsql.late_binding.enabled = true
+
 subtest ddl_blocked_in_functions
 
 # DDL should remain blocked in functions.
@@ -419,28 +423,16 @@ subtest end
 
 subtest ddl_then_dml_same_table
 
-# CockroachDB compiles routine body statements at CREATE PROCEDURE time,
-# resolving all table references against the current catalog. A table
-# created by DDL inside the procedure does not exist in the catalog when
-# subsequent statements in the same body are compiled, so referencing the
-# new table from a later statement in the same procedure fails at
-# definition time — not at execution time.
-#
-# This diverges from PostgreSQL, where PL/pgSQL uses late binding:
-# statements are planned at CALL time (or on first execution), so a
-# CREATE TABLE followed by INSERT INTO that table in the same body works
-# in PostgreSQL. PostgreSQL performs only PL/pgSQL structural parsing at
-# CREATE time (block syntax, control flow, variable resolution) but does
-# NOT plan or resolve SQL statements — those remain opaque strings until
-# execution. For example, INSERT INTO nonexistent_table succeeds at
-# CREATE PROCEDURE time in PostgreSQL and only errors at CALL time.
-#
-# TODO(spilchen): we will need to add late-binding support for procedure body
-# DDL to work like PostgreSQL.
-#
-# Workaround: split DDL and DML into separate procedures.
+# With late binding CREATE PROCEDURE accepts a body that does DDL and then
+# references the new table in the same body — references are not resolved
+# until CALL time. CALL still fails today because the body's statements
+# are built (AST -> RelExpr) eagerly at CALL plan time, before the
+# preceding CREATE TABLE has actually executed. See #167687 for the
+# proposal to defer body-statement building to execution time, which
+# would let these cases succeed. Workaround: split DDL and DML into
+# separate procedures.
 
-statement error pgcode 42P01 relation "t_immediate" does not exist
+statement ok
 CREATE PROCEDURE p_create_and_insert() LANGUAGE PLpgSQL AS $$
 BEGIN
   CREATE TABLE t_immediate (a INT PRIMARY KEY, b TEXT);
@@ -448,11 +440,14 @@ BEGIN
 END
 $$;
 
-# Test whether a COMMIT boundary between CREATE TABLE and INSERT allows
-# the INSERT to succeed. Since compilation happens at CREATE PROCEDURE
-# time, the COMMIT should not help — the INSERT is still resolved against
-# a catalog that does not yet contain the table.
-statement error pgcode 42P01 relation "t_commit_then_use" does not exist
+statement error pgcode 42P01 relation "t_immediate" does not exist
+CALL p_create_and_insert();
+
+statement ok
+DROP PROCEDURE p_create_and_insert;
+
+# Same shape but with an intervening COMMIT.
+statement ok
 CREATE PROCEDURE p_create_commit_insert() LANGUAGE PLpgSQL AS $$
 BEGIN
   CREATE TABLE t_commit_then_use (a INT);
@@ -460,6 +455,12 @@ BEGIN
   INSERT INTO t_commit_then_use VALUES (1);
 END
 $$;
+
+statement error pgcode 42P01 relation "t_commit_then_use" does not exist
+CALL p_create_commit_insert();
+
+statement ok
+DROP PROCEDURE p_create_commit_insert;
 
 subtest end
 
@@ -1514,20 +1515,24 @@ SELECT rolname FROM pg_roles WHERE rolname IN ('r_multi_1', 'r_multi_2');
 r_multi_1
 r_multi_2
 
-# CREATE SCHEMA followed by DROP SCHEMA on the same name in one body hits
-# the early-binding limitation: routine body statements resolve catalog
-# names at compile time, so the DROP SCHEMA cannot find the schema the
-# preceding CREATE SCHEMA would produce. See the ddl_then_dml_same_table
-# subtest for the analogous CREATE TABLE + INSERT case and the underlying
-# rationale.
-# TODO(#89109): late-binding support would let this work like PostgreSQL.
-statement error pgcode 3F000 unknown schema "s_transient"
+# CREATE SCHEMA followed by DROP SCHEMA on the same name in one body. Under
+# late binding CREATE PROCEDURE succeeds, but CALL still fails today because
+# body statements are built eagerly at CALL plan time, before the preceding
+# CREATE SCHEMA has executed. See the ddl_then_dml_same_table subtest for
+# the analogous CREATE TABLE + INSERT case.
+statement ok
 CREATE PROCEDURE p_create_drop_schema() LANGUAGE PLpgSQL AS $$
 BEGIN
   CREATE SCHEMA s_transient;
   DROP SCHEMA s_transient;
 END
 $$;
+
+statement error pgcode 3F000 unknown schema "s_transient"
+CALL p_create_drop_schema();
+
+statement ok
+DROP PROCEDURE p_create_drop_schema;
 
 statement ok
 DROP ROLE r_multi_1, r_multi_2;
@@ -1654,16 +1659,21 @@ CREATE SCHEMA s_with_table;
 statement ok
 CREATE TABLE s_with_table.t (a INT);
 
-# DROP SCHEMA RESTRICT performs the non-empty check at procedure compile
-# time (early binding), so a procedure that targets a non-empty schema
-# fails to define rather than failing at CALL time. This is consistent
-# with the early-binding behavior covered by ddl_then_dml_same_table.
-statement error pgcode 2BP01 schema "s_with_table" is not empty
+# Under late binding the non-empty check for DROP SCHEMA RESTRICT is
+# deferred to CALL time, so CREATE PROCEDURE accepts the body and CALL
+# raises the error.
+statement ok
 CREATE PROCEDURE p_drop_schema_restrict() LANGUAGE PLpgSQL AS $$
 BEGIN
   DROP SCHEMA s_with_table RESTRICT;
 END
 $$;
+
+statement error pgcode 2BP01 schema "s_with_table" is not empty
+CALL p_drop_schema_restrict();
+
+statement ok
+DROP PROCEDURE p_drop_schema_restrict;
 
 # CASCADE drops the schema and its child objects when CALLed.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/procedure_late_binding
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_late_binding
@@ -3,9 +3,11 @@
 # Late binding is a PL/pgSQL-only feature. LANGUAGE SQL procedures and UDFs
 # always use early binding; the setting has no effect on them.
 #
-# The setting is ON for the entire file by default. The transition tests
-# toggle it intrinsically, and late_to_early_binding_transition leaves the
-# setting OFF for late_binding_disabled, which then RESETs at the end.
+# The setting is ON for the entire file by default, with one exception:
+# after the late_to_early_binding_transition subtest the setting is OFF for
+# the remaining subtests (those that test off-behavior, including
+# plpgsql_ddl_hint which also flips back to ON to test that direction).
+# A final RESET in the last subtest restores the default.
 statement ok
 SET CLUSTER SETTING sql.procedures.plpgsql.late_binding.enabled = true
 
@@ -807,7 +809,8 @@ subtest end
 
 # --------------------------------------------------------------------------
 # OFF-section: the setting is OFF from the transition above through the end
-# of the file.
+# of the file. Subtests here do not toggle it (except plpgsql_ddl_hint, which
+# tests both directions at the end).
 # --------------------------------------------------------------------------
 
 subtest late_binding_disabled
@@ -820,6 +823,131 @@ DECLARE
   v INT;
 BEGIN
   SELECT 1 INTO v FROM no_such_table LIMIT 1;
+END
+$$
+
+subtest end
+
+subtest plpgsql_ddl_nested
+
+# The DDL detector must recurse through nested PL/pgSQL constructs (IF, LOOP),
+# not just inspect top-level statements.
+statement error pgcode 0A000 DDL statements in PL/pgSQL procedure bodies require late binding
+CREATE PROCEDURE p_ddl_if() LANGUAGE PLpgSQL AS $$
+BEGIN
+  IF TRUE THEN
+    CREATE TABLE t_ddl_if (id INT);
+  END IF;
+END
+$$
+
+statement error pgcode 0A000 DDL statements in PL/pgSQL procedure bodies require late binding
+CREATE PROCEDURE p_ddl_loop() LANGUAGE PLpgSQL AS $$
+BEGIN
+  LOOP
+    DROP TABLE t_ddl_loop;
+    EXIT;
+  END LOOP;
+END
+$$
+
+subtest end
+
+subtest plpgsql_ddl_cursor
+
+# The DDL detector must inspect SQL statements wrapped inside PL/pgSQL cursor
+# nodes (CursorDeclaration.Query and Open.Query), not just bare top-level
+# statements.
+
+# CursorDeclaration branch: bound cursor whose query is DDL.
+statement error pgcode 0A000 DDL statements in PL/pgSQL procedure bodies require late binding
+CREATE PROCEDURE p_ddl_cursor_decl() LANGUAGE PLpgSQL AS $$
+DECLARE
+  c CURSOR FOR DROP TABLE t_does_not_exist;
+BEGIN
+  OPEN c;
+END
+$$
+
+# Open branch: OPEN c FOR <DDL>.
+statement error pgcode 0A000 DDL statements in PL/pgSQL procedure bodies require late binding
+CREATE PROCEDURE p_ddl_open() LANGUAGE PLpgSQL AS $$
+DECLARE
+  c REFCURSOR;
+BEGIN
+  OPEN c FOR DROP TABLE t_does_not_exist;
+END
+$$
+
+subtest end
+
+subtest plpgsql_ddl_hint
+
+# Tests both directions: supported DDL is rejected with a hint when the
+# setting is OFF, then accepted when it is ON. Unsupported DDL is rejected
+# in both cases.
+statement error pgcode 0A000 DDL statements in PL/pgSQL procedure bodies require late binding
+CREATE PROCEDURE p_ddl_create() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_ddl (id INT);
+END
+$$
+
+statement error pgcode 0A000 DDL statements in PL/pgSQL procedure bodies require late binding
+CREATE PROCEDURE p_ddl_drop() LANGUAGE PLpgSQL AS $$
+BEGIN
+  DROP TABLE t_ddl;
+END
+$$
+
+# DDL that is not in the in-procedure allowlist (e.g. ALTER TABLE,
+# CREATE INDEX, CREATE VIEW) is reported as unimplemented at CREATE
+# PROCEDURE time regardless of the setting; enabling late binding would
+# not make these work, so users get the more specific error instead of
+# the late-binding hint.
+statement error pgcode 0A000 unimplemented: ALTER TABLE usage inside a function definition
+CREATE PROCEDURE p_ddl_alter() LANGUAGE PLpgSQL AS $$
+BEGIN
+  ALTER TABLE t_ddl ADD COLUMN c INT;
+END
+$$
+
+statement error pgcode 0A000 unimplemented: CREATE INDEX usage inside a function definition
+CREATE PROCEDURE p_ddl_idx() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE INDEX idx ON t_ddl (id);
+END
+$$
+
+# Mixed bodies are reported by the unsupported statement first, since
+# enabling the setting alone would not fix it.
+statement error pgcode 0A000 unimplemented: ALTER TABLE usage inside a function definition
+CREATE PROCEDURE p_ddl_mixed() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_ddl (id INT);
+  ALTER TABLE t_ddl ADD COLUMN c INT;
+END
+$$
+
+# With the setting enabled the supported body is accepted, and the
+# unsupported body is still rejected at CREATE time (same error as above).
+statement ok
+SET CLUSTER SETTING sql.procedures.plpgsql.late_binding.enabled = true
+
+statement ok
+CREATE PROCEDURE p_ddl_create() LANGUAGE PLpgSQL AS $$
+BEGIN
+  CREATE TABLE t_ddl (id INT);
+END
+$$
+
+statement ok
+DROP PROCEDURE p_ddl_create
+
+statement error pgcode 0A000 unimplemented: ALTER TABLE usage inside a function definition
+CREATE PROCEDURE p_ddl_alter_late() LANGUAGE PLpgSQL AS $$
+BEGIN
+  ALTER TABLE t_ddl ADD COLUMN c INT;
 END
 $$
 

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -384,27 +384,26 @@ func (b *Builder) buildStmt(
 		case *tree.Insert, *tree.Update, *tree.Delete:
 		case *tree.Call:
 		case *tree.DoBlock:
-		case *tree.CreateTable, *tree.DropTable,
-			*tree.CreateSchema, *tree.DropSchema,
-			*tree.CreateRole, *tree.DropRole,
-			*tree.Grant, *tree.Revoke, *tree.AlterDefaultPrivileges:
-			if !b.insideProcDef {
-				panic(unimplemented.NewWithIssuef(110080,
-					"%s usage inside a function definition is not supported",
-					stmt.StatementTag(),
-				))
-			}
-			// DDL and DCL are allowed inside stored procedures when the
-			// cluster has been upgraded to v26.3.
-			if !b.evalCtx.Settings.Version.IsActive(
-				b.ctx, clusterversion.V26_3,
-			) {
-				panic(pgerror.Newf(pgcode.FeatureNotSupported,
-					"%s usage inside a stored procedure is not supported until upgrade to version 26.3 is finalized",
-					stmt.StatementTag(),
-				))
-			}
 		default:
+			if isAllowlistedProcedureDDL(stmt) {
+				if !b.insideProcDef {
+					panic(unimplemented.NewWithIssuef(110080,
+						"%s usage inside a function definition is not supported",
+						stmt.StatementTag(),
+					))
+				}
+				// DDL and DCL are allowed inside stored procedures when the
+				// cluster has been upgraded to v26.3.
+				if !b.evalCtx.Settings.Version.IsActive(
+					b.ctx, clusterversion.V26_3,
+				) {
+					panic(pgerror.Newf(pgcode.FeatureNotSupported,
+						"%s usage inside a stored procedure is not supported until upgrade to version 26.3 is finalized",
+						stmt.StatementTag(),
+					))
+				}
+				break
+			}
 			if tree.CanModifySchema(stmt) {
 				panic(unimplemented.NewWithIssuef(110080,
 					"%s usage inside a function definition is not supported", stmt.StatementTag(),

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -431,6 +432,47 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 				panic(errors.WithDetailf(
 					pgerror.Newf(pgcode.InvalidTransactionTermination, "invalid transaction termination"),
 					"transaction control statements are only allowed in procedures",
+				))
+			}
+		}
+
+		// Walk the body to classify any DDL statements before deciding
+		// whether to build it. The PL/pgSQL builder relies on this check
+		// for two reasons:
+		//   1. Under late binding the body is not analyzed, so the
+		//      optbuilder's per-statement DDL gate in builder.go is never
+		//      reached. Unsupported DDL has to be rejected here or it
+		//      would silently survive until CALL time.
+		//   2. Under early binding, supported DDL is rejected here with a
+		//      hint pointing at the late-binding setting, since an early
+		//      build cannot validate references that the DDL would create
+		//      or alter later in the body.
+		// Unsupported DDL takes precedence: enabling late binding does
+		// not make it work.
+		if cf.IsProcedure {
+			var dv ddlVisitor
+			plpgsqltree.Walk(&dv, stmt.AST)
+			if dv.unsupportedStmt != nil {
+				panic(unimplemented.NewWithIssuef(110080,
+					"%s usage inside a function definition is not supported",
+					dv.unsupportedStmt.StatementTag(),
+				))
+			}
+			if dv.foundDDLStmt != nil && !lateBinding {
+				// Distinguish "the cluster has not finished upgrading" from
+				// "late binding is off" so the user sees an actionable
+				// message rather than a hint that does not yet apply.
+				if !b.evalCtx.Settings.Version.IsActive(b.ctx, clusterversion.V26_3) {
+					panic(pgerror.Newf(pgcode.FeatureNotSupported,
+						"%s usage inside a stored procedure is not supported until upgrade to version 26.3 is finalized",
+						dv.foundDDLStmt.StatementTag(),
+					))
+				}
+				panic(errors.WithHintf(
+					pgerror.Newf(pgcode.FeatureNotSupported,
+						"DDL statements in PL/pgSQL procedure bodies require late binding"),
+					"enable the cluster setting %s",
+					sqlclustersettings.PLpgSQLProcedureLateBinding.Name(),
 				))
 			}
 		}

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2908,6 +2908,84 @@ func (tc *transactionControlVisitor) Visit(
 	return stmt, !tc.foundTxnControlStatement
 }
 
+// isAllowlistedProcedureDDL reports whether stmt is one of the DDL or DCL
+// statements supported inside stored procedure bodies. The set must be kept
+// in sync with the corresponding case in (*Builder).buildStmtAtRoot.
+func isAllowlistedProcedureDDL(stmt tree.Statement) bool {
+	switch stmt.(type) {
+	case *tree.CreateTable, *tree.DropTable,
+		*tree.CreateSchema, *tree.DropSchema,
+		*tree.CreateRole, *tree.DropRole,
+		*tree.Grant, *tree.Revoke, *tree.AlterDefaultPrivileges:
+		return true
+	}
+	return false
+}
+
+// requiresLateBindingInProcedure reports whether stmt is a DDL statement that
+// introduces or removes a catalog object whose name later statements in the
+// same procedure body might reference. Such statements are unsafe under early
+// binding because the early-bound build cannot resolve references against a
+// catalog object that does not yet exist. DCL (GRANT, REVOKE, ALTER DEFAULT
+// PRIVILEGES) does not introduce new resolvable names and is safe under early
+// binding.
+func requiresLateBindingInProcedure(stmt tree.Statement) bool {
+	switch stmt.(type) {
+	case *tree.CreateTable, *tree.DropTable,
+		*tree.CreateSchema, *tree.DropSchema,
+		*tree.CreateRole, *tree.DropRole:
+		return true
+	}
+	return false
+}
+
+// ddlVisitor walks a PL/pgSQL routine body and classifies any embedded DDL.
+// It inspects the wrapped tree.Statement on each PL/pgSQL node that carries
+// one. DynamicExecute (EXECUTE of a string expression) is not implemented in
+// the optbuilder and is intentionally not inspected here.
+//
+// foundDDLStmt holds the first DDL statement encountered that requires late
+// binding (see requiresLateBindingInProcedure); when non-nil it indicates the
+// body contains DDL whose ordering relative to later statements matters.
+// unsupportedStmt holds the first DDL statement encountered that is not in the
+// procedure allowlist at all (see isAllowlistedProcedureDDL). The two fields
+// drive different error paths in buildCreateFunction: an unsupported statement
+// is reported as an "unimplemented" feature, while a body that contains
+// late-binding-sensitive DDL is gated on the late-binding cluster setting.
+type ddlVisitor struct {
+	foundDDLStmt    tree.Statement
+	unsupportedStmt tree.Statement
+}
+
+var _ ast.StatementVisitor = &ddlVisitor{}
+
+func (dv *ddlVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, recurse bool) {
+	var sqlStmt tree.Statement
+	switch s := stmt.(type) {
+	case *ast.Execute:
+		sqlStmt = s.SqlStmt
+	case *ast.ReturnQuery:
+		sqlStmt = s.SqlStmt
+	case *ast.CursorDeclaration:
+		sqlStmt = s.Query
+	case *ast.Open:
+		sqlStmt = s.Query
+	}
+	if sqlStmt == nil || !tree.CanModifySchema(sqlStmt) {
+		return stmt, true
+	}
+	if !isAllowlistedProcedureDDL(sqlStmt) {
+		if dv.unsupportedStmt == nil {
+			dv.unsupportedStmt = sqlStmt
+		}
+		return stmt, true
+	}
+	if requiresLateBindingInProcedure(sqlStmt) && dv.foundDDLStmt == nil {
+		dv.foundDDLStmt = sqlStmt
+	}
+	return stmt, true
+}
+
 var (
 	unsupportedPLStmtErr = unimplemented.New("unimplemented PL/pgSQL statement",
 		"attempted to use a PL/pgSQL statement that is not yet supported",


### PR DESCRIPTION
Previously, when late binding is disabled, a PL/pgSQL procedure body containing allowlisted DDL (CREATE TABLE, DROP TABLE, CREATE SCHEMA, DROP SCHEMA, CREATE ROLE, DROP ROLE) was built by the optbuilder. If subsequent body statements referenced the just-created object, the early-bound build could not resolve them and the user saw a confusing "relation does not exist" error.

This commit adds a pre-build pass (ddlVisitor) that walks the PL/pgSQL body to classify DDL statements before the optbuilder attempts to build them. The classifier drives two new error paths in CREATE PROCEDURE:

1. Allowlisted DDL with late binding off (and V26_3 active) is rejected with a hint pointing at the late-binding cluster setting.
2. Unsupported DDL (e.g. ALTER TABLE, CREATE INDEX) is rejected with an "unimplemented" error before the optbuilder reaches its existing per-statement DDL gate.

The allowlist is also expanded to include CREATE SCHEMA, DROP SCHEMA, CREATE ROLE, and DROP ROLE in stored procedure bodies, factored into a shared isAllowlistedProcedureDDL helper used by both ddlVisitor and the
optbuilder's existing buildStmtAtRoot gate.

Epic: [CRDB-31256](https://cockroachlabs.atlassian.net/browse/CRDB-31256)
Resolves: https://github.com/cockroachdb/cockroach/issues/170651

Release note (sql change): A PL/pgSQL procedure body containing DDL is
now rejected at CREATE PROCEDURE time with a hint suggesting the
`sql.procedures.plpgsql.late_binding.enabled` cluster setting be
enabled. Additionally, CREATE SCHEMA, DROP SCHEMA, CREATE ROLE, and
DROP ROLE are now allowed inside stored procedure bodies (subject to
the same late-binding requirement).