### PR TITLE
release-25.4: release: switch release-workflow runners to ubuntu_2004

### DIFF
--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -64,7 +64,7 @@ jobs:
     # branch and re-run. The `if:` above (prod repo + master only) plus the
     # workflow_dispatch + write-access requirement is the access control here.
     # The release-ops environment is reserved for the publishing workflow.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -173,7 +173,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -248,7 +248,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -306,7 +306,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -389,7 +389,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 90
     permissions:
       id-token: write
@@ -440,7 +440,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 90
     permissions:
       id-token: write
@@ -496,7 +496,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -564,7 +564,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -607,7 +607,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -670,7 +670,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -731,7 +731,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -803,7 +803,7 @@ jobs:
       - sentry-panic
       - publish-cloud-only
       - cloud-rollout
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 10
     permissions:
       id-token: write

--- a/.github/workflows/release-pick-sha.yml
+++ b/.github/workflows/release-pick-sha.yml
@@ -66,7 +66,7 @@ jobs:
     # The `if:` above (prod repo + master only) plus the workflow_dispatch +
     # write-access requirement is the access control here. The release-ops
     # environment is reserved for the publishing workflow.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -195,7 +195,7 @@ jobs:
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
     name: Update version.txt
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -281,7 +281,7 @@ jobs:
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
     name: Publish staged cockroach release
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 90
     permissions:
       id-token: write
@@ -372,7 +372,7 @@ jobs:
       }}
     # Reviewer-approval gate is on approve-publish upstream; this job
     # inherits the gate transitively via its needs chain.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -437,7 +437,7 @@ jobs:
       }}
     # Reviewer-approval gate is on approve-publish upstream; this job
     # inherits the gate transitively via its needs chain.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -498,7 +498,7 @@ jobs:
     # only posts a Slack summary — gating it would block delivery of the
     # final status (especially failure pings) until the same human
     # approves an extra step, defeating the point of the notification.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 10
     permissions:
       id-token: write


### PR DESCRIPTION
The `ubuntu_2404` self-hosted runner pool is not available on this
release branch. Pin the release workflows to the `ubuntu_2004` /
`ubuntu_big_2004` labels.

Release justification: release-tooling fix to unblock release workflows on this branch.

Epic: none
Release note: None