### PR TITLE
sql/opt/xform: penalize TopK directly above a Lock

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -640,3 +640,55 @@ RESET optimizer_use_lock_op_for_serializable
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+subtest skip_locked_ordered_limit
+
+# Regression test: the optimizer used to pick TopK (or Sort) directly above a Lock
+# for "ORDER BY <unindexed col> LIMIT k FOR UPDATE SKIP LOCKED" queries. That
+# shape locks every input row only to discard all but k, which under SKIP
+# LOCKED starves concurrent sessions: with N eligible rows the first session
+# locks all N, and subsequent sessions skip all N and return zero rows. The
+# SortAboveLockPenalty in the coster pushes the Sort below the Lock so only
+# ~k rows are locked.
+
+statement ok
+CREATE TABLE skl (k INT PRIMARY KEY, v INT, FAMILY (k, v))
+
+statement ok
+GRANT ALL ON skl TO testuser
+
+statement ok
+INSERT INTO skl VALUES (1, 1), (2, 2), (3, 3), (4, 4)
+
+user testuser
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+# Session A locks the smallest-v row. If the planner had picked Sort/TopK
+# above Lock, all four rows would be locked here, starving session B.
+query I
+SELECT k FROM skl WHERE v > 0 ORDER BY v LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+1
+
+user root
+
+# Session B runs concurrently (session A's txn is still open). It must see
+# the next row, not zero rows.
+query I
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT k FROM skl WHERE v > 0 ORDER BY v LIMIT 1 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+2
+
+user testuser
+
+statement ok
+COMMIT
+
+user root
+
+statement ok
+DROP TABLE skl

--- a/pkg/sql/opt/memo/cost.go
+++ b/pkg/sql/opt/memo/cost.go
@@ -36,7 +36,7 @@ type Cost struct {
 // member will have a lower cost.
 var MaxCost = Cost{
 	C:         math.Inf(+1),
-	Penalties: HugeCostPenalty | FullScanPenalty | PlanGramMismatchPenalty | UnboundedCardinalityPenalty,
+	Penalties: HugeCostPenalty | FullScanPenalty | PlanGramMismatchPenalty | UnboundedCardinalityPenalty | TopKAboveLockPenalty,
 }
 
 // Less returns true if this cost is lower than the given cost.
@@ -115,6 +115,19 @@ const (
 	// can produce. See props.AnyCardinality.
 	UnboundedCardinalityPenalty
 
+	// TopKAboveLockPenalty is true if the plan matches one of two shapes:
+	// TopK directly above a Lock, or Limit above Sort directly above a Lock.
+	// Both shapes force the Lock to process (and lock) every row produced by
+	// its input, even when only K rows are needed. Beyond wasted locking work,
+	// this under SKIP LOCKED starves concurrent sessions: rows that would have
+	// been emitted by an alternative plan are needlessly locked here and then
+	// skipped by other sessions, which can return fewer rows than they should.
+	//
+	// The preferred alternative places the Sort below the Lock (via the
+	// Lock's passthrough of input-ordering requirements), with a streaming
+	// Limit above the Lock, so only ~K rows are actually locked.
+	TopKAboveLockPenalty
+
 	// NoPenalties represents no penalties.
 	NoPenalties Penalties = 0
 )
@@ -126,9 +139,9 @@ const (
 // Where:
 //
 //	<Cost> is the floating point cost value.
-//	<Penalties> contains "H", "F", "P", or "U" for HugeCostPenalty,
-//	  FullScanPenalty, PlanGramMismatchPenalty, and
-//	  UnboundedCardinalityPenalty, respectively.
+//	<Penalties> contains "H", "F", "P", "U", or "T" for HugeCostPenalty,
+//	  FullScanPenalty, PlanGramMismatchPenalty,
+//	  UnboundedCardinalityPenalty, and TopKAboveLockPenalty, respectively.
 //	<aux> contains the number of full scans and unbounded reads.
 //
 // For example, the summary "1.23:HF:5f6u" indicates a cost of 1.23 with the
@@ -148,6 +161,9 @@ func (c Cost) Summary() string {
 	}
 	if c.Penalties&UnboundedCardinalityPenalty != 0 {
 		sb.WriteByte('U')
+	}
+	if c.Penalties&TopKAboveLockPenalty != 0 {
+		sb.WriteByte('T')
 	}
 	_, _ = fmt.Fprintf(&sb, ":%df", c.aux.fullScanCount)
 	_, _ = fmt.Fprintf(&sb, "%du", c.aux.unboundedReadCount)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -939,6 +939,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if cost.Penalties&UnboundedCardinalityPenalty != 0 {
 				b.WriteString(" unbounded-cardinality")
 			}
+			if cost.Penalties&TopKAboveLockPenalty != 0 {
+				b.WriteString(" topk-above-lock")
+			}
 			tp.Child(b.String())
 		}
 	}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -717,6 +717,11 @@ func (c *coster) computeTopKCost(topk *memo.TopKExpr, required *physical.Require
 	// TODO(harding): Add the CPU cost of emitting the K output rows. This should
 	// be done in conjunction with computeSortCost.
 
+	// Penalize TopK directly above a Lock — see TopKAboveLockPenalty for why.
+	if topk.Input.Op() == opt.LockOp {
+		cost.Penalties |= memo.TopKAboveLockPenalty
+	}
+
 	return cost
 }
 
@@ -762,6 +767,15 @@ func (c *coster) computeSortCost(sort *memo.SortExpr, required *physical.Require
 	cost.C += c.rowCmpCost(numKeyCols-numPreorderedCols).C * numCmpOpsPerRow * stats.RowCount
 	// TODO(harding): Add the CPU cost of emitting the output rows. This should be
 	// done in conjunction with computeTopKCost.
+
+	// Penalize a Sort enforcer directly above a Lock when there is a limit
+	// hint flowing down — i.e. Limit -> Sort -> Lock. Without a limit above,
+	// all rows have to flow through anyway and there is no better alternative.
+	// See TopKAboveLockPenalty.
+	if required.LimitHint > 0 && sort.Input.Op() == opt.LockOp {
+		cost.Penalties |= memo.TopKAboveLockPenalty
+	}
+
 	return cost
 }
 

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -579,6 +579,60 @@ limit
  │         └── limit hint: 5.00
  └── 5
 
+# Regression test: when SKIP LOCKED is combined with ORDER BY on a non-indexed
+# column, the optimizer must not pick a TopK (or Sort) above the Lock. Either
+# shape locks every row produced by the Lock's input only to discard all but
+# K, which under SKIP LOCKED also starves concurrent sessions (they see the
+# discarded rows as locked and skip them, returning fewer rows than they
+# should). The preferred plan places the Sort below the Lock with a Limit
+# above, so only ~K rows are locked. The SortAboveLockPenalty in the coster
+# steers the optimizer away from the bad shape.
+exec-ddl
+CREATE TABLE skl (k INT PRIMARY KEY, v INT)
+----
+
+opt set=optimizer_use_lock_op_for_serializable=true
+SELECT k FROM skl WHERE v > 0 ORDER BY v LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+limit
+ ├── columns: k:1!null  [hidden: v:2!null]
+ ├── internal-ordering: +2
+ ├── cardinality: [0 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── lock skl
+ │    ├── columns: k:1!null v:2!null
+ │    ├── key columns: k:1
+ │    ├── lock columns: (5,6)
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: +2
+ │    ├── limit hint: 1.00
+ │    └── sort
+ │         ├── columns: k:1!null v:2!null
+ │         ├── volatile
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2)
+ │         ├── ordering: +2
+ │         ├── limit hint: 1.00
+ │         └── select
+ │              ├── columns: k:1!null v:2!null
+ │              ├── volatile
+ │              ├── key: (1)
+ │              ├── fd: (1)-->(2)
+ │              ├── scan skl
+ │              │    ├── columns: k:1!null v:2
+ │              │    ├── locking: none,skip-locked
+ │              │    ├── volatile
+ │              │    ├── key: (1)
+ │              │    └── fd: (1)-->(2)
+ │              └── filters
+ │                   └── v:2 > 0 [outer=(2), constraints=(/2: [/1 - ]; tight)]
+ └── 1
+
 exec-ddl
 CREATE TABLE abcd (
   a INT PRIMARY KEY,


### PR DESCRIPTION
Add TopKAboveLockPenalty and apply it in the coster for TopK and Limit+Sort operators whose direct input is a Lock. This shape locks every row produced by the Lock's input only to discard all but K. Under SKIP LOCKED it also starves concurrent sessions: the discarded rows are already locked, so other sessions skip them and can return fewer rows than they should. With the penalty, the optimizer instead places the Sort below the Lock with a Limit above, so only ~K rows are locked.

Note that for Lock operators without SKIP LOCKED, PushLimitIntoLock should have already fired and moved the Limit into the Lock's input.

Informs #121917

Release note (bug fix): Fixed a planner issue where "ORDER BY <unindexed col> LIMIT k FOR UPDATE SKIP LOCKED" could lock all input rows and cause concurrent sessions to return fewer rows than expected. The optimizer now places the sort below the lock so only ~k rows are locked.