### PR TITLE
release-25.2: testutils/lint: use IsCustomOrAdhocBuild

### DIFF
--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -25,7 +25,7 @@ func TestNightlyLint(t *testing.T) {
 	// TestHelpURLs checks that all help texts have a valid documentation URL.
 	t.Run("TestHelpURLs", func(t *testing.T) {
 		skip.UnderShort(t)
-		if build.ParsedVersion().IsPrerelease() || build.ParsedVersion().IsCustomOrNightlyBuild() {
+		if build.ParsedVersion().IsPrerelease() || build.ParsedVersion().IsCustomOrAdhocBuild() {
 			skip.IgnoreLint(t, "pre-release or customized build")
 		}
 		if pkgSpecified {


### PR DESCRIPTION
The GHA-migration backport (#170813) brought in the bumped
`cockroachdb/version` package that renamed `IsCustomOrNightlyBuild` to
`IsCustomOrAdhocBuild`, and patched `pkg/build/info.go` accordingly,
but missed this caller. The result was a build break in the nightly
`LintURLsBazel` test on release-25.2.

Fixes #170979

Release justification: fix to unblock release-25.2 nightly lint.

Epic: none
Release note: None