### PR TITLE
workload: disable import row count validation in fixture tests

### DIFF
--- a/pkg/workload/all/all_test.go
+++ b/pkg/workload/all/all_test.go
@@ -72,7 +72,13 @@ func runImportFixtureTest(
 		SQLMemoryPoolSize: sqlMemoryPoolSize,
 	})
 	defer s.Stopper().Stop(ctx)
-	sqlutils.MakeSQLRunner(db).Exec(t, `CREATE DATABASE d`)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	// This test validates workload import fixtures and then runs workload-specific
+	// consistency checks. IMPORT's INSPECT-backed row count validation is covered
+	// elsewhere, and sync validation can dominate this test under small
+	// metamorphic scan batch sizes.
+	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'off'`)
 
 	l := fixture.ImportDataLoader{}
 	if _, err := workloadsql.Setup(ctx, db, gen, l); err != nil {


### PR DESCRIPTION
TestImportFixture_TPCC can time out when the metamorphic import-row-count-validation setting selects sync mode. In that mode, each IMPORT waits for an INSPECT job to validate row counts. When combined with a small metamorphic default-batch-bytes-limit, those INSPECT scans can dominate the test runtime, especially under CI resource contention.

This test is meant to validate workload import fixtures and then run each workload's consistency hook. It is not intended to exercise IMPORT's INSPECT-backed row count validation, which has dedicated coverage elsewhere.

Set `bulkio.import.row_count_validation.mode = 'off'` for the workload import fixture test server before loading fixtures. This keeps the fixture coverage intact while avoiding redundant synchronous INSPECT work in this timeout-prone test path.

Epic: none
Fixes: #170810
Release note: None