### PR TITLE
lease: return initial versions from RegisterLeaseObserver

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -2175,8 +2175,9 @@ func TestAlterChangefeedAddTargetsDuringSchemaChangeBackfill(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// Set verbose log to confirm whether or not we hit the same nil row issue as in #140669
-	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2")
+	// Set verbose log to confirm whether or not we hit the same nil row issue
+	// as in #140669; schema_feed=2 logs descriptor-version transitions.
+	testutils.SetVModule(t, "kv_feed=2,changefeed_processors=2,schema_feed=2")
 
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3171,6 +3171,7 @@ WITH resolved='50ms', min_checkpoint_frequency='50ms', no_initial_scan, cursor=$
 func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	testutils.SetVModule(t, "schema_feed=2")
 
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -25,8 +25,8 @@ import (
 func TestChangefeedNemeses(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 169820, "failing due to release blocker")
 	skip.UnderRace(t, "takes >1 min under race")
+	testutils.SetVModule(t, "schema_feed=2")
 
 	testutils.RunValues(t, "nemeses_options=", cdctest.NemesesOptions, func(t *testing.T, nop cdctest.NemesesOption) {
 		testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -64,7 +64,7 @@ type leaseAcquirer interface {
 	AcquireFreshestFromStore(ctx context.Context, id descpb.ID) error
 	// TODO(yang): Investigate whether the codec can be stored in the schema feed itself.
 	Codec() keys.SQLCodec
-	RegisterLeaseObserver(observer lease.Observer) (unregisterFn func())
+	RegisterLeaseObserver(observer lease.Observer, ids []descpb.ID) (initialVersions map[descpb.ID]descpb.DescriptorVersion, unregisterFn func())
 }
 
 // SchemaFeed is a stream of events corresponding the relevant set of
@@ -282,7 +282,12 @@ func (tf *schemaFeed) Run(ctx context.Context) error {
 		return err
 	}
 
-	unregisterFn := tf.leaseMgr.RegisterLeaseObserver(tf)
+	targetIDs := make([]descpb.ID, 0, tf.targets.NumUniqueTables())
+	_ = tf.targets.EachTableID(func(id descpb.ID) error {
+		targetIDs = append(targetIDs, id)
+		return nil
+	})
+	initialVersions, unregisterFn := tf.leaseMgr.RegisterLeaseObserver(tf, targetIDs)
 	// Make sure the observer unregisters before trying to release leases.
 	defer func() {
 		tf.mu.Lock()
@@ -299,6 +304,21 @@ func (tf *schemaFeed) Run(ctx context.Context) error {
 		tf.mu.staleLeases = false
 	}()
 	defer unregisterFn()
+
+	// Seed each target's latestVersion from the snapshot the lease manager
+	// returned at registration time. Without this, a descriptor version that
+	// had already been broadcast before we registered would be invisible to
+	// us (maybeAddObserverEvent dedups re-broadcasts), and we would happily
+	// store a stale lease on the next Acquire. See #169820.
+	func() {
+		tf.mu.Lock()
+		defer tf.mu.Unlock()
+		for id, v := range initialVersions {
+			if ld, ok := tf.mu.heldLeases[id]; ok && v > ld.latestVersion {
+				ld.latestVersion = v
+			}
+		}
+	}()
 
 	// Fetch the table descs as of the initial frontier and prime the table
 	// history with them. This addresses #41694 where we'd skip the rest of a
@@ -557,6 +577,7 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 			// version could not have changed.
 			heldLease := tf.mu.heldLeases[id]
 			if heldLease.leasedDescriptor == nil {
+				prevLatest := heldLease.latestVersion // captured for V(2) log below
 				// Otherwise, a new version was detected, so acquire it at advanceTo.
 				newLease, err := tf.leaseMgr.Acquire(ctx, lease.TimestampToReadTimestamp(advanceTo), id)
 				if err != nil {
@@ -566,7 +587,11 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 				if newLease.Underlying().GetVersion() >= heldLease.latestVersion {
 					heldLease.latestVersion = newLease.Underlying().GetVersion()
 					tf.mu.heldLeases[id].leasedDescriptor = newLease
+					log.VEventf(ctx, 2, "schemafeed pauseOrResumePolling id=%d: acquired and stored lease version=%d (prevLatest=%d)",
+						id, newLease.Underlying().GetVersion(), prevLatest)
 				} else {
+					log.VEventf(ctx, 2, "schemafeed pauseOrResumePolling id=%d: acquired version=%d but latestVersion=%d is newer; releasing",
+						id, newLease.Underlying().GetVersion(), heldLease.latestVersion)
 					// The latest observed version was not picked up yet.
 					newLease.Release(ctx)
 				}
@@ -1009,10 +1034,16 @@ func (tf *schemaFeed) OnNewVersion(
 		return
 	}
 	// Check if the new version is greater than the latest version we know
-	// about.
+	// about. The initial version snapshot returned by RegisterLeaseObserver
+	// already covers anything broadcast before we registered, so a stale
+	// notification at startup is a no-op here.
 	if ld.latestVersion >= version {
+		log.VEventf(ctx, 2, "schemafeed OnNewVersion id=%d version=%d: already at latestVersion=%d, no-op",
+			id, version, ld.latestVersion)
 		return
 	}
+	prevVersion := ld.latestVersion
+	hadLease := ld.leasedDescriptor != nil
 	ld.latestVersion = version
 	tf.mu.staleLeases = true
 	tf.mu.pollingPaused = false
@@ -1021,6 +1052,8 @@ func (tf *schemaFeed) OnNewVersion(
 		ld.leasedDescriptor.Release(ctx)
 		ld.leasedDescriptor = nil
 	}
+	log.VEventf(ctx, 2, "schemafeed OnNewVersion id=%d: advanced latestVersion %d->%d, releasedLease=%v",
+		id, prevVersion, version, hadLease)
 }
 
 type doNothingSchemaFeed struct{}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -375,9 +375,11 @@ func (t *testLeaseAcquirer) Codec() keys.SQLCodec {
 	panic("should not be called")
 }
 
-func (t *testLeaseAcquirer) RegisterLeaseObserver(observer lease.Observer) (unregisterFn func()) {
+func (t *testLeaseAcquirer) RegisterLeaseObserver(
+	observer lease.Observer, _ []descpb.ID,
+) (initialVersions map[descpb.ID]descpb.DescriptorVersion, unregisterFn func()) {
 	t.observers = append(t.observers, observer)
-	return func() {
+	return nil, func() {
 		t.unregisterLeaseObserver(observer)
 	}
 }
@@ -498,7 +500,7 @@ func TestPauseOrResumePolling(t *testing.T) {
 		targets:  CreateChangefeedTargets(tableID),
 	}
 	sf.testingInitSchemaFeed()
-	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	_, unregisterFn := lm.RegisterLeaseObserver(&sf, nil)
 	defer unregisterFn()
 
 	getFrontier := func() hlc.Timestamp {
@@ -612,7 +614,7 @@ func TestPauseOrResumePollingAdvancesToNow(t *testing.T) {
 		targets:  CreateChangefeedTargets(tableID),
 	}
 	sf.testingInitSchemaFeed()
-	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	_, unregisterFn := lm.RegisterLeaseObserver(&sf, nil)
 	defer unregisterFn()
 
 	getFrontier := func() hlc.Timestamp {
@@ -680,7 +682,7 @@ func BenchmarkPauseOrResumePolling(b *testing.B) {
 		targets:  CreateChangefeedTargets(tableID),
 	}
 	sf.testingInitSchemaFeed()
-	unregisterFn := lm.RegisterLeaseObserver(&sf)
+	_, unregisterFn := lm.RegisterLeaseObserver(&sf, nil)
 	defer unregisterFn()
 
 	setFrontier := func(ts hlc.Timestamp) error {

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -4634,7 +4634,7 @@ func TestObserverNotificationFromRangefeed(t *testing.T) {
 		lease:     ld,
 		startTime: nodes.Server(1).Clock().Now(),
 	}
-	_ = lm1.RegisterLeaseObserver(obs)
+	_, _ = lm1.RegisterLeaseObserver(obs, []descpb.ID{tableID})
 	// Run schema change on Node 0 in a goroutine because it will block
 	// on the two-version invariant waiting for Node 1 to release version 1.
 	errCh := make(chan error, 1)

--- a/pkg/sql/catalog/lease/observer.go
+++ b/pkg/sql/catalog/lease/observer.go
@@ -12,17 +12,34 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-// Observer is an interface that allows observers to be notified of new
-// versions of descriptors.
+// Observer is notified of new descriptor versions. Versions for a single
+// descriptor are delivered in strictly increasing order. State that existed
+// before registration is returned from Manager.RegisterLeaseObserver instead
+// of being replayed through OnNewVersion.
 type Observer interface {
-	// OnNewVersion Invoked when a new version of a descriptor becomes available.
+	// OnNewVersion is invoked when a new version of a descriptor becomes
+	// available.
 	OnNewVersion(ctx context.Context, descID descpb.ID, newVersion descpb.DescriptorVersion, modificationTime hlc.Timestamp)
 }
 
-// RegisterLeaseObserver registers an observer. An unregisterFn is returned
-// to remove this observer. Note: Observers are buffered, pending events may
-// still fire after unregistering.
-func (m *Manager) RegisterLeaseObserver(observer Observer) (unregisterFn func()) {
+// RegisterLeaseObserver registers an observer and, for each descriptor in
+// ids, returns the most recently notified version that the lease manager
+// knows about. The snapshot is taken atomically with adding the observer to
+// the broadcast list, so a freshly registered observer can detect that a
+// lease it already holds is stale without relying on a re-broadcast that
+// the per-descriptor dedup in maybeAddObserverEvent would otherwise
+// suppress.
+//
+// The returned map only contains entries for descriptors that the lease
+// manager has tracked and broadcast at least once; absent ids mean "no
+// prior broadcast for this descriptor, you'll see future versions via
+// OnNewVersion". Pass nil for ids to skip the snapshot entirely.
+//
+// An unregisterFn is returned to remove the observer. Note: events queued
+// before unregister may still fire afterward.
+func (m *Manager) RegisterLeaseObserver(
+	observer Observer, ids []descpb.ID,
+) (initialVersions map[descpb.ID]descpb.DescriptorVersion, unregisterFn func()) {
 	// Writers will need mutual exclusion to avoid clobbering.
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -36,7 +53,22 @@ func (m *Manager) RegisterLeaseObserver(observer Observer) (unregisterFn func())
 	}
 	newObservers = append(newObservers, observer)
 	m.mu.observers.Store(&newObservers)
-	return func() {
+	if len(ids) > 0 {
+		initialVersions = make(map[descpb.ID]descpb.DescriptorVersion, len(ids))
+		for _, id := range ids {
+			t, ok := m.mu.descriptors[id]
+			if !ok {
+				continue
+			}
+			t.mu.Lock()
+			v := t.mu.maxVersionNotified
+			t.mu.Unlock()
+			if v > 0 {
+				initialVersions[id] = v
+			}
+		}
+	}
+	return initialVersions, func() {
 		m.unregisterLeaseObserver(observer)
 	}
 }

--- a/pkg/sql/catalog/lease/observer_test.go
+++ b/pkg/sql/catalog/lease/observer_test.go
@@ -57,7 +57,7 @@ func TestLeaseObserver(t *testing.T) {
 		targetID: tableID,
 	}
 	lm := server.LeaseManager().(*lease.Manager)
-	unregisterFn := lm.RegisterLeaseObserver(obs)
+	_, unregisterFn := lm.RegisterLeaseObserver(obs, []descpb.ID{tableID})
 
 	// Trigger initial acquisition on node 0.
 	sqlRunner.Exec(t, "SELECT * FROM t")
@@ -147,4 +147,80 @@ func TestLeaseObserver(t *testing.T) {
 	// No new events should be see.
 	require.Equal(t, numEvents, obs.numEvents.Load())
 	require.NoError(t, grp.Wait())
+}
+
+// TestRegisterLeaseObserverReturnsInitialVersions verifies that an observer
+// registered after a descriptor version has already been broadcast learns
+// about that version from the map returned by RegisterLeaseObserver, rather
+// than depending on a re-broadcast that would be suppressed by the
+// per-descriptor dedup in maybeAddObserverEvent. Regression test for #169820.
+func TestRegisterLeaseObserverReturnsInitialVersions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	server, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer server.Stopper().Stop(ctx)
+
+	sqlRunner := sqlutils.MakeSQLRunner(db)
+	sqlRunner.Exec(t, "CREATE TABLE t (k INT PRIMARY KEY)")
+	var tableID descpb.ID
+	sqlRunner.QueryRow(t, "SELECT 't'::regclass::int").Scan(&tableID)
+
+	lm := server.LeaseManager().(*lease.Manager)
+
+	// Register a first observer as a synchronization point: it lets us
+	// wait until the lease manager has actually broadcast new versions of
+	// the table descriptor (via maybeAddObserverEvent), so that
+	// maxVersionNotified is non-trivial when we register the second
+	// observer below.
+	firstObserver := &testObserver{
+		notified: make(chan descpb.DescriptorVersion, 100),
+		targetID: tableID,
+	}
+	_, firstObserverUnreg := lm.RegisterLeaseObserver(firstObserver, []descpb.ID{tableID})
+
+	// Trigger acquisition (so the descriptor is known to the lease
+	// manager) and then run schema changes so the broadcast version is
+	// strictly greater than 1.
+	sqlRunner.Exec(t, "SELECT * FROM t")
+	sqlRunner.Exec(t, "ALTER TABLE t ADD COLUMN v INT")
+	sqlRunner.Exec(t, "ALTER TABLE t ADD COLUMN w INT")
+
+	var maxSeen descpb.DescriptorVersion
+	testutils.SucceedsSoon(t, func() error {
+		for {
+			select {
+			case v := <-firstObserver.notified:
+				if v > maxSeen {
+					maxSeen = v
+				}
+			default:
+				if maxSeen >= 2 {
+					return nil
+				}
+				return errors.Newf("first observer has only seen version %d so far", maxSeen)
+			}
+		}
+	})
+	firstObserverUnreg()
+
+	// Register a second observer. The returned map must include our
+	// table at a version at least as high as what the first observer
+	// saw. No OnNewVersion plumbing needed: the snapshot is captured
+	// atomically with subscription inside RegisterLeaseObserver.
+	lateObserver := &testObserver{
+		notified: make(chan descpb.DescriptorVersion, 100),
+		targetID: tableID,
+	}
+	initial, lateObserverUnreg := lm.RegisterLeaseObserver(lateObserver, []descpb.ID{tableID})
+	defer lateObserverUnreg()
+
+	v, ok := initial[tableID]
+	require.True(t, ok, "expected descriptor %d in initialVersions, got %v", tableID, initial)
+	require.GreaterOrEqual(t, v, maxSeen,
+		"initial version for %d was %d, expected >= %d", tableID, v, maxSeen)
+	// initialVersions should never include the zero version sentinel.
+	for id, ver := range initial {
+		require.NotZero(t, ver, "initialVersions[%d] is zero", id)
+	}
 }


### PR DESCRIPTION
A lease.Observer registered after a descriptor version had already been broadcast would never learn about that version, because the lease manager dedups re-broadcasts per descriptor. In CDC, this caused a schemafeed restart to hold a stale lease forever and block subsequent schema changes on the watched table.

RegisterLeaseObserver now returns a snapshot of the most recently notified version for each requested descriptor, captured atomically with subscription. The schemafeed seeds its per-target state from that snapshot so its existing post-Acquire staleness check rejects a cached older lease.

Also adds V(2) diagnostics to the schemafeed and re-enables TestChangefeedNemeses, which had been skipped pending this fix.

Fixes #169820
Fixes #169505

Release note: none

Epic: none