### PR TITLE
sql: track domain constraint validity in descriptor

### DIFF
--- a/pkg/sql/catalog/typedesc/hydrate.go
+++ b/pkg/sql/catalog/typedesc/hydrate.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
@@ -162,6 +163,7 @@ func ensureTypeMetadataIsHydrated(
 				Name:         d.GetCheckConstraintName(i),
 				Expr:         d.GetCheckConstraintExpr(i),
 				ConstraintID: d.GetCheckConstraintID(i),
+				Validated:    d.GetCheckConstraintValidity(i) == descpb.ConstraintValidity_Validated,
 			}
 		}
 		tm.DomainData = &types.DomainMetadata{

--- a/pkg/sql/logictest/testdata/logic_test/domain
+++ b/pkg/sql/logictest/testdata/logic_test/domain
@@ -771,19 +771,19 @@ CREATE DOMAIN d_constraint_names AS INT
   CHECK (VALUE < 19)
   CHECK (VALUE != 23);
 
-query TTT colnames
-SELECT conname, contype, pg_get_constraintdef(oid) AS condef
+query TTTB colnames
+SELECT conname, contype, pg_get_constraintdef(oid) AS condef, convalidated
 FROM pg_constraint
 WHERE contypid = 'd_constraint_names'::regtype
 ORDER BY conname
 ----
-conname                       contype  condef
-d_constraint_names_check      c        CHECK ((value < 17))
-d_constraint_names_check1     c        CHECK ((value < 13))
-d_constraint_names_check2     c        CHECK ((value < 19))
-d_constraint_names_check3     c        CHECK ((value != 23))
-d_constraint_names_not_null   c        CHECK ((value > 0))
-d_constraint_names_not_null1  n        NOT NULL
+conname                       contype  condef                convalidated
+d_constraint_names_check      c        CHECK ((value < 17))  true
+d_constraint_names_check1     c        CHECK ((value < 13))  true
+d_constraint_names_check2     c        CHECK ((value < 19))  true
+d_constraint_names_check3     c        CHECK ((value != 23)) true
+d_constraint_names_not_null   c        CHECK ((value > 0))   true
+d_constraint_names_not_null1  n        NOT NULL               true
 
 statement ok
 DROP DOMAIN d_constraint_names;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1471,38 +1471,42 @@ func populateDomainConstraints(
 			displayExpr = f.CloseAndGetString()
 		}
 		consrc := tree.NewDString(fmt.Sprintf("(%s)", displayExpr))
-		condef := tree.NewDString(fmt.Sprintf("CHECK ((%s))", displayExpr))
+		validity := ""
+		if !ck.Validated {
+			validity = " NOT VALID"
+		}
+		condef := tree.NewDString(fmt.Sprintf("CHECK ((%s))%s", displayExpr, validity))
 		if err := addRow(
-			conoid,               // oid
-			dNameOrNull(ck.Name), // conname
-			nspOid,               // connamespace
-			conTypeCheck,         // contype
-			tree.DBoolFalse,      // condeferrable
-			tree.DBoolFalse,      // condeferred
-			tree.DBoolTrue,       // convalidated
-			oidZero,              // conrelid
-			tree.NewDOid(typOid), // contypid
-			oidZero,              // conindid
-			oidZero,              // conparentid
-			oidZero,              // confrelid
-			tree.DNull,           // confupdtype
-			tree.DNull,           // confdeltype
-			tree.DNull,           // confmatchtype
-			tree.DBoolTrue,       // conislocal
-			zeroVal,              // coninhcount
-			tree.DBoolTrue,       // connoinherit
-			tree.DNull,           // conkey
-			tree.DNull,           // confkey
-			tree.DNull,           // conpfeqop
-			tree.DNull,           // conppeqop
-			tree.DNull,           // conffeqop
-			tree.DNull,           // confdelsetcols
-			tree.DNull,           // conexclop
-			consrc,               // conbin
-			consrc,               // consrc
-			condef,               // condef
-			tree.DBoolTrue,       // conenforced
-			tree.DBoolFalse,      // conperiod
+			conoid,                                   // oid
+			dNameOrNull(ck.Name),                     // conname
+			nspOid,                                   // connamespace
+			conTypeCheck,                             // contype
+			tree.DBoolFalse,                          // condeferrable
+			tree.DBoolFalse,                          // condeferred
+			tree.MakeDBool(tree.DBool(ck.Validated)), // convalidated
+			oidZero,                                  // conrelid
+			tree.NewDOid(typOid),                     // contypid
+			oidZero,                                  // conindid
+			oidZero,                                  // conparentid
+			oidZero,                                  // confrelid
+			tree.DNull,                               // confupdtype
+			tree.DNull,                               // confdeltype
+			tree.DNull,                               // confmatchtype
+			tree.DBoolTrue,                           // conislocal
+			zeroVal,                                  // coninhcount
+			tree.DBoolTrue,                           // connoinherit
+			tree.DNull,                               // conkey
+			tree.DNull,                               // confkey
+			tree.DNull,                               // conpfeqop
+			tree.DNull,                               // conppeqop
+			tree.DNull,                               // conffeqop
+			tree.DNull,                               // confdelsetcols
+			tree.DNull,                               // conexclop
+			consrc,                                   // conbin
+			consrc,                                   // consrc
+			condef,                                   // condef
+			tree.DBoolTrue,                           // conenforced
+			tree.DBoolFalse,                          // conperiod
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -370,6 +370,9 @@ type DomainCheckConstraint struct {
 	Expr string
 	// ConstraintID uniquely identifies this constraint within the domain.
 	ConstraintID catid.ConstraintID
+	// Validated indicates whether this constraint has been validated against
+	// all existing data. False for constraints added with NOT VALID.
+	Validated bool
 }
 
 func (e *EnumMetadata) debugString() string {


### PR DESCRIPTION
Previously, all constraints were assumed to be
validated. This change adds support for
unvalidated domain constraints existing among the
descriptors.

Support for manipulating the validated attribute
of descriptors will be added in subsequent diffs.

Epic: CRDB-62146
Part of: #166937

Release note: None
