### PR TITLE
drt: resume paused import jobs after disk-fill cleanup

### DIFF
--- a/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
@@ -40,6 +40,7 @@ do
   # Create the workload script
   cat <<EOF >/tmp/tpcc_drop.sh
 #!/usr/bin/env bash
+set -o pipefail
 
 read -r -a PGURLS_ARR <<< "$PGURLS"
 
@@ -68,13 +69,18 @@ while true; do
         --concurrency 4 \
         --db cct_tpcc_drop \
         "$PG_URL_N1" | tee "\$INIT_LOG"
-    if [ \$? -eq 0 ]; then
-        rm "\$INIT_LOG"
+    if [ \$? -ne 0 ]; then
+        sleep 20
+        echo ">> tpcc import failed, skipping workload run and retrying"
+        ./cockroach sql --url "${PG_URL_N1}" -e "DROP DATABASE IF EXISTS cct_tpcc_drop CASCADE;"
+        sleep 3600
+        continue
     fi
+    rm "\$INIT_LOG"
     echo ">> Dropping cct_tpcc_drop_old if it exists"
     ./cockroach sql --url "${PG_URL_N1}" -e "DROP DATABASE cct_tpcc_drop_old CASCADE;"
     sleep 5
-    echo ">> Starting tpcc workload for 1h"
+    echo ">> Starting tpcc workload for 24h"
     ./cockroach workload run tpcc \
         --warehouses 3000 \
         --active-warehouses 1000 \

--- a/pkg/cmd/roachtest/operations/disk_fill.go
+++ b/pkg/cmd/roachtest/operations/disk_fill.go
@@ -64,6 +64,39 @@ func removeFillFiles(
 	}
 }
 
+// maybeResumePausedImportJobs resumes any IMPORT jobs that were paused due to
+// insufficient disk capacity during the fill period.
+func maybeResumePausedImportJobs(
+	ctx context.Context, o operation.Operation, c cluster.Cluster, nodeID int,
+) {
+	db, err := c.ConnE(ctx, o.L(), nodeID)
+	if err != nil {
+		o.Errorf("failed to connect to node %d to resume imports: %v", nodeID, err)
+		return
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRowContext(ctx,
+		"SELECT count(*) FROM [SHOW JOBS] WHERE status = 'paused' AND job_type = 'IMPORT'",
+	).Scan(&count); err != nil {
+		o.Errorf("failed to check for paused import jobs: %v", err)
+		return
+	}
+	if count == 0 {
+		return
+	}
+
+	o.Status(fmt.Sprintf("resuming %d paused import job(s)", count))
+	if _, err := db.ExecContext(ctx,
+		"RESUME JOBS (WITH x AS (SHOW JOBS) SELECT job_id FROM x WHERE status = 'paused' AND job_type = 'IMPORT')",
+	); err != nil {
+		o.Errorf("failed to resume paused import jobs: %v", err)
+		return
+	}
+	o.Status(fmt.Sprintf("resumed %d paused import job(s)", count))
+}
+
 type cleanupDiskFill struct {
 	node       option.NodeListOption
 	storeCount int
@@ -81,6 +114,7 @@ func (cl *cleanupDiskFill) Cleanup(ctx context.Context, o operation.Operation, c
 	// resolves on its own once the fill files are removed.
 	if helpers.CheckNodeHealth(ctx, o, c, cl.node[0], 5 /* maxAttempts */, 5*time.Second) {
 		o.Status(fmt.Sprintf("node %s healthy after cleanup", cl.node.NodeIDsString()))
+		maybeResumePausedImportJobs(ctx, o, c, cl.node[0])
 		return
 	}
 
@@ -101,6 +135,7 @@ func (cl *cleanupDiskFill) Cleanup(ctx context.Context, o operation.Operation, c
 		return
 	}
 	o.Status(fmt.Sprintf("node %d healthy after restart", cl.node[0]))
+	maybeResumePausedImportJobs(ctx, o, c, cl.node[0])
 }
 
 // fillStores creates ballast files on each store of the target node,


### PR DESCRIPTION
## Summary

- During DRT runs, the `disk-fill/ood` operation can reduce free disk space below
  the 5% ingestion threshold while a TPC-C import is concurrently running. This
  causes CockroachDB to auto-pause the IMPORT jobs, leaving tables stuck in OFFLINE
  state indefinitely. Other operations (e.g. `inspect/database`) that later encounter
  these offline tables panic because they call `o.Fatal()` on the "relation is offline:
  importing" error.
- This was observed on `drt-chaos-aws` where 4 IMPORT jobs were paused for 22 hours
  until manual cancellation.
- **disk_fill.go**: During cleanup, after removing ballast files and confirming node
  health, resume any IMPORT jobs that were paused due to the disk pressure.
- **generate_tpcc_drop.sh**: When `workload init tpcc` fails (exit code 1), skip the
  workload run, drop the partially-created database to clean up offline tables, and
  retry the import.

Epic: none

Release note: None