### PR TITLE
changefeedccl: add create_kafka_topics option

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -135,6 +135,7 @@ const (
 	OptLaggingRangesPollingInterval       = `lagging_ranges_polling_interval`
 	OptIgnoreDisableChangefeedReplication = `ignore_disable_changefeed_replication`
 	OptEncodeJSONValueNullAsObject        = `encode_json_value_null_as_object`
+	OptCreateKafkaTopics                  = `create_kafka_topics`
 	// TODO(#142273): look into whether we want to add headers to pub/sub, and other
 	// sinks as well (eg cloudstorage, webhook, ..). Currently it's kafka-only.
 	OptHeadersJSONColumnName = `headers_json_column_name`
@@ -435,6 +436,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptLaggingRangesPollingInterval:       durationOption,
 	OptIgnoreDisableChangefeedReplication: flagOption,
 	OptEncodeJSONValueNullAsObject:        flagOption,
+	OptCreateKafkaTopics:                  enum("broker_auto", "explicit", "off").orEmptyMeans("broker_auto"),
 	OptEnrichedProperties:                 csv(string(EnrichedPropertySource), string(EnrichedPropertySchema)),
 	OptRangeDistributionStrategy:          enum(string(ChangefeedRangeDistributionStrategyDefault), string(ChangefeedRangeDistributionStrategyBalancedSimple)),
 	OptHeadersJSONColumnName:              stringOption,
@@ -462,7 +464,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 var SQLValidOptions map[string]struct{} = nil
 
 // KafkaValidOptions is options exclusive to Kafka sink
-var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaRegistry, OptKafkaSinkConfig, OptHeadersJSONColumnName, OptExtraHeaders, OptPartitionAlg)
+var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaRegistry, OptKafkaSinkConfig, OptHeadersJSONColumnName, OptExtraHeaders, OptPartitionAlg, OptCreateKafkaTopics)
 
 // CloudStorageValidOptions is options exclusive to cloud storage sink
 var CloudStorageValidOptions = makeStringSet(OptCompression, OptCsvHeader)
@@ -709,6 +711,31 @@ func (s StatementOptions) HasEndTime() bool {
 // GetEndTime returns the user-provided end time.
 func (s StatementOptions) GetEndTime() string {
 	return s.m[OptEndTime]
+}
+
+// CreateKafkaTopics controls how changefeeds create Kafka topics.
+type CreateKafkaTopics string
+
+const (
+	// CreateKafkaTopicsBrokerAuto uses Kafka broker auto topic creation.
+	CreateKafkaTopicsBrokerAuto CreateKafkaTopics = "broker_auto"
+	// CreateKafkaTopicsExplicit has changefeeds create topics through the Kafka API.
+	CreateKafkaTopicsExplicit CreateKafkaTopics = "explicit"
+	// CreateKafkaTopicsOff implies that other two options are disabled.
+	CreateKafkaTopicsOff CreateKafkaTopics = "off"
+)
+
+// GetCreateKafkaTopics returns the provided topic creation mode.
+// It defaults to CreateKafkaTopicsBrokerAuto.
+func (s StatementOptions) GetCreateKafkaTopics() (CreateKafkaTopics, error) {
+	if _, ok := s.m[OptCreateKafkaTopics]; !ok {
+		return CreateKafkaTopicsBrokerAuto, nil
+	}
+	rawVal, err := s.getEnumValue(OptCreateKafkaTopics)
+	if err != nil {
+		return CreateKafkaTopicsBrokerAuto, err
+	}
+	return CreateKafkaTopics(rawVal), nil
 }
 
 func (s StatementOptions) getEnumValue(k string) (string, error) {

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -135,3 +135,32 @@ func TestAvroSchemaPrefixValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCreateKafkaTopics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		name        string
+		opts        map[string]string
+		expected    CreateKafkaTopics
+		expectedErr string
+	}{
+		{name: "default", expected: CreateKafkaTopicsBrokerAuto},
+		{name: "broker_auto", opts: map[string]string{OptCreateKafkaTopics: string(CreateKafkaTopicsBrokerAuto)}, expected: CreateKafkaTopicsBrokerAuto},
+		{name: "explicit", opts: map[string]string{OptCreateKafkaTopics: string(CreateKafkaTopicsExplicit)}, expected: CreateKafkaTopicsExplicit},
+		{name: "off", opts: map[string]string{OptCreateKafkaTopics: string(CreateKafkaTopicsOff)}, expected: CreateKafkaTopicsOff},
+		{name: "bare option means broker_auto", opts: map[string]string{OptCreateKafkaTopics: ""}, expected: CreateKafkaTopicsBrokerAuto},
+		{name: "invalid value rejected", opts: map[string]string{OptCreateKafkaTopics: "yes"}, expectedErr: "unknown create_kafka_topics: yes"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := MakeStatementOptions(tc.opts).GetCreateKafkaTopics()
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
this change adds `create_kafka_topics` option for `CREATE CHANGEFEED` statement. This commit only wires up the option surface and its parser

Part of: #155157

Release note: None