### PR TITLE
workload/rand: fix cross-database LoadTable and Diff

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -581,7 +581,8 @@ func verifyConflictCorrectness(
 	// with matching origin timestamps, so if there are 100 or more something
 	// else is wrong.
 	const diffLimit = 100
-	diffs, err := workloadrand.Diff(setup.left.db, "conflict.conflict", setup.right.db, "conflict.conflict", diffLimit)
+	conflictTable := workloadrand.QualifiedName{Table: "conflict", Schema: "public", Database: "conflict"}
+	diffs, err := workloadrand.Diff(setup.left.db, conflictTable, setup.right.db, conflictTable, diffLimit)
 	require.NoError(t, err)
 	require.NotEmpty(t, diffs, "fingerprints differ but no row diffs found")
 	require.Less(t, len(diffs), diffLimit, "too many diffs; likely a real divergence, not a timestamp tie")

--- a/pkg/workload/conflict/conflict.go
+++ b/pkg/workload/conflict/conflict.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	workloadrand "github.com/cockroachdb/cockroach/pkg/workload/rand"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/spf13/pflag"
 )
@@ -104,7 +105,7 @@ func (w *conflict) Ops(
 		poolA := clusterA.Get()
 		poolB := clusterB.Get()
 		dbs := []*gosql.DB{stdlib.OpenDBFromPool(poolA), stdlib.OpenDBFromPool(poolB)}
-		worker, err := newConflictWorker(dbs, w.tableName)
+		worker, err := newConflictWorker(dbs, workloadrand.QualifiedName{Table: w.tableName})
 		if err != nil {
 			return workload.QueryLoad{}, err
 		}

--- a/pkg/workload/conflict/conflict_worker.go
+++ b/pkg/workload/conflict/conflict_worker.go
@@ -23,7 +23,9 @@ type conflictWorker struct {
 	nullPct int
 }
 
-func newConflictWorker(connections []*gosql.DB, tableName string) (*conflictWorker, error) {
+func newConflictWorker(
+	connections []*gosql.DB, tableName workloadrand.QualifiedName,
+) (*conflictWorker, error) {
 	table, err := workloadrand.LoadTable(connections[0], tableName)
 	if err != nil {
 		return nil, err

--- a/pkg/workload/rand/diff.go
+++ b/pkg/workload/rand/diff.go
@@ -231,7 +231,7 @@ func fetchDiffRows(
 //   - Primary key hashes use FNV64, so hash collisions would cause rows to be
 //     silently dropped. This is negligible for reasonable table sizes.
 func Diff(
-	connA *gosql.DB, tableA string, connB *gosql.DB, tableB string, resultLimit int,
+	connA *gosql.DB, tableA QualifiedName, connB *gosql.DB, tableB QualifiedName, resultLimit int,
 ) ([]RowDiff, error) {
 	schema, err := LoadTable(connA, tableA)
 	if err != nil {
@@ -245,11 +245,11 @@ func Diff(
 	pkHashExpr := buildPKHashExpr(&schema)
 
 	// Phase 1: load hashes from both tables.
-	hashesA, err := queryHashes(connA, buildHashQuery(&schema, tableA))
+	hashesA, err := queryHashes(connA, buildHashQuery(&schema, tableA.String()))
 	if err != nil {
 		return nil, err
 	}
-	hashesB, err := queryHashes(connB, buildHashQuery(&schema, tableB))
+	hashesB, err := queryHashes(connB, buildHashQuery(&schema, tableB.String()))
 	if err != nil {
 		return nil, err
 	}
@@ -274,12 +274,12 @@ func Diff(
 
 	// Phase 2: fetch full row data only for differing rows.
 	numCols := len(schema.Cols)
-	fetchQueryA := buildFetchQuery(&schema, pkHashExpr, tableA)
+	fetchQueryA := buildFetchQuery(&schema, pkHashExpr, tableA.String())
 	dataA, err := fetchDiffRows(connA, fetchQueryA, numCols, diffPKs)
 	if err != nil {
 		return nil, err
 	}
-	fetchQueryB := buildFetchQuery(&schema, pkHashExpr, tableB)
+	fetchQueryB := buildFetchQuery(&schema, pkHashExpr, tableB.String())
 	dataB, err := fetchDiffRows(connB, fetchQueryB, numCols, diffPKs)
 	if err != nil {
 		return nil, err

--- a/pkg/workload/rand/diff_test.go
+++ b/pkg/workload/rand/diff_test.go
@@ -58,19 +58,19 @@ func TestDiff(t *testing.T) {
 	// the whole name as a single identifier).
 	sqlDB.Exec(t, `CREATE TABLE diff_a (id INT PRIMARY KEY, name STRING, value INT)`)
 	sqlDB.Exec(t, `CREATE TABLE diff_b (id INT PRIMARY KEY, name STRING, value INT)`)
-	const diffA = "defaultdb.public.diff_a"
-	const diffB = "defaultdb.public.diff_b"
+	diffA := QualifiedName{Table: "diff_a", Schema: "public", Database: "defaultdb"}
+	diffB := QualifiedName{Table: "diff_b", Schema: "public", Database: "defaultdb"}
 
 	// BIT column tables for the qualified-name regression test.
 	sqlDB.Exec(t, `CREATE TABLE bit_a (id INT PRIMARY KEY, bits BIT(15))`)
 	sqlDB.Exec(t, `CREATE TABLE bit_b (id INT PRIMARY KEY, bits BIT(15))`)
-	const bitA = "defaultdb.public.bit_a"
-	const bitB = "defaultdb.public.bit_b"
+	bitA := QualifiedName{Table: "bit_a", Schema: "public", Database: "defaultdb"}
+	bitB := QualifiedName{Table: "bit_b", Schema: "public", Database: "defaultdb"}
 
 	type diffCheck struct {
 		name     string
-		tableA   string // fully qualified table A name
-		tableB   string // fully qualified table B name
+		tableA   QualifiedName
+		tableB   QualifiedName
 		setup    []string
 		limit    int
 		wantLen  int
@@ -217,8 +217,8 @@ func TestDiffRandomSchema(t *testing.T) {
 		shortNameB := fmt.Sprintf("diff_rand_b_%d", attempt)
 		// Use fully qualified names to exercise the schema.table path in diff
 		// queries.
-		tableNameA := fmt.Sprintf("defaultdb.public.%s", shortNameA)
-		tableNameB := fmt.Sprintf("defaultdb.public.%s", shortNameB)
+		tableNameA := QualifiedName{Table: shortNameA, Schema: "public", Database: "defaultdb"}
+		tableNameB := QualifiedName{Table: shortNameB, Schema: "public", Database: "defaultdb"}
 
 		// Extract the table body and create both tables with the same schema.
 		// The random schema generator can produce features (e.g. partitions)
@@ -268,8 +268,8 @@ func TestDiffRandomSchema(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("fingerprint-diff-%d", created), func(t *testing.T) {
-			fpA := fingerprint(t, sqlDB, tableNameA)
-			fpB := fingerprint(t, sqlDB, tableNameB)
+			fpA := fingerprint(t, sqlDB, tableNameA.String())
+			fpB := fingerprint(t, sqlDB, tableNameB.String())
 
 			diffs, err := Diff(db, tableNameA, db, tableNameB, 100)
 			require.NoError(t, err)
@@ -282,6 +282,44 @@ func TestDiffRandomSchema(t *testing.T) {
 	}
 }
 
+// TestDiffCrossDatabase is a regression test for #170730. LoadTable fails with
+// "no columns detected" when called with a cross-database qualified table name
+// from a connection to a different database, because pg_catalog virtual tables
+// are scoped to the connection's current database.
+func TestDiffCrossDatabase(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderRace(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, "CREATE DATABASE xdb")
+	xdbConn := s.SQLConn(t, serverutils.DBName("xdb"))
+	xdbSQL := sqlutils.MakeSQLRunner(xdbConn)
+
+	xdbSQL.Exec(t, `CREATE TABLE xdb_a (id INT PRIMARY KEY, name STRING, value INT)`)
+	xdbSQL.Exec(t, `CREATE TABLE xdb_b (id INT PRIMARY KEY, name STRING, value INT)`)
+	xdbSQL.Exec(t, `INSERT INTO xdb_a VALUES (1, 'alice', 10), (2, 'bob', 20)`)
+	xdbSQL.Exec(t, `INSERT INTO xdb_b VALUES (1, 'alice', 10), (2, 'bob', 20)`)
+
+	// Call LoadTable from the defaultdb connection using a cross-database
+	// name. Before the fix, this failed because pg_catalog is scoped to the
+	// connection's current database.
+	xdbA := QualifiedName{Table: "xdb_a", Schema: "public", Database: "xdb"}
+	xdbB := QualifiedName{Table: "xdb_b", Schema: "public", Database: "xdb"}
+	tableA, err := LoadTable(db, xdbA)
+	require.NoError(t, err)
+	require.NotEmpty(t, tableA.Cols)
+
+	// Diff the two tables from the defaultdb connection.
+	diffs, err := Diff(db, xdbA, db, xdbB, 100)
+	require.NoError(t, err)
+	require.Empty(t, diffs, "identical tables should produce no diffs")
+}
+
 // insertRows inserts n random rows into the given table using the TableWriter.
 // Rows that fail to insert (e.g. due to unique constraint violations on
 // secondary indexes) are silently skipped.
@@ -291,7 +329,7 @@ func insertRows(
 	db *gosql.DB,
 	rng *rand.Rand,
 	table *Table,
-	tableName string,
+	tableName QualifiedName,
 	n int,
 ) {
 	t.Helper()

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -121,7 +121,7 @@ func (w *random) Ops(
 		tableName = w.Tables()[0].Name
 	}
 
-	table, err := LoadTable(db, tableName)
+	table, err := LoadTable(db, QualifiedName{Table: tableName})
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}

--- a/pkg/workload/rand/rand_test.go
+++ b/pkg/workload/rand/rand_test.go
@@ -90,7 +90,7 @@ func TestRandRun(t *testing.T) {
 			writeStmt, err := db.Prepare(stmt)
 			require.NoError(t, err)
 
-			table, err := LoadTable(db, tblName)
+			table, err := LoadTable(db, QualifiedName{Table: tblName})
 			require.NoError(t, err)
 
 			op := randOp{

--- a/pkg/workload/rand/schema.go
+++ b/pkg/workload/rand/schema.go
@@ -22,8 +22,49 @@ import (
 	"github.com/lib/pq/oid"
 )
 
+// QualifiedName identifies a table by name, and optionally by schema and
+// database. When Database is non-empty, pg_catalog and information_schema
+// queries are prefixed with the database name so they resolve correctly even
+// when the connection targets a different database.
+type QualifiedName struct {
+	// Table is the unqualified table name (e.g. "foo").
+	Table string
+	// Schema, when non-empty, is included between Database and Table
+	// (e.g. "public").
+	Schema string
+	// Database, when non-empty, is prepended to form a fully-qualified
+	// reference for DML and REGCLASS resolution (e.g. "mydb.public.foo"),
+	// and is also used to prefix pg_catalog and information_schema queries
+	// so schema introspection targets the correct database.
+	Database string
+}
+
+// catalogPrefix returns the database-qualified prefix for pg_catalog and
+// information_schema queries (e.g. "mydb."). Returns "" when the table is
+// in the connection's current database.
+func (n QualifiedName) catalogPrefix() string {
+	if n.Database == "" {
+		return ""
+	}
+	return n.Database + "."
+}
+
+// String returns the fully-qualified table name, joining whichever of
+// Database, Schema, and Table are set with dots.
+func (n QualifiedName) String() string {
+	var parts []string
+	if n.Database != "" {
+		parts = append(parts, n.Database)
+	}
+	if n.Schema != "" {
+		parts = append(parts, n.Schema)
+	}
+	parts = append(parts, n.Table)
+	return strings.Join(parts, ".")
+}
+
 type Table struct {
-	Name       string
+	Name       QualifiedName
 	Cols       []Col
 	PrimaryKey []int
 	// PrimaryKeyComponents is the set of columns that influence the primary key.
@@ -118,15 +159,19 @@ func (t *Table) MutateRow(rng *rand.Rand, nullPct int, prevRow []any) ([]any, er
 // `character_maximum_length` column is NULL, it means the column has
 // variable width and we set the width of the type to 0, which will
 // cause the random data generator to generate data with random width.
-func typeForOid(db *gosql.DB, typeOid oid.Oid, relid int, columnName string) (*types.T, error) {
+func typeForOid(
+	db *gosql.DB, typeOid oid.Oid, relid int, columnName string, catPrefix string,
+) (*types.T, error) {
 	datumType := *types.OidToType[typeOid]
 	if typeOid == oid.T_bit || typeOid == oid.T_char {
 		var width int32
 		if err := db.QueryRow(
-			`SELECT IFNULL(character_maximum_length, 0)
-			FROM information_schema.columns
-			JOIN pg_catalog.pg_class ON pg_class.relname = table_name
-			WHERE pg_class.oid = $1 AND column_name = $2`,
+			fmt.Sprintf(
+				`SELECT IFNULL(character_maximum_length, 0)
+				FROM %sinformation_schema.columns
+				JOIN %spg_catalog.pg_class ON pg_class.relname = table_name
+				WHERE pg_class.oid = $1 AND column_name = $2`,
+				catPrefix, catPrefix),
 			relid, columnName).Scan(&width); err != nil {
 			return nil, err
 		}
@@ -138,20 +183,22 @@ func typeForOid(db *gosql.DB, typeOid oid.Oid, relid int, columnName string) (*t
 }
 
 // LoadTable loads a table's schema from the database.
-func LoadTable(conn *gosql.DB, tableName string) (_ Table, retErr error) {
+func LoadTable(conn *gosql.DB, tableName QualifiedName) (_ Table, retErr error) {
+	catPrefix := tableName.catalogPrefix()
+
 	var relid int
-	if err := conn.QueryRow("SELECT $1::REGCLASS::OID", tableName).Scan(&relid); err != nil {
-		return Table{}, err
+	if err := conn.QueryRow("SELECT $1::REGCLASS::OID", tableName.String()).Scan(&relid); err != nil {
+		return Table{}, errors.Wrapf(err, "resolving REGCLASS OID for %s", tableName)
 	}
 
-	rows, err := conn.Query(`
+	rows, err := conn.Query(fmt.Sprintf(`
 SELECT attname, atttypid, adsrc, NOT attnotnull, attgenerated != '', pg_get_expr(adbin, adrelid) as expression
-FROM pg_catalog.pg_attribute
-LEFT JOIN pg_catalog.pg_attrdef
+FROM %spg_catalog.pg_attribute
+LEFT JOIN %spg_catalog.pg_attrdef
 	ON attrelid=adrelid AND attnum=adnum
-WHERE attrelid=$1 AND NOT attisdropped`, relid)
+WHERE attrelid=$1 AND NOT attisdropped`, catPrefix, catPrefix), relid)
 	if err != nil {
-		return Table{}, err
+		return Table{}, errors.Wrapf(err, "querying columns for %s", tableName)
 	}
 	defer func() { retErr = errors.CombineErrors(retErr, rows.Close()) }()
 	var cols []Col
@@ -164,11 +211,11 @@ WHERE attrelid=$1 AND NOT attisdropped`, relid)
 
 		var typOid int
 		if err := rows.Scan(&c.Name, &typOid, &c.CDefault, &c.IsNullable, &c.IsComputed, &c.Expression); err != nil {
-			return Table{}, err
+			return Table{}, errors.Wrapf(err, "scanning column row for %s", tableName)
 		}
-		c.DataType, err = typeForOid(conn, oid.Oid(typOid), relid, c.Name)
+		c.DataType, err = typeForOid(conn, oid.Oid(typOid), relid, c.Name, catPrefix)
 		if err != nil {
-			return Table{}, err
+			return Table{}, errors.Wrapf(err, "resolving type for column %s in %s", c.Name, tableName)
 		}
 		if c.CDefault.String == "unique_rowid()" { // skip
 			continue
@@ -181,11 +228,11 @@ WHERE attrelid=$1 AND NOT attisdropped`, relid)
 	}
 
 	if numCols == 0 {
-		return Table{}, errors.New("no columns detected")
+		return Table{}, errors.Newf("no columns detected for %s", tableName)
 	}
 
 	if err = rows.Err(); err != nil {
-		return Table{}, err
+		return Table{}, errors.Wrapf(err, "iterating columns for %s", tableName)
 	}
 
 	t := Table{
@@ -193,22 +240,21 @@ WHERE attrelid=$1 AND NOT attisdropped`, relid)
 		Cols: cols,
 	}
 
-	rows, err = conn.Query(
-		`
+	rows, err = conn.Query(fmt.Sprintf(`
 SELECT a.attname
-FROM   pg_index i
-JOIN   pg_attribute a ON a.attrelid = i.indrelid
+FROM   %spg_catalog.pg_index i
+JOIN   %spg_catalog.pg_attribute a ON a.attrelid = i.indrelid
 					AND a.attnum = ANY(i.indkey)
 WHERE  i.indrelid = $1
-AND    i.indisprimary`, relid)
+AND    i.indisprimary`, catPrefix, catPrefix), relid)
 	if err != nil {
-		return Table{}, err
+		return Table{}, errors.Wrapf(err, "querying primary key for %s", tableName)
 	}
 	defer func() { retErr = errors.CombineErrors(retErr, rows.Close()) }()
 	for rows.Next() {
 		var colname string
 		if err := rows.Scan(&colname); err != nil {
-			return Table{}, err
+			return Table{}, errors.Wrapf(err, "scanning primary key column for %s", tableName)
 		}
 		for i, c := range cols {
 			if c.Name == colname {
@@ -217,7 +263,7 @@ AND    i.indisprimary`, relid)
 		}
 	}
 	if err = rows.Err(); err != nil {
-		return Table{}, err
+		return Table{}, errors.Wrapf(err, "iterating primary key for %s", tableName)
 	}
 
 	t.PrimaryKeyComponents = make(map[int]bool)

--- a/pkg/workload/rand/writer.go
+++ b/pkg/workload/rand/writer.go
@@ -43,7 +43,7 @@ func NewTableWriter(conn *gosql.DB, table Table) *TableWriter {
 
 	upsertStmt := fmt.Sprintf(
 		`INSERT INTO %s (%s) VALUES (%s) ON CONFLICT (%s) DO UPDATE SET %s`,
-		table.Name,
+		table.Name.String(),
 		strings.Join(columns, ", "),
 		strings.Join(params, ", "),
 		strings.Join(pkColumns, ", "),
@@ -62,7 +62,7 @@ func NewTableWriter(conn *gosql.DB, table Table) *TableWriter {
 	}
 	deleteStmt := fmt.Sprintf(
 		`DELETE FROM %s WHERE %s`,
-		table.Name, strings.Join(pkComponents, " AND "),
+		table.Name.String(), strings.Join(pkComponents, " AND "),
 	)
 
 	return &TableWriter{

--- a/pkg/workload/rand/writer_test.go
+++ b/pkg/workload/rand/writer_test.go
@@ -37,7 +37,7 @@ func TestWriter(t *testing.T) {
 	sqlDB.Exec(t, `CREATE DATABASE test`)
 	sqlDB.Exec(t, `CREATE TABLE test_writer (id INT PRIMARY KEY, data TEXT NOT NULL)`)
 
-	table, err := LoadTable(db, "test_writer")
+	table, err := LoadTable(db, QualifiedName{Table: "test_writer"})
 	require.NoError(t, err)
 
 	writer := NewTableWriter(db, table)
@@ -72,7 +72,7 @@ func runWriterTest(
 
 	t.Logf("stmt: %s\n", createStmt)
 
-	table, err := LoadTable(db, tableName)
+	table, err := LoadTable(db, QualifiedName{Table: tableName})
 	require.NoError(t, err)
 
 	writer := NewTableWriter(db, table)


### PR DESCRIPTION
LoadTable fails with "no columns detected" when called with a cross-database table name from a connection to a different database. The root cause is that pg_catalog virtual tables are scoped to the connection's current database, so the REGCLASS OID resolves correctly but pg_attribute returns no rows.

Introduce QualifiedName with Table and Database fields. When Database is set, pg_catalog and information_schema references are prefixed with the database name (e.g. "otherdb.pg_catalog.pg_attribute") so schema introspection targets the correct database. Update LoadTable, Diff, and all callers to use QualifiedName.

Add TestDiffCrossDatabase as a regression test.

Fixes: #170053
Fixes: #170730
Epic: none
Release note: None