### PR TITLE
scripts: improve trigger-pr-roachtest.sh

### DIFF
--- a/scripts/trigger-pr-roachtest.sh
+++ b/scripts/trigger-pr-roachtest.sh
@@ -13,6 +13,16 @@ if [ -z $token ]; then
 TEAMCITY_TOKEN not set. Get one here:
 
 https://teamcity.cockroachdb.com/profile.html?item=accessTokens
+
+Usage: $0 <pr-number-or-branch> <test-regex> [sha]
+
+Examples:
+  $0 12345 'perturbation/full/intents'
+  $0 my-branch-name 'kv/splits.*' a1b2c3d4
+
+Note: PR numbers work for all cases (recommended). Branch names only work
+for branches pushed directly to cockroachdb/cockroach, not personal forks.
+For fork branches, use the PR number instead.
 EOF
   exit 1
 fi
@@ -20,7 +30,7 @@ fi
 pr=${1-}
 
 while [ -z $pr ]; do
-  read -p 'PR number (defaults to first arg, can also use branch name): ' pr
+  read -p 'PR number or branch name (PR number recommended): ' pr
 done
 
 tests=${2-}

--- a/scripts/trigger-pr-roachtest.sh
+++ b/scripts/trigger-pr-roachtest.sh
@@ -23,6 +23,14 @@ Examples:
 Note: PR numbers work for all cases (recommended). Branch names only work
 for branches pushed directly to cockroachdb/cockroach, not personal forks.
 For fork branches, use the PR number instead.
+
+Environment variables:
+  COUNT     - number of test iterations (default: 1)
+  DEBUG     - enable debug mode (default: false)
+  USE_SPOT  - use spot VMs: never, auto, always (default: never)
+              The "auto" default in nightly scripts uses spot for the
+              first attempt, which causes preemptions on single-iteration
+              PR-triggered runs. Override here defaults to "never".
 EOF
   exit 1
 fi
@@ -60,6 +68,7 @@ json_payload=$(jq -n \
   --arg tests "$tests" \
   --arg envDebug "${DEBUG-false}" \
   --arg envCount "${COUNT-1}" \
+  --arg envUseSpot "${USE_SPOT-never}" \
   '{
   buildType: {id: "Cockroach_Nightlies_RoachtestNightlyGceBazel"},
   branchName: $branch_name,
@@ -70,7 +79,8 @@ json_payload=$(jq -n \
       {name: "env.SELECT_PROBABILITY", value: "1.0"},
       {name: "env.DEBUG", value: $envDebug},
       {name: "env.COUNT", value: $envCount},
-      {name: "env.TESTS", value: $tests}
+      {name: "env.TESTS", value: $tests},
+      {name: "env.USE_SPOT", value: $envUseSpot}
     ]
   }
 }')


### PR DESCRIPTION
Two small improvements to `scripts/trigger-pr-roachtest.sh`:

1. **Better help text**: Clarify that PR numbers are recommended over branch names. Branch names only work for branches pushed directly to `cockroachdb/cockroach`, not personal forks. Triggering by branch name from a fork results in TeamCity reporting "branch does not correspond to any branch monitored by the build VCS roots" and the test being ignored.

2. **Default `USE_SPOT=never`**: The nightly TeamCity script (`perturbation_nightly_metamorphic_impl.sh` and `roachtest_nightly_impl.sh`) invokes roachtest with `--use-spot="${USE_SPOT:-auto}"`. The `auto` mode uses spot VMs for the first attempt, falling back to non-spot if the test fails due to preemption. This works well for the nightly run (COUNT>1) where the fallback recovers preempted tests.

   PR-triggered runs typically use COUNT=1, so there is no second attempt and every spot preemption surfaces as a test failure. The triggered build's report shows "VMs preempted during the test run" rather than real test results, making it impossible to evaluate the change. Default `USE_SPOT` to `"never"` so PR-triggered runs get real (non-spot) VMs. Callers who want the legacy behavior can still set `USE_SPOT=auto` explicitly.

## Motivation

Both findings came out of trying to validate #170724 (re-enabling perturbation/full tests). The first two attempts saw 5/6 tests fail with VM preemptions, masking the actual test behavior. Once `USE_SPOT=never` was set, 5/6 tests passed cleanly. See the test results table in https://github.com/cockroachdb/cockroach/pull/170724#issuecomment-4516777236 for the before/after.

Epic: none

Release note: None