### PR TITLE
ui: make Metrics page charts responsive to viewport width

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/visualization/visualizations.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/visualization/visualizations.module.scss
@@ -6,7 +6,9 @@
 @import "src/core/index.module";
 
 .visualization {
-  width: fit-content;
+  // Fill the flex/grid slot so the chart inside can resize down on
+  // narrow viewports.
+  width: 100%;
   position: relative;
   background-color: #fff;
   color: $headings-color;
@@ -26,8 +28,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  // These are the dimensions of the linegraph.
-  min-width: 947px;
+  // Reserve vertical space for the spinner so layout doesn't shift on load.
   min-height: 300px;
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -277,6 +277,26 @@ export function InternalLineGraph({
     };
   }, []);
 
+  // Resize uPlot when its container changes size. The !!data dependency
+  // attaches the observer once data arrives and Visualization renders
+  // children (until then, the el ref is unattached).
+  useEffect(() => {
+    const container = el.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(entries => {
+      const u = uRef.current;
+      if (!u) return;
+      const width = entries[0]?.contentRect.width;
+      if (width && width > 0) {
+        u.setSize({ width, height: 300 });
+      }
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [!!data]);
+
   // Update chart when data, time info, or display dependencies change.
   // prevDataRef is still needed because the effect uses previous data to
   // compute prior series keys (deciding whether to setData() on the
@@ -341,6 +361,7 @@ export function InternalLineGraph({
       // Updates existing plot with new points.
       uRef.current.setData(uPlotData);
     } else {
+      const initialWidth = el.current?.clientWidth || 947;
       const options = configureUPlotLineChart(
         metricElements,
         axisElement,
@@ -348,6 +369,7 @@ export function InternalLineGraph({
         setNewTimeRange,
         () => xAxisDomainRef.current,
         () => yAxisDomainRef.current,
+        initialWidth,
       );
 
       if (uRef.current) {

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -209,6 +209,9 @@ export function configureUPlotLineChart(
   setMetricsFixedWindow: (startMillis: number, endMillis: number) => void,
   getLatestXAxisDomain: () => AxisDomain,
   getLatestYAxisDomain: () => AxisDomain,
+  // Pass the container's current width; subsequent resizes should be
+  // driven via uPlot.setSize().
+  initialWidth?: number,
 ): uPlot.Options {
   const formattedRaw = formatMetricData(metrics, data);
   // Copy palette over since we mutate it in the `series` function
@@ -224,7 +227,7 @@ export function configureUPlotLineChart(
   // Please see https://github.com/leeoniya/uPlot/tree/master/docs for
   // information on how to construct this object.
   return {
-    width: 947,
+    width: initialWidth ?? 947,
     height: 300,
     cursor: {
       lock: true,


### PR DESCRIPTION
uPlot charts on the Metrics page were hardcoded to 947px wide and .visualization used width: fit-content, so the right-hand Summary panel was clipped on viewports narrower than ~1350px (e.g. 13" MacBook Pro at default Retina scaling). No scrollbar appeared because the layout panel uses overflow: hidden.

Replace the fixed width with the container's actual clientWidth at chart creation time, add a ResizeObserver to call uPlot.setSize() on resize, and switch .visualization to width: 100%. Remove the hardcoded min-width: 947px from the loading spinner wrapper.

bars.ts (BarGraph component) has the same hardcoded width; left as a follow-up to keep this PR scoped to the reported Metrics page bug.

<img width="1558" height="986" alt="image" src="https://github.com/user-attachments/assets/b6ed1242-39ec-4a36-a004-547942396e84" />

Fixes: #170975
Epic: CRDB-64261

Release note (ui change): Fixed a bug on the DB Console Metrics page where the Summary panel was clipped on viewports narrower than ~1350px. Charts now resize to fit the available width.