### PR TITLE
backup: stop populating RestoreDetails.TableDescs in planning

### DIFF
--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -2350,17 +2350,11 @@ func doRestorePlan(
 		return errors.Wrapf(err, "function descriptor rewrite failed")
 	}
 
-	encodedTables := make([]*descpb.TableDescriptor, len(tables))
-	for i, table := range tables {
-		encodedTables[i] = table.TableDesc()
-	}
-
 	restoreDetails := jobspb.RestoreDetails{
 		EndTime:            endTime,
 		DescriptorRewrites: descriptorRewrites,
 		URIs:               defaultURIs,
 		BackupLocalityInfo: localityInfo,
-		TableDescs:         encodedTables,
 		Tenants:            tenants,
 		OverrideDB:         overrideDBName,
 		DescriptorCoverage: restoreStmt.DescriptorCoverage,


### PR DESCRIPTION
The restore resumer reconstructs `details.TableDescs` in `createImportingDescriptors` before any code reads the field, so the planning-time population is dead weight. At ~1 KB per table, it inflates the initial `system.job_info` row past the 64 MiB raft command limit at ~100k descriptors, blocking RESTORE at job creation.

Follow-up work will address the same writeback in the resumer.

Informs: #170669

Release note: None

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>