### PR TITLE
sql: move domain check constraint validation into helper

### DIFF
--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "computed_exprs.go",
         "default_exprs.go",
         "doc.go",
+        "domain.go",
         "expr.go",
         "hash_sharded_compute_expr.go",
         "name.go",

--- a/pkg/sql/catalog/schemaexpr/domain.go
+++ b/pkg/sql/catalog/schemaexpr/domain.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package schemaexpr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// IsDomainValueRef reports whether e is a reference to the keyword `VALUE` used
+// inside a domain CHECK expression.
+func IsDomainValueRef(e tree.Expr) bool {
+	n, ok := e.(*tree.UnresolvedName)
+	return ok && n.NumParts == 1 && strings.EqualFold(n.Parts[0], "value")
+}
+
+// TypeCheckDomainCheckExpr validates an expression by substituting VALUE with a
+// typed null of the base type and type-checking as boolean. This catches
+// invalid expressions (e.g., referencing nonexistent functions) at CREATE
+// DOMAIN time rather than at INSERT/UPDATE time.
+func TypeCheckDomainCheckExpr(
+	ctx context.Context, semaCtx *tree.SemaContext, expr tree.Expr, baseType *types.T,
+) (tree.TypedExpr, error) {
+	substituted, err := tree.SimpleVisit(expr, func(e tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		if !IsDomainValueRef(e) {
+			return true, e, nil
+		}
+		return false, tree.NewTypedCastExpr(tree.DNull, baseType), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tree.TypeCheck(ctx, substituted, semaCtx, types.Bool)
+}

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
@@ -572,28 +573,13 @@ func (p *planner) createDomainWithID(
 		return unimplemented.NewWithIssue(32552, "domain of arrays and tuples is not yet supported")
 	}
 
-	// Build CHECK constraints. Each expression is validated by substituting
-	// VALUE with a typed null of the base type and type-checking as boolean.
-	// This catches invalid expressions (e.g., referencing nonexistent
-	// functions) at CREATE DOMAIN time rather than at INSERT/UPDATE time.
 	var nextConstraintID descpb.ConstraintID = 1
 	var usedNames []string
 	checks := make(
 		[]descpb.TypeDescriptor_Domain_CheckConstraint, len(n.DomainConstraints),
 	)
 	for i, c := range n.DomainConstraints {
-		validationExpr, err := tree.SimpleVisit(c.Expr, func(e tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-			if n, ok := e.(*tree.UnresolvedName); ok {
-				if n.NumParts == 1 && strings.EqualFold(n.Parts[0], "value") {
-					return false, tree.NewTypedCastExpr(tree.DNull, baseType), nil
-				}
-			}
-			return true, e, nil
-		})
-		if err != nil {
-			return err
-		}
-		if _, err := tree.TypeCheck(params.ctx, validationExpr, params.p.SemaCtx(), types.Bool); err != nil {
+		if _, err := schemaexpr.TypeCheckDomainCheckExpr(params.ctx, params.p.SemaCtx(), c.Expr, baseType); err != nil {
 			return pgerror.Wrapf(err, pgcode.InvalidObjectDefinition,
 				"invalid CHECK expression for domain %s", typeName.Type())
 		}


### PR DESCRIPTION
The legacy schema changer-implemented `CREATE
DOMAIN` uses this logic to validate the check
constraint expressions. THE DSC-implemented `ALTER
DOMAIN ... ADD CONSTRAINT` needs to share the
validations for internal consistency.

Epic: CRDB-62146
Part of: #166937

Release note: None
