### PR TITLE
sql: short-circuit cascades and triggers when 0 rows affected

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2486,18 +2486,26 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 // Because cascades and triggers can themselves generate more cascades, check,
 // or trigger queries, this method can append to plan.cascades, plan.checkPlans,
 // and plan.triggers (and all these plans must be closed later).
-//
-// Returns false if an error was encountered and sets that error in the provided
-// receiver.
 func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 	ctx context.Context,
 	planner *planner,
 	evalCtxFactory func(usedConcurrently bool) *extendedEvalContext,
 	plan *planComponents,
 	recv *DistSQLReceiver,
-) bool {
-	if len(plan.cascades) == 0 && len(plan.checkPlans) == 0 && len(plan.triggers) == 0 {
-		return false
+) {
+	if len(plan.checkPlans) == 0 {
+		if len(plan.cascades) == 0 && len(plan.triggers) == 0 {
+			// We have no postqueries to run.
+			return
+		}
+		if rcr, ok := recv.resultWriter.(RestrictedCommandResult); ok && rcr.RowsAffected() == 0 {
+			// We have some cascades and / or row-level triggers, but the main
+			// query didn't modify any rows, meaning that cascades / row-level
+			// triggers would no-op, so we simply short-circuit their execution.
+			// TODO(#126362): once we support statement-level triggers, this
+			// might need to be adjusted.
+			return
+		}
 	}
 
 	prevSteppingMode := planner.Txn().ConfigureStepping(ctx, kv.SteppingEnabled)
@@ -2533,7 +2541,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 			// run as part of the same statement as the corresponding mutations.
 			if err := planner.Txn().Step(ctx, false /* allowReadTimestampStep */); err != nil {
 				recv.SetError(err)
-				return false
+				return
 			}
 
 			// The cascading query is allowed to autocommit only if it is the last
@@ -2555,7 +2563,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 				&plan.cascades[cascadesIdx], defaultGetSaveFlowsFunc,
 			)
 			if !ok {
-				return false
+				return
 			}
 			checksContainLocking = checksContainLocking || newChecksContainLocking
 		}
@@ -2578,7 +2586,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 			// part of the same statement as the corresponding mutations.
 			if err := planner.Txn().Step(ctx, false /* allowReadTimestampStep */); err != nil {
 				recv.SetError(err)
-				return false
+				return
 			}
 
 			// We'll run the checks in parallel if the parallelization is enabled, we have
@@ -2604,7 +2612,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 				checksToRun := plan.checkPlans[checksIdx:]
 				if err := dsp.planAndRunChecksInParallel(ctx, checksToRun, planner, evalCtxFactory, recv); err != nil {
 					recv.SetError(err)
-					return false
+					return
 				}
 			} else {
 				if (len(plan.checkPlans) - checksIdx) > 1 {
@@ -2624,7 +2632,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 						recv.stats.add,
 					); err != nil {
 						recv.SetError(err)
-						return false
+						return
 					}
 				}
 			}
@@ -2658,12 +2666,11 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 				&plan.triggers[triggersIdx], defaultGetSaveFlowsFunc,
 			)
 			if !ok {
-				return false
+				return
 			}
 			checksContainLocking = checksContainLocking || newChecksContainLocking
 		}
 	}
-	return true
 }
 
 // checkPostQueryBuffer checks whether the given post-query has an input buffer

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -821,6 +821,7 @@ CREATE TABLE delrng1 (
   data INT,
   FAMILY (p, data)
 );
+INSERT INTO delrng1 VALUES (1, 1), (15, 15);
 CREATE TABLE delrng2 (
   p INT,
   q INT,

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -1020,3 +1020,80 @@ Del (locking) /Table/120/1/1/0
 Del (locking) /Table/120/2/"foo"/"bar"/0
 
 subtest end
+
+# Cascades should be short-circuited if the main query didn't delete any rows.
+statement ok
+CREATE TABLE parent138975 (k INT PRIMARY KEY, v INT, INDEX(v));
+
+statement ok
+CREATE TABLE child138975 (k INT PRIMARY KEY, parent_k INT REFERENCES parent138975(k) ON DELETE CASCADE);
+
+query T
+EXPLAIN ANALYZE DELETE FROM parent138975 WHERE k >= 1 AND k <= 100;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+plan type: custom
+regions: <hidden>
+·
+• root
+│
+├── • delete
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ execution time: 0µs
+│   │ actual row count: 0
+│   │ from: parent138975
+│   │
+│   └── • scan
+│         sql nodes: <hidden>
+│         kv nodes: <hidden>
+│         regions: <hidden>
+│         KV time: 0µs
+│         KV rows decoded: 0
+│         actual row count: 0
+│         missing stats
+│         table: parent138975@parent138975_pkey
+│         spans: [/1 - /100]
+│         locking strength: for update
+│
+└── • fk-cascade
+      fk: child138975_parent_k_fkey
+      short-circuited
+
+# Same as above but using the delete-range operator.
+statement ok
+DROP TABLE child138975;
+
+statement ok
+DROP TABLE parent138975;
+
+statement ok
+CREATE TABLE parent138975 (k INT PRIMARY KEY);
+
+statement ok
+CREATE TABLE child138975 (k INT PRIMARY KEY, parent_k INT REFERENCES parent138975(k) ON DELETE CASCADE);
+
+query T
+EXPLAIN ANALYZE DELETE FROM parent138975 WHERE k >= 1 AND k <= 100;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+plan type: generic, re-optimized
+regions: <hidden>
+·
+• root
+│
+├── • delete range
+│     sql nodes: <hidden>
+│     regions: <hidden>
+│     execution time: 0µs
+│     actual row count: 0
+│     from: parent138975
+│     spans: [/1 - /100]
+│
+└── • fk-cascade
+      fk: child138975_parent_k_fkey
+      short-circuited


### PR DESCRIPTION
When the main mutation query doesn't modify any rows, cascades and row-level triggers are guaranteed to be no-ops. This commit skips their execution in `PlanAndRunPostQueries` in such a scenario.

Note that there is some risk of relying on RowsAffected - we've had bugs in the past around this statistic, and if we mistakenly report 0 rows affected, then now the impact would be much worse.

This commit also removes unused return parameter.

Fixes: #138975.
Release note: None