### PR TITLE
workload: reduce yscb setup batch size

### DIFF
--- a/pkg/workload/all/all_test.go
+++ b/pkg/workload/all/all_test.go
@@ -222,6 +222,12 @@ func TestAllRegisteredSetup(t *testing.T) {
 			sqlutils.MakeSQLRunner(srv.SystemLayer().SQLConn(t)).Exec(t, `SET CLUSTER SETTING kv.range_merge.queue.enabled = false`)
 
 			var l workloadsql.InsertsDataLoader
+			if meta.Name == `ycsb` {
+				// YCSB's default 1000-row insert batches fan out to ~11K CPuts
+				// because each column lives in its own family. Under external
+				// process tenants this can starve SQL liveness heartbeats.
+				l.BatchSize = 100
+			}
 			if _, err := workloadsql.Setup(ctx, db, gen, l); err != nil {
 				t.Fatalf(`%+v`, err)
 			}


### PR DESCRIPTION
`TestAllRegisteredSetup/ycsb` can run under an external-process test tenant. YCSB's default setup path uses 1000-row `INSERT` batches, and because YCSB places each field in its own column family, each batch fans out to a large number of KV writes.

In overloaded CI runs, that can starve SQL liveness heartbeats long enough for the tenant to shut down, surfacing as setup failures such as "sql: database is closed".

Cap only the YCSB `InsertsDataLoader` batch size in `TestAllRegisteredSetup`. This keeps the test exercising the same workload and tenant mode while reducing the size of each setup write batch. This does not change YCSB workload defaults or benchmark/import behavior outside this test.

Epic: none
Fixes: #170911, #169034, #168946
Release note: None