### PR TITLE
importer: wire Parquet LIST columns into the IMPORT producer

### DIFF
--- a/pkg/sql/importer/read_import_parquet.go
+++ b/pkg/sql/importer/read_import_parquet.go
@@ -148,9 +148,10 @@ type parquetRowProducer struct {
 	currentRowInGroup int64 // Current position within row group
 
 	// Column selection - which Parquet columns to actually read
-	columnsToRead []int                          // Parquet column indices to read
-	numColumns    int                            // Total number of columns in Parquet file
-	columnReaders map[int]file.ColumnChunkReader // Maps Parquet column index -> reader
+	columnsToRead     []int                            // Parquet column indices to read
+	numColumns        int                              // Total number of columns in Parquet file
+	columnReaders     map[int]file.ColumnChunkReader   // Maps Parquet column index -> reader
+	listColumnReaders map[int]*parquetListColumnReader // Stateful readers for LIST columns (per row group)
 
 	// Cached schema metadata (populated once per file, used for all batches)
 	columnMetadata map[int]*parquetColumnMetadata // Maps Parquet column index -> metadata
@@ -217,36 +218,81 @@ func newParquetRowProducer(
 	// Count total rows across all row groups for progress tracking
 	totalRows := int64(0)
 	totalRowGroups := reader.NumRowGroups()
-	for i := 0; i < totalRowGroups; i++ {
+	for i := range totalRowGroups {
 		totalRows += reader.RowGroup(i).NumRows()
 	}
 
 	numColumns := reader.MetaData().Schema.NumColumns()
 	batchSize := int64(defaultParquetBatchSize)
 	parquetSchema := reader.MetaData().Schema
-	// Determine which columns to read
-	var columnsToRead []int
-	if importCtx == nil {
-		// No import context (test mode) - read all columns
-		columnsToRead = make([]int, numColumns)
-		for i := 0; i < numColumns; i++ {
-			columnsToRead[i] = i
-		}
-	} else {
-		// Determine which Parquet columns to read based on target table columns
-		columnsToRead, err = determineColumnsToRead(importCtx, parquetSchema)
+
+	// Build columnMetadata for every leaf before deciding which leaves to
+	// read. A Parquet LIST<T> column is encoded as a 3-level nested group:
+	//
+	//   tags        (group, LIST-annotated)   <- the name the user wrote
+	//     list      (repeated group)
+	//       element (leaf, the actual T data) <- what Schema.Column(i) returns
+	//
+	// The Apache Arrow Parquet API only exposes leaves through
+	// Schema.Column(i) and Schema.NumColumns(), so the LIST column at leaf
+	// index i shows up as "element", not "tags". determineColumnsToRead
+	// matches Parquet column names against the IMPORT target list (e.g.
+	// "tags"), so it needs the group-node name, not the leaf name, or it
+	// would silently skip every LIST column.
+	//
+	// parquetSchema.ColumnRoot(i) returns the top-level group/leaf node
+	// (the user-visible name) for any leaf — flat, LIST, MAP, or otherwise —
+	// so we use it to populate columnMetadata[i].columnName unconditionally.
+	//
+	// detectListColumn errors (for unsupported nested structures like
+	// LIST<LIST<T>> or MAP) are stored in columnMetadata[i].detectionErr
+	// and only surfaced later if the user actually imports that column.
+	// Deferring lets a file with unsupported columns still open and be
+	// partially imported, as long as the user does not target those
+	// columns.
+	columnMetadata := make(map[int]*parquetColumnMetadata)
+	for colIdx := range numColumns {
+		col := parquetSchema.Column(colIdx)
+		name := parquetSchema.ColumnRoot(colIdx).Name()
+
+		listInfo, err := detectListColumn(parquetSchema, colIdx)
 		if err != nil {
-			return nil, err
+			columnMetadata[colIdx] = &parquetColumnMetadata{
+				columnName:   name,
+				detectionErr: err,
+			}
+			continue
+		}
+
+		if listInfo != nil {
+			columnMetadata[colIdx] = &parquetColumnMetadata{
+				columnName:    name,
+				logicalType:   listInfo.elementLogicalType,
+				convertedType: listInfo.elementConvertedType,
+				isList:        true,
+				listInfo:      listInfo,
+			}
+		} else {
+			columnMetadata[colIdx] = &parquetColumnMetadata{
+				columnName:    name,
+				logicalType:   deriveLogicalType(col),
+				convertedType: col.ConvertedType(),
+			}
 		}
 	}
 
-	// Cache schema metadata once per file for all columns we'll read.
-	columnMetadata := make(map[int]*parquetColumnMetadata)
-	for _, colIdx := range columnsToRead {
-		col := parquetSchema.Column(colIdx)
-		columnMetadata[colIdx] = &parquetColumnMetadata{
-			logicalType:   deriveLogicalType(col),
-			convertedType: col.ConvertedType(), // Keep for reference/debugging
+	// Determine which columns to read.
+	var columnsToRead []int
+	if importCtx == nil {
+		// No import context (test mode) - read all columns.
+		columnsToRead = make([]int, numColumns)
+		for i := range numColumns {
+			columnsToRead[i] = i
+		}
+	} else {
+		columnsToRead, err = determineColumnsToRead(importCtx, parquetSchema, columnMetadata)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -325,6 +371,7 @@ func (p *parquetRowProducer) advanceToNextRowGroup() error {
 		p.rowsInGroup = 0
 		p.currentRowInGroup = 0
 		p.columnReaders = nil
+		p.listColumnReaders = nil
 		return nil
 	}
 
@@ -333,14 +380,30 @@ func (p *parquetRowProducer) advanceToNextRowGroup() error {
 	p.rowsInGroup = rowGroup.NumRows()
 	p.currentRowInGroup = 0
 
-	// Set up column chunk readers only for columns we need to read
+	// Set up column chunk readers only for columns we need to read.
+	// listColumnReaders is allocated lazily; most files have no LIST columns.
 	p.columnReaders = make(map[int]file.ColumnChunkReader, len(p.columnsToRead))
+	p.listColumnReaders = nil
 	for _, colIdx := range p.columnsToRead {
 		colReader, err := rowGroup.Column(colIdx)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get column reader for column %d", colIdx)
+			return errors.Wrapf(err, "column reader for column %d", colIdx)
 		}
 		p.columnReaders[colIdx] = colReader
+
+		// Create stateful readers for LIST columns so that overflow
+		// entries are preserved across fillBuffer calls.
+		metadata := p.columnMetadata[colIdx]
+		if metadata.isList {
+			listReader, err := newParquetListColumnReader(colReader, metadata.listInfo)
+			if err != nil {
+				return errors.Wrapf(err, "creating LIST reader for column %d", colIdx)
+			}
+			if p.listColumnReaders == nil {
+				p.listColumnReaders = make(map[int]*parquetListColumnReader)
+			}
+			p.listColumnReaders[colIdx] = listReader
+		}
 	}
 
 	return nil
@@ -365,17 +428,26 @@ func (p *parquetRowProducer) fillBuffer() error {
 			p.rowsInGroup, p.currentRowInGroup)
 	}
 
-	// Read rowsToRead values only from columns we need
+	// Read rowsToRead values only from columns we need.
 	for _, colIdx := range p.columnsToRead {
-		colReader := p.columnReaders[colIdx]
+		metadata := p.columnMetadata[colIdx]
 
-		// Read a batch of typed values from this column
-		batch, err := p.readBatchFromColumn(colReader, colIdx, rowsToRead)
+		var batch *parquetColumnBatch
+		var err error
+		if metadata.isList {
+			// LIST columns use a stateful reader that handles repetition levels,
+			// reassembles per-row element arrays, and buffers overflow rows
+			// across fillBuffer calls.
+			batch, err = p.listColumnReaders[colIdx].ReadBatch(rowsToRead)
+		} else {
+			batch, err = p.readBatchFromColumn(p.columnReaders[colIdx], colIdx, rowsToRead)
+		}
 		if err != nil {
-			return errors.Wrapf(err, "failed to read batch from column %d", colIdx)
+			return errors.Wrapf(err, "reading batch from column %q (index %d)",
+				p.columnMetadata[colIdx].columnName, colIdx)
 		}
 
-		// Store the batch for this column (sparse array - only needed columns populated)
+		// Store the batch for this column (sparse array - only needed columns populated).
 		p.columnBatches[colIdx] = batch
 	}
 
@@ -452,6 +524,11 @@ func (p *parquetRowProducer) Err() error {
 	// This prevents silent data loss similar to the issue fixed in PR #161318
 	// for Avro imports, where storage errors could be missed if only cached
 	// errors were checked.
+	//
+	// LIST columns are covered transparently: the file.ColumnChunkReader that
+	// backs each parquetListColumnReader is also registered in p.columnReaders
+	// when the row group is opened (see advanceToNextRowGroup), so the loop
+	// below observes streaming errors for both flat and LIST columns.
 	for _, colReader := range p.columnReaders {
 		if err := colReader.Err(); err != nil {
 			return err
@@ -489,11 +566,12 @@ func (p *parquetRowProducer) validateAndBuildColumnMapping(
 ) (map[string]int, error) {
 	parquetSchema := p.reader.MetaData().Schema
 
-	// Build a map of Parquet column names (lowercase) for quick lookup
+	// Build a map of Parquet column names (lowercase) for quick lookup.
+	// columnMetadata.columnName is the user-visible name (group name for
+	// LIST columns, leaf name otherwise) populated at file open.
 	parquetColNames := make(map[string]bool)
-	for parquetColIdx := 0; parquetColIdx < parquetSchema.NumColumns(); parquetColIdx++ {
-		parquetCol := parquetSchema.Column(parquetColIdx)
-		parquetColNames[strings.ToLower(parquetCol.Name())] = true
+	for parquetColIdx := range parquetSchema.NumColumns() {
+		parquetColNames[strings.ToLower(p.columnMetadata[parquetColIdx].columnName)] = true
 	}
 	fieldNameToIdx := make(map[string]int)
 
@@ -550,24 +628,46 @@ func (p *parquetRowProducer) validateAndBuildColumnMapping(
 	// Validate type compatibility ONLY for columns we're actually reading.
 	for _, parquetColIdx := range p.columnsToRead {
 		parquetCol := parquetSchema.Column(parquetColIdx)
-		parquetColName := parquetCol.Name()
+		metadata := p.columnMetadata[parquetColIdx]
+		colName := metadata.columnName
 
-		// Find corresponding table column index in visibleCols
-		tableColIdx, found := fieldNameToIdx[strings.ToLower(parquetColName)]
+		// Find corresponding table column index in visibleCols.
+		tableColIdx, found := fieldNameToIdx[strings.ToLower(colName)]
 		if !found {
 			// This shouldn't happen since columnsToRead was determined based on
 			// the target columns, but handle it defensively.
 			continue
 		}
 
-		// Get target column type from the table descriptor
+		// Get target column type from the table descriptor.
 		targetCol := visibleCols[tableColIdx]
 		targetType := targetCol.GetType()
 
-		// Validate type compatibility using cached metadata
-		metadata := p.columnMetadata[parquetColIdx]
-		if err := validateWithLogicalType(parquetCol.PhysicalType(), metadata.logicalType, targetType); err != nil {
-			return nil, errors.Wrapf(err, "column %q", parquetColName)
+		// Validate type compatibility using cached metadata.
+		if metadata.isList {
+			// LIST columns validate against the target's array contents type;
+			// a JSONB target is accepted unconditionally since any supported
+			// primitive list can be serialized to JSON.
+			if targetType.Family() == types.JsonFamily {
+				continue
+			}
+			if targetType.Family() != types.ArrayFamily {
+				return nil, errors.Newf(
+					"column %q: Parquet LIST requires an ARRAY or JSONB target type, got %s",
+					colName, targetType.Family())
+			}
+			elementTargetType := targetType.ArrayContents()
+			if err := validateWithLogicalType(
+				parquetCol.PhysicalType(), metadata.logicalType, elementTargetType,
+			); err != nil {
+				return nil, errors.Wrapf(err, "column %q (LIST element type)", colName)
+			}
+		} else {
+			if err := validateWithLogicalType(
+				parquetCol.PhysicalType(), metadata.logicalType, targetType,
+			); err != nil {
+				return nil, errors.Wrapf(err, "column %q", colName)
+			}
 		}
 	}
 
@@ -596,7 +696,9 @@ func (p *parquetRowProducer) validateAndBuildColumnMapping(
 // determineColumnsToRead determines which Parquet column indices need to be read
 // based on the target table columns. Returns the list of Parquet column indices.
 func determineColumnsToRead(
-	importCtx *parallelImportContext, parquetSchema *schema.Schema,
+	importCtx *parallelImportContext,
+	parquetSchema *schema.Schema,
+	columnMetadata map[int]*parquetColumnMetadata,
 ) ([]int, error) {
 	// This function is only called when importCtx is non-nil.
 	// In test mode, newParquetRowProducer receives nil importCtx and reads all columns.
@@ -619,29 +721,41 @@ func determineColumnsToRead(
 		}
 	}
 
-	// Find which Parquet columns match our target columns
+	// Find which Parquet columns match our target columns. columnMetadata
+	// already holds the user-visible column name for every leaf (set via
+	// parquetSchema.ColumnRoot in newParquetRowProducer), so it works for
+	// LIST columns whose leaf name differs from the group name.
 	var columnsToRead []int
-	for parquetColIdx := 0; parquetColIdx < parquetSchema.NumColumns(); parquetColIdx++ {
-		parquetCol := parquetSchema.Column(parquetColIdx)
-		parquetColName := strings.ToLower(parquetCol.Name())
+	for parquetColIdx := range parquetSchema.NumColumns() {
+		meta := columnMetadata[parquetColIdx]
+		parquetColName := strings.ToLower(meta.columnName)
 
-		// If this Parquet column is in our target set, we need to read it
-		if targetColSet[parquetColName] {
-			// Validate that the column doesn't have nested or repeated structures.
-			// Definition level > 1 indicates nested/repeated data (arrays, maps, etc.)
-			// which we don't currently support.
-			maxDefLevel := parquetCol.MaxDefinitionLevel()
-			if maxDefLevel > 1 {
-				return nil,
-					unimplemented.NewWithIssueDetailf(162543,
-						"support parquet nested types for import",
-						"column %q has nested or repeated structure (definition level %d); "+
-							"only simple required and optional columns are supported",
-						parquetColName, maxDefLevel)
-
-			}
-			columnsToRead = append(columnsToRead, parquetColIdx)
+		if !targetColSet[parquetColName] {
+			continue
 		}
+
+		// Surface any error deferred from detectListColumn at file-open
+		// time. We only fail here, after confirming the user actually
+		// wants this column. Wrap with the user-visible column name so
+		// the message identifies the column the user requested rather
+		// than an internal parquet group name.
+		if meta.detectionErr != nil {
+			return nil, errors.Wrapf(meta.detectionErr, "column %q", meta.columnName)
+		}
+
+		parquetCol := parquetSchema.Column(parquetColIdx)
+		maxDefLevel := parquetCol.MaxDefinitionLevel()
+		if maxDefLevel > 1 && !meta.isList {
+			// detectListColumn already accepted any supported LIST column. A
+			// definition level above 1 on a non-LIST leaf means MAPs or deeper
+			// nesting, which the importer does not yet handle.
+			return nil, unimplemented.NewWithIssueDetailf(162543,
+				"parquet-nested-type",
+				"column %q has nested or repeated structure (definition level %d); "+
+					"only simple required/optional columns and single-level LISTs are supported",
+				parquetColName, maxDefLevel)
+		}
+		columnsToRead = append(columnsToRead, parquetColIdx)
 	}
 
 	return columnsToRead, nil
@@ -690,16 +804,16 @@ func newParquetRowConsumer(
 	// For each Parquet column index, store the corresponding target column index (-1 if not mapped).
 	numCols := producer.reader.MetaData().Schema.NumColumns()
 	colMapping := make([]int, numCols)
-	for parquetColIdx := 0; parquetColIdx < numCols; parquetColIdx++ {
-		parquetColName := producer.reader.MetaData().Schema.Column(parquetColIdx).Name()
-		if targetIdx, found := nameToTargetIdx[strings.ToLower(parquetColName)]; found {
+	for parquetColIdx := range numCols {
+		colName := producer.columnMetadata[parquetColIdx].columnName
+		if targetIdx, found := nameToTargetIdx[strings.ToLower(colName)]; found {
 			colMapping[parquetColIdx] = targetIdx
 			continue
 		}
 		colMapping[parquetColIdx] = -1
 		if strict {
 			return nil, errors.Newf(
-				"column %q in Parquet file is not in the target table", parquetColName)
+				"column %q in Parquet file is not in the target table", colName)
 		}
 	}
 
@@ -726,7 +840,7 @@ func (c *parquetRowConsumer) FillDatums(
 	rowIdx := view.rowIndex
 
 	// For each column in the Parquet file, find the corresponding target column.
-	for parquetColIdx := 0; parquetColIdx < view.numColumns; parquetColIdx++ {
+	for parquetColIdx := range view.numColumns {
 		// Skip columns we didn't read.
 		batch := view.batches[parquetColIdx]
 		if batch == nil {

--- a/pkg/sql/importer/read_import_parquet_logical.go
+++ b/pkg/sql/importer/read_import_parquet_logical.go
@@ -199,11 +199,10 @@ func validateWithLogicalType(
 			return nil
 		}
 
-		// Check for unsupported LogicalTypes that require nested column handling
-		if _, ok := logicalType.(schema.ListLogicalType); ok {
-			return unimplemented.NewWithIssuef(162543,
-				"ListLogicalType not supported (requires nested column chunk handling)")
-		}
+		// Check for unsupported LogicalTypes that require nested column handling.
+		// Note: ListLogicalType is not checked here because LIST columns are
+		// detected and validated at a higher level (detectListColumn). This
+		// function only sees the element's logical type for LIST columns.
 		if _, ok := logicalType.(schema.MapLogicalType); ok {
 			return unimplemented.NewWithIssuef(162543,
 				"MapLogicalType not supported (requires nested column chunk handling)")

--- a/pkg/sql/importer/read_import_parquet_test.go
+++ b/pkg/sql/importer/read_import_parquet_test.go
@@ -83,68 +83,29 @@ func viewToRow(rowData interface{}) []interface{} {
 	return row
 }
 
-// createTestParquetFile creates a simple Parquet file in memory for testing
+// createTestParquetFile creates a simple Parquet file in memory for testing.
 func createTestParquetFile(
 	t *testing.T, numRows int, compression compress.Compression,
-) *bytes.Buffer {
-	// Handle empty file case - return nil, tests should check for this
-	if numRows == 0 {
-		return nil
-	}
-
-	pool := memory.NewGoAllocator()
-
-	// Define schema with various types
-	schema := arrow.NewSchema(
-		[]arrow.Field{
-			{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
-			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
-			{Name: "score", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
-			{Name: "active", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
-		},
-		nil,
-	)
-
-	// Build record with test data
-	builder := array.NewRecordBuilder(pool, schema)
-	defer builder.Release()
-
-	idBuilder := builder.Field(0).(*array.Int32Builder)
-	nameBuilder := builder.Field(1).(*array.StringBuilder)
-	scoreBuilder := builder.Field(2).(*array.Float64Builder)
-	activeBuilder := builder.Field(3).(*array.BooleanBuilder)
-
-	for i := 0; i < numRows; i++ {
-		idBuilder.Append(int32(i))
-		if i%3 == 0 {
-			nameBuilder.AppendNull()
-		} else {
-			nameBuilder.Append("name_" + string(rune('A'+i%26)))
+) *fileReader {
+	t.Helper()
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "score", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "active", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+	}, nil)
+	rows := make([]parquetRow, numRows)
+	for i := range numRows {
+		var name, score any
+		if i%3 != 0 {
+			name = "name_" + string(rune('A'+i%26))
 		}
-		if i%5 == 0 {
-			scoreBuilder.AppendNull()
-		} else {
-			scoreBuilder.Append(float64(i) * 1.5)
+		if i%5 != 0 {
+			score = float64(i) * 1.5
 		}
-		activeBuilder.Append(i%2 == 0)
+		rows[i] = parquetRow{int32(i), name, score, i%2 == 0}
 	}
-
-	record := builder.NewRecord()
-	defer record.Release()
-
-	// Write to Parquet format with specified compression
-	buf := new(bytes.Buffer)
-	writerProps := parquet.NewWriterProperties(parquet.WithCompression(compression))
-	writer, err := pqarrow.NewFileWriter(schema, buf, writerProps, pqarrow.DefaultWriterProps())
-	require.NoError(t, err)
-
-	err = writer.Write(record)
-	require.NoError(t, err)
-
-	err = writer.Close()
-	require.NoError(t, err)
-
-	return buf
+	return makeParquetFile(t, schema, rows, withParquetCompression(compression))
 }
 
 func TestParquetRowProducerBasicScanning(t *testing.T) {
@@ -166,16 +127,7 @@ func TestParquetRowProducerBasicScanning(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a test Parquet file with 10 rows and specified compression
-			parquetData := createTestParquetFile(t, 10, tc.compression)
-
-			// Create fileReader from buffer - use the same bytes.Reader instance for all interfaces
-			reader := bytes.NewReader(parquetData.Bytes())
-			fileReader := &fileReader{
-				Reader:   reader,
-				ReaderAt: reader,
-				Seeker:   reader,
-				total:    int64(parquetData.Len()),
-			}
+			fileReader := createTestParquetFile(t, 10, tc.compression)
 
 			producer, err := newParquetRowProducer(fileReader, nil)
 			require.NoError(t, err)
@@ -213,15 +165,7 @@ func TestParquetRowProducerNullHandling(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Create a test Parquet file
-	parquetData := createTestParquetFile(t, 15, compress.Codecs.Uncompressed)
-
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, 15, compress.Codecs.Uncompressed)
 
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
@@ -261,15 +205,7 @@ func TestParquetRowProducerBatching(t *testing.T) {
 
 	// Create a file with more rows than the batch size
 	numRows := 250
-	parquetData := createTestParquetFile(t, numRows, compress.Codecs.Uncompressed)
-
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, numRows, compress.Codecs.Uncompressed)
 
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
@@ -299,15 +235,7 @@ func TestParquetRowProducerProgress(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	numRows := 100
-	parquetData := createTestParquetFile(t, numRows, compress.Codecs.Uncompressed)
-
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, numRows, compress.Codecs.Uncompressed)
 
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
@@ -341,15 +269,7 @@ func TestParquetRowProducerSingleRow(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	// Create a Parquet file with just 1 row
-	parquetData := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
-
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
 
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
@@ -369,15 +289,7 @@ func TestParquetRowProducerSkip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	parquetData := createTestParquetFile(t, 10, compress.Codecs.Uncompressed)
-
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, 10, compress.Codecs.Uncompressed)
 
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
@@ -542,14 +454,7 @@ func TestParquetRowConsumerCreation(t *testing.T) {
 	}
 
 	// Create a mock Parquet file to get the schema
-	parquetData := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
 
@@ -604,14 +509,7 @@ func TestParquetAutomaticColumnMapping(t *testing.T) {
 	}
 
 	// Create a mock Parquet file to get the schema
-	parquetData := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
 
@@ -1153,14 +1051,7 @@ func TestParquetMissingRequiredColumn(t *testing.T) {
 	}
 
 	// Create a mock Parquet file (has id, name, score, active - but NOT email)
-	parquetData := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
-	reader := bytes.NewReader(parquetData.Bytes())
-	fileReader := &fileReader{
-		Reader:   reader,
-		ReaderAt: reader,
-		Seeker:   reader,
-		total:    int64(parquetData.Len()),
-	}
+	fileReader := createTestParquetFile(t, 1, compress.Codecs.Uncompressed)
 	producer, err := newParquetRowProducer(fileReader, nil)
 	require.NoError(t, err)
 
@@ -1816,6 +1707,822 @@ func TestParquetPlainPrimitivesValidation(t *testing.T) {
 	t.Log("Successfully validated plain primitive types through consumer creation")
 }
 
+// TestParquetListSchemaDetection verifies that detectListColumn correctly
+// identifies valid LIST columns and rejects unsupported nesting.
+func TestParquetListSchemaDetection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pool := memory.NewGoAllocator()
+
+	t.Run("DetectsListColumn", func(t *testing.T) {
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "tags", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		lb := builder.Field(0).(*array.ListBuilder)
+		lb.Append(true)
+		lb.ValueBuilder().(*array.StringBuilder).Append("a")
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.NotNil(t, listInfo)
+		require.Equal(t, "tags", listInfo.columnName)
+		require.True(t, listInfo.elementIsOptional)
+		require.Equal(t, int16(3), listInfo.maxDefLevel)
+		require.Equal(t, int16(3), listInfo.presentElementDefLevel)
+		require.Equal(t, 1, listInfo.nestingDepth)
+		require.Len(t, listInfo.levels, 1)
+		require.Equal(t, int16(1), listInfo.levels[0].repLevel)
+		require.Equal(t, int16(0), listInfo.levels[0].nullListDefLevel)
+		require.Equal(t, int16(1), listInfo.levels[0].emptyListDefLevel)
+	})
+
+	t.Run("FlatColumnNotDetectedAsList", func(t *testing.T) {
+		arrowSchema := arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		}, nil)
+		builder := array.NewRecordBuilder(pool, arrowSchema)
+		defer builder.Release()
+
+		builder.Field(0).(*array.Int32Builder).Append(1)
+
+		record := builder.NewRecord()
+		defer record.Release()
+
+		buf := new(bytes.Buffer)
+		writerProps := parquet.NewWriterProperties(
+			parquet.WithCompression(compress.Codecs.Uncompressed))
+		writer, err := pqarrow.NewFileWriter(
+			arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader := bytes.NewReader(buf.Bytes())
+		fr := &fileReader{
+			Reader: reader, ReaderAt: reader, Seeker: reader,
+			total: int64(buf.Len()),
+		}
+		parquetReader, err := file.NewParquetReader(fr)
+		require.NoError(t, err)
+
+		pqSchema := parquetReader.MetaData().Schema
+		listInfo, err := detectListColumn(pqSchema, 0)
+		require.NoError(t, err)
+		require.Nil(t, listInfo, "flat column should not be detected as LIST")
+	})
+}
+
+// parquetRow is one row passed to makeParquetFile: one value per column, in
+// schema order. Conventions:
+//   - nil means the column is NULL (or the LIST itself is NULL).
+//   - For a LIST<T> column, pass []any of element values. An empty []any{}
+//     is an empty list (not NULL).
+//   - Primitive columns require the exact Go type (int32 for Int32, string
+//     for String, etc.) — see appendParquetValue for the supported set.
+type parquetRow []any
+
+// parquetFileOption configures non-default knobs of makeParquetFile.
+type parquetFileOption func(*parquetFileOptions)
+
+type parquetFileOptions struct {
+	compression compress.Compression
+}
+
+// withParquetCompression overrides the default compression (Uncompressed).
+func withParquetCompression(c compress.Compression) parquetFileOption {
+	return func(o *parquetFileOptions) { o.compression = c }
+}
+
+// makeParquetFile assembles an in-memory parquet file from the given arrow
+// schema plus a slice of rows, and returns it wrapped in a *fileReader ready
+// to feed the importer. Defaults to uncompressed.
+//
+// TODO(sravotto): adopt this helper at the other ~15 inline
+// pqarrow.NewFileWriter sites in this file and the sibling
+// read_import_parquet_list_test.go / read_import_parquet_batch_test.go.
+// Extend appendParquetValue and add options (max row group length, ...) as
+// those call sites need them.
+func makeParquetFile(
+	t *testing.T, arrowSchema *arrow.Schema, rows []parquetRow, opts ...parquetFileOption,
+) *fileReader {
+	t.Helper()
+	options := parquetFileOptions{compression: compress.Codecs.Uncompressed}
+	for _, o := range opts {
+		o(&options)
+	}
+	buf := new(bytes.Buffer)
+	writer, err := pqarrow.NewFileWriter(
+		arrowSchema, buf,
+		parquet.NewWriterProperties(parquet.WithCompression(options.compression)),
+		pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+
+	builder := array.NewRecordBuilder(memory.NewGoAllocator(), arrowSchema)
+	defer builder.Release()
+	for rowIdx, row := range rows {
+		require.Lenf(t, row, len(arrowSchema.Fields()),
+			"row %d has %d values but schema has %d columns",
+			rowIdx, len(row), len(arrowSchema.Fields()))
+		for colIdx, val := range row {
+			appendParquetValue(t, rowIdx, colIdx,
+				arrowSchema.Field(colIdx).Type, builder.Field(colIdx), val)
+		}
+	}
+	record := builder.NewRecord()
+	defer record.Release()
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+
+	reader := bytes.NewReader(buf.Bytes())
+	return &fileReader{
+		Reader: reader, ReaderAt: reader, Seeker: reader,
+		total: int64(buf.Len()),
+	}
+}
+
+// appendParquetValue appends one Go value to the arrow builder for the given
+// column type, applying the parquetRow conventions documented on parquetRow.
+// rowIdx and colIdx are only used for error messages.
+func appendParquetValue(
+	t *testing.T, rowIdx, colIdx int, dt arrow.DataType, b array.Builder, val any,
+) {
+	t.Helper()
+	if val == nil {
+		b.AppendNull()
+		return
+	}
+	switch dt := dt.(type) {
+	case *arrow.Int32Type:
+		v, ok := val.(int32)
+		require.Truef(t, ok, "row %d col %d: expected int32, got %T", rowIdx, colIdx, val)
+		b.(*array.Int32Builder).Append(v)
+	case *arrow.Float64Type:
+		v, ok := val.(float64)
+		require.Truef(t, ok, "row %d col %d: expected float64, got %T", rowIdx, colIdx, val)
+		b.(*array.Float64Builder).Append(v)
+	case *arrow.BooleanType:
+		v, ok := val.(bool)
+		require.Truef(t, ok, "row %d col %d: expected bool, got %T", rowIdx, colIdx, val)
+		b.(*array.BooleanBuilder).Append(v)
+	case *arrow.StringType:
+		v, ok := val.(string)
+		require.Truef(t, ok, "row %d col %d: expected string, got %T", rowIdx, colIdx, val)
+		b.(*array.StringBuilder).Append(v)
+	case *arrow.ListType:
+		elems, ok := val.([]any)
+		require.Truef(t, ok, "row %d col %d: expected []any for LIST, got %T", rowIdx, colIdx, val)
+		lb := b.(*array.ListBuilder)
+		lb.Append(true)
+		for _, elem := range elems {
+			appendParquetValue(t, rowIdx, colIdx, dt.Elem(), lb.ValueBuilder(), elem)
+		}
+	default:
+		t.Fatalf("row %d col %d: unsupported arrow type %T (extend appendParquetValue)",
+			rowIdx, colIdx, dt)
+	}
+}
+
+// TestParquetListEndToEnd drives the full producer/consumer pipeline for LIST
+// columns: it scans every row, calls FillDatums, and asserts that the assembled
+// datums match what the Parquet file encodes for both ARRAY and JSONB targets.
+func TestParquetListEndToEnd(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
+	defer row.TestingSetDatumRowConverterBatchSize(2)()
+
+	// jsonArr builds a JSONB array datum from primitive Go values, mirroring
+	// the elements assembled by parquetElementToJSON.
+	jsonArr := func(t *testing.T, elems ...any) tree.Datum {
+		t.Helper()
+		ab := json.NewArrayBuilder(len(elems))
+		for _, e := range elems {
+			if e == nil {
+				ab.Add(json.NullJSONValue)
+				continue
+			}
+			switch v := e.(type) {
+			case string:
+				ab.Add(json.FromString(v))
+			default:
+				t.Fatalf("unsupported jsonArr element type %T", e)
+			}
+		}
+		return tree.NewDJSON(ab.Build())
+	}
+
+	// stringArr builds a tree.DArray of strings (with optional nulls).
+	stringArr := func(t *testing.T, elems ...any) tree.Datum {
+		t.Helper()
+		arr := tree.NewDArray(types.String)
+		for _, e := range elems {
+			if e == nil {
+				require.NoError(t, arr.Append(tree.DNull))
+				continue
+			}
+			require.NoError(t, arr.Append(tree.NewDString(e.(string))))
+		}
+		return arr
+	}
+
+	cases := []struct {
+		name        string
+		tagsColType *types.T
+		// expectedTags is keyed by id (1..4) — the value the consumer should
+		// produce for the "tags" column on that row.
+		expectedTags func(t *testing.T) map[int]tree.Datum
+	}{
+		{
+			name:        "ListToArray",
+			tagsColType: types.MakeArray(types.String),
+			expectedTags: func(t *testing.T) map[int]tree.Datum {
+				return map[int]tree.Datum{
+					1: stringArr(t, "a", "b"),
+					2: tree.DNull,
+					3: stringArr(t),
+					4: stringArr(t, "x"),
+				}
+			},
+		},
+		{
+			name:        "ListToJSON",
+			tagsColType: types.Jsonb,
+			expectedTags: func(t *testing.T) map[int]tree.Datum {
+				return map[int]tree.Datum{
+					1: jsonArr(t, "a", "b"),
+					2: tree.DNull,
+					3: jsonArr(t),
+					4: jsonArr(t, "x"),
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fr := makeParquetFile(t, arrow.NewSchema([]arrow.Field{
+				{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+				{Name: "tags", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+			}, nil), []parquetRow{
+				{int32(1), []any{"a", "b"}},
+				{int32(2), nil},
+				{int32(3), []any{}},
+				{int32(4), []any{"x"}},
+			})
+
+			tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+				ID:   1,
+				Name: "test_table",
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "id", Type: types.Int4},
+					{ID: 2, Name: "tags", Type: tc.tagsColType, Nullable: true},
+				},
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID: 1, Name: "pk",
+					KeyColumnIDs:        []descpb.ColumnID{1},
+					KeyColumnNames:      []string{"id"},
+					KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+				},
+			}).BuildImmutableTable()
+			targetCols := tree.NameList{"id", "tags"}
+			importCtx := &parallelImportContext{
+				tableDesc:  tableDesc,
+				targetCols: targetCols,
+			}
+
+			producer, err := newParquetRowProducer(fr, importCtx)
+			require.NoError(t, err)
+			consumer, err := newParquetRowConsumer(
+				importCtx, producer, &importFileContext{}, false)
+			require.NoError(t, err)
+
+			conv, err := row.NewDatumRowConverter(
+				ctx, &semaCtx, tableDesc, targetCols, evalCtx.Copy(),
+				nil /* kvCh */, nil /* seqChunkProvider */, nil /* metrics */, nil, /* db */
+			)
+			require.NoError(t, err)
+
+			expected := tc.expectedTags(t)
+			seen := 0
+			for producer.Scan() {
+				rowData, err := producer.Row()
+				require.NoError(t, err)
+				require.NoError(t, consumer.FillDatums(ctx, rowData, int64(seen), conv))
+
+				require.Len(t, conv.Datums, 2)
+				id := int(tree.MustBeDInt(conv.Datums[0]))
+				want, ok := expected[id]
+				require.True(t, ok, "unexpected id %d", id)
+				require.Equalf(t, want, conv.Datums[1], "tags datum for id=%d", id)
+				seen++
+			}
+			require.NoError(t, producer.Err())
+			require.Equal(t, len(expected), seen)
+		})
+	}
+}
+
+// TestParquetListOmittedFromTargets verifies that a parquet file containing a
+// LIST column can still be imported when that LIST column is not in the
+// IMPORT target list. The producer must open the file, skip the LIST column,
+// and yield the remaining columns.
+func TestParquetListOmittedFromTargets(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
+	defer row.TestingSetDatumRowConverterBatchSize(2)()
+
+	fr := makeParquetFile(t, arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "tags", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+	}, nil), []parquetRow{
+		{int32(1), []any{"a", "b"}},
+		{int32(2), nil},
+		{int32(3), []any{}},
+		{int32(4), []any{"x"}},
+	})
+
+	tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+		ID:   1,
+		Name: "test_table",
+		Columns: []descpb.ColumnDescriptor{
+			{ID: 1, Name: "id", Type: types.Int4},
+			{ID: 2, Name: "tags", Type: types.MakeArray(types.String), Nullable: true},
+		},
+		PrimaryIndex: descpb.IndexDescriptor{
+			ID: 1, Name: "pk",
+			KeyColumnIDs:        []descpb.ColumnID{1},
+			KeyColumnNames:      []string{"id"},
+			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+		},
+	}).BuildImmutableTable()
+	// IMPORT INTO t(id) — the user explicitly omits the tags column.
+	targetCols := tree.NameList{"id"}
+	importCtx := &parallelImportContext{
+		tableDesc:  tableDesc,
+		targetCols: targetCols,
+	}
+
+	producer, err := newParquetRowProducer(fr, importCtx)
+	require.NoError(t, err)
+	consumer, err := newParquetRowConsumer(
+		importCtx, producer, &importFileContext{}, false)
+	require.NoError(t, err)
+
+	conv, err := row.NewDatumRowConverter(
+		ctx, &semaCtx, tableDesc, targetCols, evalCtx.Copy(),
+		nil /* kvCh */, nil /* seqChunkProvider */, nil /* metrics */, nil, /* db */
+	)
+	require.NoError(t, err)
+
+	expectedIDs := []int{1, 2, 3, 4}
+	seen := 0
+	for producer.Scan() {
+		rowData, err := producer.Row()
+		require.NoError(t, err)
+		require.NoError(t, consumer.FillDatums(ctx, rowData, int64(seen), conv))
+
+		// The converter still allocates a slot for every visible column, but
+		// "tags" was not in targetCols and therefore stays at its default.
+		require.Equal(t, expectedIDs[seen], int(tree.MustBeDInt(conv.Datums[0])))
+		seen++
+	}
+	require.NoError(t, producer.Err())
+	require.Equal(t, len(expectedIDs), seen)
+}
+
+// TestParquetUnsupportedColumnDeferred verifies that detectListColumn errors
+// for unsupported parquet structures (nested LIST, MAP) are deferred until
+// the user actually imports the offending column. Otherwise, opening a
+// parquet file that contains any unsupported column would fail regardless
+// of which columns the user asked for.
+func TestParquetUnsupportedColumnDeferred(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const fieldID = -1
+
+	// Build a parquet schema with one importable flat column ("id") and one
+	// unsupported nested LIST column ("nested"). We can't easily produce a
+	// real LIST<LIST<T>> parquet file with the high-level arrow writer, so
+	// we exercise determineColumnsToRead directly: it is the function that
+	// decides which columns to read and is where the deferred error must
+	// surface.
+	idLeaf, err := schema.NewPrimitiveNode(
+		"id", parquet.Repetitions.Required,
+		parquet.Types.Int32, -1, fieldID)
+	require.NoError(t, err)
+
+	innerLeaf, err := schema.NewPrimitiveNode(
+		"element", parquet.Repetitions.Optional,
+		parquet.Types.Int32, -1, fieldID)
+	require.NoError(t, err)
+	innerRepeated, err := schema.NewGroupNode(
+		"list", parquet.Repetitions.Repeated,
+		[]schema.Node{innerLeaf}, fieldID)
+	require.NoError(t, err)
+	innerList, err := schema.NewGroupNodeLogical(
+		"element", parquet.Repetitions.Optional,
+		[]schema.Node{innerRepeated},
+		schema.ListLogicalType{}, fieldID)
+	require.NoError(t, err)
+	outerRepeated, err := schema.NewGroupNode(
+		"list", parquet.Repetitions.Repeated,
+		[]schema.Node{innerList}, fieldID)
+	require.NoError(t, err)
+	nestedList, err := schema.NewGroupNodeLogical(
+		"nested_list", parquet.Repetitions.Optional,
+		[]schema.Node{outerRepeated},
+		schema.ListLogicalType{}, fieldID)
+	require.NoError(t, err)
+
+	root, err := schema.NewGroupNode(
+		"schema", parquet.Repetitions.Required,
+		[]schema.Node{idLeaf, nestedList}, fieldID)
+	require.NoError(t, err)
+	pqSchema := schema.NewSchema(root)
+
+	// Mirror what newParquetRowProducer does: build columnMetadata for every
+	// leaf, deferring detectListColumn errors. The leaf order matches the
+	// schema's column layout: 0=id, 1=nested.element.
+	columnMetadata := make(map[int]*parquetColumnMetadata)
+	for colIdx := range pqSchema.NumColumns() {
+		col := pqSchema.Column(colIdx)
+		name := pqSchema.ColumnRoot(colIdx).Name()
+		listInfo, detectErr := detectListColumn(pqSchema, colIdx)
+		switch {
+		case detectErr != nil:
+			columnMetadata[colIdx] = &parquetColumnMetadata{
+				columnName:   name,
+				detectionErr: detectErr,
+			}
+		case listInfo != nil:
+			columnMetadata[colIdx] = &parquetColumnMetadata{
+				columnName: name,
+				isList:     true,
+				listInfo:   listInfo,
+			}
+		default:
+			columnMetadata[colIdx] = &parquetColumnMetadata{
+				columnName:    name,
+				logicalType:   deriveLogicalType(col),
+				convertedType: col.ConvertedType(),
+			}
+		}
+	}
+	require.Error(t, columnMetadata[1].detectionErr,
+		"nested LIST should produce a deferred error in metadata")
+
+	tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+		ID:   1,
+		Name: "t",
+		Columns: []descpb.ColumnDescriptor{
+			{ID: 1, Name: "id", Type: types.Int4},
+			{ID: 2, Name: "nested_list", Type: types.MakeArray(types.MakeArray(types.Int4)), Nullable: true},
+		},
+		PrimaryIndex: descpb.IndexDescriptor{
+			ID: 1, Name: "pk",
+			KeyColumnIDs:        []descpb.ColumnID{1},
+			KeyColumnNames:      []string{"id"},
+			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+		},
+	}).BuildImmutableTable()
+
+	t.Run("OmittingUnsupportedColumnSucceeds", func(t *testing.T) {
+		importCtx := &parallelImportContext{
+			tableDesc:  tableDesc,
+			targetCols: tree.NameList{"id"},
+		}
+		cols, err := determineColumnsToRead(importCtx, pqSchema, columnMetadata)
+		require.NoError(t, err)
+		require.Equal(t, []int{0}, cols)
+	})
+
+	t.Run("ImportingUnsupportedColumnFails", func(t *testing.T) {
+		importCtx := &parallelImportContext{
+			tableDesc:  tableDesc,
+			targetCols: tree.NameList{"id", "nested_list"},
+		}
+		_, err := determineColumnsToRead(importCtx, pqSchema, columnMetadata)
+		require.Error(t, err)
+		require.ErrorContains(t, err, `column "nested_list"`)
+		require.ErrorContains(t, err, "nested LIST")
+	})
+}
+
+// TestParquetMultipleListColumns drives the full producer/consumer pipeline
+// against a file with two LIST columns. Each LIST is read by its own stateful
+// reader, and we verify both columns produce the expected per-row datums.
+func TestParquetMultipleListColumns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
+	defer row.TestingSetDatumRowConverterBatchSize(2)()
+
+	stringArr := func(t *testing.T, elems ...string) tree.Datum {
+		t.Helper()
+		arr := tree.NewDArray(types.String)
+		for _, e := range elems {
+			require.NoError(t, arr.Append(tree.NewDString(e)))
+		}
+		return arr
+	}
+	intArr := func(t *testing.T, elems ...int) tree.Datum {
+		t.Helper()
+		arr := tree.NewDArray(types.Int4)
+		for _, e := range elems {
+			require.NoError(t, arr.Append(tree.NewDInt(tree.DInt(e))))
+		}
+		return arr
+	}
+
+	type expected struct {
+		tags   tree.Datum
+		scores tree.Datum
+	}
+	want := map[int]expected{
+		1: {tags: stringArr(t, "a", "b"), scores: intArr(t, 10, 20, 30)},
+		2: {tags: tree.DNull, scores: intArr(t)},
+		3: {tags: stringArr(t), scores: tree.DNull},
+		4: {tags: stringArr(t, "x"), scores: intArr(t, 99)},
+	}
+
+	fr := makeParquetFile(t, arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "tags", Type: arrow.ListOf(arrow.BinaryTypes.String), Nullable: true},
+		{Name: "scores", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+	}, nil), []parquetRow{
+		{int32(1), []any{"a", "b"}, []any{int32(10), int32(20), int32(30)}},
+		{int32(2), nil, []any{}},
+		{int32(3), []any{}, nil},
+		{int32(4), []any{"x"}, []any{int32(99)}},
+	})
+
+	tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+		ID:   1,
+		Name: "test_table",
+		Columns: []descpb.ColumnDescriptor{
+			{ID: 1, Name: "id", Type: types.Int4},
+			{ID: 2, Name: "tags", Type: types.MakeArray(types.String), Nullable: true},
+			{ID: 3, Name: "scores", Type: types.MakeArray(types.Int4), Nullable: true},
+		},
+		PrimaryIndex: descpb.IndexDescriptor{
+			ID: 1, Name: "pk",
+			KeyColumnIDs:        []descpb.ColumnID{1},
+			KeyColumnNames:      []string{"id"},
+			KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+		},
+	}).BuildImmutableTable()
+	targetCols := tree.NameList{"id", "tags", "scores"}
+	importCtx := &parallelImportContext{
+		tableDesc:  tableDesc,
+		targetCols: targetCols,
+	}
+
+	producer, err := newParquetRowProducer(fr, importCtx)
+	require.NoError(t, err)
+	consumer, err := newParquetRowConsumer(
+		importCtx, producer, &importFileContext{}, false)
+	require.NoError(t, err)
+
+	conv, err := row.NewDatumRowConverter(
+		ctx, &semaCtx, tableDesc, targetCols, evalCtx.Copy(),
+		nil /* kvCh */, nil /* seqChunkProvider */, nil /* metrics */, nil, /* db */
+	)
+	require.NoError(t, err)
+
+	seen := 0
+	for producer.Scan() {
+		rowData, err := producer.Row()
+		require.NoError(t, err)
+		require.NoError(t, consumer.FillDatums(ctx, rowData, int64(seen), conv))
+
+		require.Len(t, conv.Datums, 3)
+		id := int(tree.MustBeDInt(conv.Datums[0]))
+		exp, ok := want[id]
+		require.True(t, ok, "unexpected id %d", id)
+		require.Equalf(t, exp.tags, conv.Datums[1], "tags datum for id=%d", id)
+		require.Equalf(t, exp.scores, conv.Datums[2], "scores datum for id=%d", id)
+		seen++
+	}
+	require.NoError(t, producer.Err())
+	require.Equal(t, len(want), seen)
+}
+
+// TestParquetListMultiBatch verifies that LIST column data is correctly
+// preserved across multiple fillBuffer calls, ensuring level entries
+// consumed by a chunk read but beyond the batch boundary are not
+// discarded.
+func TestParquetListMultiBatch(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pool := memory.NewGoAllocator()
+
+	// Create a file with 300 rows (batch size is 100, so 3 fillBuffer calls).
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "scores", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+	}, nil)
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+
+	idBuilder := builder.Field(0).(*array.Int32Builder)
+	lb := builder.Field(1).(*array.ListBuilder)
+	vb := lb.ValueBuilder().(*array.Int32Builder)
+
+	numRows := 300
+	for i := range numRows {
+		idBuilder.Append(int32(i))
+		if i%10 == 0 {
+			// Every 10th row: null list.
+			lb.AppendNull()
+		} else if i%10 == 1 {
+			// Every 10th+1 row: empty list.
+			lb.Append(true)
+		} else {
+			// Other rows: [i*100, i*100+1, i*100+2].
+			lb.Append(true)
+			vb.Append(int32(i * 100))
+			vb.Append(int32(i*100 + 1))
+			vb.Append(int32(i*100 + 2))
+		}
+	}
+
+	record := builder.NewRecord()
+	defer record.Release()
+
+	buf := new(bytes.Buffer)
+	writerProps := parquet.NewWriterProperties(
+		parquet.WithCompression(compress.Codecs.Uncompressed))
+	writer, err := pqarrow.NewFileWriter(
+		arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+
+	reader := bytes.NewReader(buf.Bytes())
+	fr := &fileReader{
+		Reader: reader, ReaderAt: reader, Seeker: reader,
+		total: int64(buf.Len()),
+	}
+
+	// Read through the full producer pipeline (no importCtx = test mode).
+	producer, err := newParquetRowProducer(fr, nil)
+	require.NoError(t, err)
+
+	rowIdx := 0
+	for producer.Scan() {
+		rowData, err := producer.Row()
+		require.NoError(t, err)
+
+		view := rowData.(*parquetRowView)
+		// Find the LIST column batch (column with isList=true).
+		for colIdx := range view.numColumns {
+			batch := view.batches[colIdx]
+			if batch == nil || !batch.isList {
+				continue
+			}
+
+			val, isNull, err := batch.GetValueAt(int(view.rowIndex))
+			require.NoError(t, err, "row %d", rowIdx)
+
+			if rowIdx%10 == 0 {
+				// Null list.
+				require.True(t, isNull, "row %d should be null", rowIdx)
+			} else if rowIdx%10 == 1 {
+				// Empty list.
+				require.False(t, isNull, "row %d should not be null", rowIdx)
+				elements := val.([]any)
+				require.Len(t, elements, 0, "row %d should be empty list", rowIdx)
+			} else {
+				// 3-element list.
+				require.False(t, isNull, "row %d should not be null", rowIdx)
+				elements := val.([]any)
+				require.Len(t, elements, 3, "row %d", rowIdx)
+				require.Equal(t, int32(rowIdx*100), elements[0], "row %d elem 0", rowIdx)
+				require.Equal(t, int32(rowIdx*100+1), elements[1], "row %d elem 1", rowIdx)
+				require.Equal(t, int32(rowIdx*100+2), elements[2], "row %d elem 2", rowIdx)
+			}
+		}
+		rowIdx++
+	}
+	require.NoError(t, producer.Err())
+	require.Equal(t, numRows, rowIdx, "should read all rows")
+}
+
+// TestParquetListAcrossRowGroups verifies that the producer correctly resets
+// LIST reader state on a row-group boundary. The test forces multiple row
+// groups via WithMaxRowGroupLength and drives the full Scan/Row pipeline.
+func TestParquetListAcrossRowGroups(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pool := memory.NewGoAllocator()
+
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+		{Name: "vals", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+	}, nil)
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+	idBuilder := builder.Field(0).(*array.Int32Builder)
+	lb := builder.Field(1).(*array.ListBuilder)
+	vb := lb.ValueBuilder().(*array.Int32Builder)
+
+	const numRows = 25
+	for i := range numRows {
+		idBuilder.Append(int32(i))
+		lb.Append(true)
+		vb.Append(int32(i))
+		vb.Append(int32(i + 1))
+	}
+	record := builder.NewRecord()
+	defer record.Release()
+
+	buf := new(bytes.Buffer)
+	writerProps := parquet.NewWriterProperties(
+		parquet.WithCompression(compress.Codecs.Uncompressed),
+		parquet.WithMaxRowGroupLength(5),
+	)
+	writer, err := pqarrow.NewFileWriter(
+		arrowSchema, buf, writerProps, pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+
+	reader := bytes.NewReader(buf.Bytes())
+	fr := &fileReader{
+		Reader: reader, ReaderAt: reader, Seeker: reader,
+		total: int64(buf.Len()),
+	}
+
+	producer, err := newParquetRowProducer(fr, nil)
+	require.NoError(t, err)
+	require.Greater(t, producer.totalRowGroups, 1,
+		"test fixture should produce multiple row groups")
+
+	rowIdx := 0
+	for producer.Scan() {
+		rowData, err := producer.Row()
+		require.NoError(t, err)
+		view := rowData.(*parquetRowView)
+		for colIdx := range view.numColumns {
+			batch := view.batches[colIdx]
+			if batch == nil || !batch.isList {
+				continue
+			}
+			val, isNull, err := batch.GetValueAt(int(view.rowIndex))
+			require.NoError(t, err, "row %d", rowIdx)
+			require.False(t, isNull, "row %d should not be null", rowIdx)
+			elements := val.([]any)
+			require.Len(t, elements, 2, "row %d", rowIdx)
+			require.Equal(t, int32(rowIdx), elements[0], "row %d elem 0", rowIdx)
+			require.Equal(t, int32(rowIdx+1), elements[1], "row %d elem 1", rowIdx)
+		}
+		rowIdx++
+	}
+	require.NoError(t, producer.Err())
+	require.Equal(t, numRows, rowIdx)
+}
+
 // TestParquetElementToJSON pins the JSON output of parquetElementToJSON for
 // every supported physical type and the recognized logical-type annotations.
 // The assertions are coupled to tree.AsJSON's per-datum formatting, so a
@@ -2071,6 +2778,99 @@ func TestAssembleListDatum(t *testing.T) {
 		require.ErrorContains(t, err, "expected []any for LIST column")
 		require.True(t, errors.HasAssertionFailure(err))
 	})
+}
+
+// TestParquetListValidationRejects verifies that the LIST branch of
+// validateAndBuildColumnMapping rejects non-ARRAY/JSONB targets and arrays
+// whose element type is incompatible with the Parquet element's physical type,
+// surfacing the error at file-open time rather than mid-import.
+func TestParquetListValidationRejects(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Build a Parquet file with a single LIST<int32> column named "vals".
+	pool := memory.NewGoAllocator()
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "vals", Type: arrow.ListOf(arrow.PrimitiveTypes.Int32), Nullable: true},
+	}, nil)
+	builder := array.NewRecordBuilder(pool, arrowSchema)
+	defer builder.Release()
+	lb := builder.Field(0).(*array.ListBuilder)
+	vb := lb.ValueBuilder().(*array.Int32Builder)
+	lb.Append(true)
+	vb.Append(1)
+	record := builder.NewRecord()
+	defer record.Release()
+
+	buf := new(bytes.Buffer)
+	writer, err := pqarrow.NewFileWriter(
+		arrowSchema, buf,
+		parquet.NewWriterProperties(parquet.WithCompression(compress.Codecs.Uncompressed)),
+		pqarrow.DefaultWriterProps())
+	require.NoError(t, err)
+	require.NoError(t, writer.Write(record))
+	require.NoError(t, writer.Close())
+	parquetBytes := buf.Bytes()
+
+	newImportCtxWithType := func(colType *types.T) *parallelImportContext {
+		tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+			Name: "t",
+			Columns: []descpb.ColumnDescriptor{
+				{ID: 1, Name: "id", Type: types.Int},
+				{ID: 2, Name: "vals", Type: colType, Nullable: true},
+			},
+			NextColumnID: 3,
+			PrimaryIndex: descpb.IndexDescriptor{
+				ID: 1, Name: "pk",
+				KeyColumnIDs:        []descpb.ColumnID{1},
+				KeyColumnNames:      []string{"id"},
+				KeyColumnDirections: []catenumpb.IndexColumn_Direction{catenumpb.IndexColumn_ASC},
+			},
+		}).BuildImmutableTable()
+		return &parallelImportContext{
+			tableDesc:  tableDesc,
+			targetCols: tree.NameList{"vals"},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		colType      *types.T
+		expectedErr  string
+		expectedHelp string // optional substring for the wrapping context
+	}{
+		{
+			name:         "scalar int target",
+			colType:      types.Int,
+			expectedErr:  "Parquet LIST requires an ARRAY or JSONB target type",
+			expectedHelp: `column "vals"`,
+		},
+		{
+			name:         "string array target for int list",
+			colType:      types.MakeArray(types.String),
+			expectedErr:  "int32 type can only be converted to INT or DECIMAL, got StringFamily",
+			expectedHelp: `column "vals" (LIST element type)`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := bytes.NewReader(parquetBytes)
+			fr := &fileReader{
+				Reader: reader, ReaderAt: reader, Seeker: reader,
+				total: int64(len(parquetBytes)),
+			}
+			importCtx := newImportCtxWithType(tc.colType)
+			producer, err := newParquetRowProducer(fr, importCtx)
+			require.NoError(t, err)
+			_, err = newParquetRowConsumer(importCtx, producer, &importFileContext{}, false)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectedErr)
+			if tc.expectedHelp != "" {
+				require.Contains(t, err.Error(), tc.expectedHelp)
+			}
+		})
+	}
 }
 
 // TestParquetConsumerListRouting verifies that parquetRowConsumer.FillDatums

--- a/pkg/sql/importer/read_import_parquet_types.go
+++ b/pkg/sql/importer/read_import_parquet_types.go
@@ -27,6 +27,13 @@ import (
 // parquetColumnMetadata caches immutable schema information for a column.
 // This is populated once when the file is opened and reused across all batches.
 type parquetColumnMetadata struct {
+	// columnName is the user-visible column name. For flat columns this is the
+	// leaf name (e.g. "id"); for LIST columns it is the top-level group node
+	// name (e.g. "tags", not "element"). Always populated, even when
+	// detectListColumn fails — it is the canonical source of truth for the
+	// column's name and is used to match against IMPORT target columns.
+	columnName string
+
 	logicalType   schema.LogicalType   // Always populated (derived from ConvertedType if needed)
 	convertedType schema.ConvertedType // Original annotation (for reference/debugging)
 
@@ -34,6 +41,17 @@ type parquetColumnMetadata struct {
 	// logicalType and convertedType describe the element's types, not the
 	// enclosing group's.
 	isList bool
+
+	// listInfo holds the list schema metadata; non-nil iff isList is true.
+	listInfo *parquetListColumnInfo
+
+	// detectionErr, when non-nil, is the deferred error from
+	// detectListColumn for an unsupported column (e.g. nested LIST or
+	// MAP). It is surfaced only if the column is in the import target
+	// set, so files with unsupported columns can still be partially
+	// imported. logicalType, convertedType, isList, and listInfo are
+	// unset in this case.
+	detectionErr error
 }
 
 // Helper functions for common Parquet type conversions.


### PR DESCRIPTION
Wire parquetListColumnReader (added in #169699) into the IMPORT pipeline so Parquet LIST columns land in CockroachDB ARRAY or JSONB columns. The consumer-side helpers and the FillDatums routing landed in a prior PR; this PR adds the producer-side detection, per-row-group state, validation, and integration tests.

Producer-side, columnMetadata is populated before column selection because a LIST column's user-visible name is the enclosing group node ("tags"), not the Parquet leaf ("element"); without this ordering, determineColumnsToRead would silently skip every LIST column. Per row group, a stateful parquetListColumnReader preserves element overflow across fillBuffer calls.

Validation rejects LIST columns whose target is neither ARRAY nor JSONB or whose element physical type is incompatible with the array contents type. The early ListLogicalType reject in validateWithLogicalType is removed because LIST columns are now detected one level higher (detectListColumn) and only the element's logical type reaches validateWithLogicalType.

Part of: #162543

Release note (sql change): IMPORT INTO ... PARQUET now supports Parquet LIST columns. A LIST is decoded into a target ARRAY column (with an element type matching the Parquet element's physical or logical type) or a target JSONB column (serialized as a JSON array). Nested LISTs and MAP columns remain unsupported and are rejected at file-open time. When a LIST element is an unannotated BYTE_ARRAY, the bytes are passed through to the target as a string with no UTF-8 validation; for genuinely binary data, target an ARRAY<BYTES> column to preserve the original bytes losslessly.

Epic: none