### PR TITLE
sql: support BEGIN ATOMIC and bare RETURN body syntax for routines

### DIFF
--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -49,10 +49,6 @@ type createFunctionNode struct {
 func (n *createFunctionNode) ReadingOwnWrites() {}
 
 func (n *createFunctionNode) startExec(params runParams) error {
-	if n.cf.RoutineBody != nil {
-		return unimplemented.NewWithIssue(85144, "CREATE FUNCTION...sql_body unimplemented")
-	}
-
 	if err := params.p.canCreateOnSchema(
 		params.ctx, n.scDesc.GetID(), n.dbDesc.GetID(), params.p.User(), skipCheckPublicSchema,
 	); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/udf_options
+++ b/pkg/sql/logictest/testdata/logic_test/udf_options
@@ -212,3 +212,227 @@ query I
 SELECT strict_fn_imp('foo', NULL)
 ----
 NULL
+
+# Tests for the SQL-standard inline body syntax (BEGIN ATOMIC ... END
+# and bare RETURN expr) for CREATE FUNCTION and CREATE PROCEDURE. These
+# bodies are translated into the legacy string body form during opt
+# building, so the descriptor and execution paths are unchanged.
+
+subtest sql_body
+
+statement ok
+CREATE TABLE abc (a INT PRIMARY KEY, b INT);
+INSERT INTO abc VALUES (1, 10), (2, 20)
+
+subtest sql_body/begin_atomic_single
+
+statement ok
+CREATE FUNCTION f1(i INT) RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    SELECT b FROM abc WHERE a = i;
+  END
+
+query I
+SELECT f1(1)
+----
+10
+
+subtest sql_body/bare_return
+
+statement ok
+CREATE FUNCTION f2(i INT) RETURNS INT LANGUAGE SQL
+  RETURN (SELECT b FROM abc WHERE a = i)
+
+query I
+SELECT f2(2)
+----
+20
+
+subtest sql_body/begin_atomic_with_return
+
+statement ok
+CREATE FUNCTION f3(i INT) RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    RETURN (SELECT b FROM abc WHERE a = i);
+  END
+
+query I
+SELECT f3(1)
+----
+10
+
+subtest sql_body/begin_atomic_multi_stmt
+
+statement ok
+CREATE FUNCTION f4(i INT, j INT) RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    INSERT INTO abc VALUES (i, j);
+    SELECT b FROM abc WHERE a = i;
+  END
+
+query I
+SELECT f4(99, 999)
+----
+999
+
+subtest sql_body/return_not_last
+
+# RETURN is the result expression, not a control-flow statement: it only
+# determines the result when it is the final body statement. A RETURN
+# followed by more statements has its value discarded, and the last
+# statement determines the result. This matches Postgres, which evaluates
+# the last body statement regardless of RETURN position, so rewriting
+# RETURN as SELECT is faithful.
+statement ok
+CREATE FUNCTION f_return_then_select() RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    RETURN 1;
+    SELECT 2;
+  END
+
+query I
+SELECT f_return_then_select()
+----
+2
+
+statement ok
+CREATE FUNCTION f_select_return_select() RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    SELECT 7;
+    RETURN 3;
+    SELECT 4;
+  END
+
+query I
+SELECT f_select_return_select()
+----
+4
+
+# Multiple RETURNs are allowed (no "first RETURN wins" short-circuit); the
+# last body statement still determines the result, matching Postgres.
+statement ok
+CREATE FUNCTION f_two_returns() RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    RETURN 1;
+    RETURN 2;
+  END
+
+query I
+SELECT f_two_returns()
+----
+2
+
+statement ok
+CREATE FUNCTION f_return_return_select() RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    RETURN 1;
+    RETURN 2;
+    SELECT 3;
+  END
+
+query I
+SELECT f_return_return_select()
+----
+3
+
+subtest sql_body/procedure_begin_atomic
+
+statement ok
+CREATE PROCEDURE p1(i INT) LANGUAGE SQL
+  BEGIN ATOMIC
+    INSERT INTO abc VALUES (i, i);
+  END
+
+statement ok
+CALL p1(50)
+
+query II rowsort
+SELECT a, b FROM abc
+----
+1   10
+2   20
+50  50
+99  999
+
+subtest sql_body/plpgsql_inline_body_rejected
+
+statement error inline SQL function body only valid for language SQL
+CREATE FUNCTION f5() RETURNS INT LANGUAGE PLPGSQL
+  BEGIN ATOMIC
+    RETURN 1;
+  END
+
+subtest sql_body/polymorphic_inline_body_rejected
+
+statement error SQL function with unquoted function body cannot have polymorphic arguments
+CREATE FUNCTION f6(x ANYELEMENT) RETURNS ANYELEMENT LANGUAGE SQL
+  RETURN x
+
+subtest sql_body/early_binding_blocks_drop_column
+
+# The reference tracking that protects existing string-body UDFs also covers
+# inline-body ones, since both paths land in the same opt builder logic.
+statement error pgcode 2BP01 cannot drop column "b" because function "f1" depends on it
+ALTER TABLE abc DROP COLUMN b
+
+subtest sql_body/show_create_renders_string_form
+
+# Inline-body functions are stored as string bodies, so SHOW CREATE
+# FUNCTION renders the AS $$ ... $$ form rather than the original
+# BEGIN ATOMIC syntax. This is a deliberate trade-off to avoid changing
+# descriptor storage.
+query T
+SELECT create_statement FROM [SHOW CREATE FUNCTION f1]
+----
+CREATE FUNCTION public.f1(i INT8)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+    SELECT b FROM public.abc WHERE a = i;
+  $$
+
+subtest sql_body/duplicate_body_rejected
+
+# Specifying both an AS $$ ... $$ string body and an inline RETURN or
+# BEGIN ATOMIC body is rejected, matching Postgres (pgcode 42P13).
+statement error pgcode 42P13 duplicate function body specified
+CREATE FUNCTION f7(x INT) RETURNS INT
+  LANGUAGE SQL
+  AS $$ SELECT x * 2 $$
+  RETURN x * 3
+
+statement error pgcode 42P13 duplicate function body specified
+CREATE FUNCTION f8(x INT) RETURNS INT
+  LANGUAGE SQL
+  AS $$ SELECT x * 2 $$
+  BEGIN ATOMIC
+    SELECT x * 3;
+  END
+
+subtest sql_body/ddl_in_inline_body_rejected
+
+# Postgres parses BEGIN ATOMIC bodies at definition time (early binding), so DDL
+# and DCL are forbidden there. This holds even for procedures, which otherwise
+# support DDL through the dollar-quoted AS $$ ... $$ form.
+statement error pgcode 0A000 CREATE TABLE is not yet supported in unquoted SQL routine body
+CREATE FUNCTION f9() RETURNS INT LANGUAGE SQL
+  BEGIN ATOMIC
+    CREATE TABLE t_inline (a INT);
+    SELECT 1;
+  END
+
+statement error pgcode 0A000 CREATE TABLE is not yet supported in unquoted SQL routine body
+CREATE PROCEDURE p2() LANGUAGE SQL
+  BEGIN ATOMIC
+    CREATE TABLE t_inline (a INT);
+  END
+
+statement error pgcode 0A000 GRANT is not yet supported in unquoted SQL routine body
+CREATE PROCEDURE p3() LANGUAGE SQL
+  BEGIN ATOMIC
+    GRANT ALL ON TABLE abc TO testuser;
+  END

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -72,8 +72,17 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		}
 	}()
 
-	if cf.RoutineBody != nil {
-		panic(unimplemented.New("CREATE FUNCTION sql_body", "CREATE FUNCTION...sql_body unimplemented"))
+	// inlineBody records whether the user wrote the SQL-standard inline body
+	// syntax (`BEGIN ATOMIC ... END` or a bare `RETURN expr`). The conversion
+	// below rewrites it into the legacy string body form so the rest of this
+	// function can process both shapes uniformly. We retain the flag because
+	// some validation rules (e.g. polymorphic-arg rejection) only apply when
+	// the body was inline.
+	inlineBody := cf.RoutineBody != nil
+	if inlineBody {
+		if err := tree.ConvertInlineRoutineBodyToOption(cf); err != nil {
+			panic(err)
+		}
 	}
 
 	if err := tree.ValidateRoutineOptions(cf.Options, cf.IsProcedure); err != nil {
@@ -280,6 +289,13 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 				class: param.Class,
 			})
 		}
+	}
+
+	if inlineBody && sawPolymorphicInParam {
+		// PostgreSQL forbids polymorphic IN parameters with inline body syntax
+		// because early binding requires concrete argument types at parse time.
+		panic(pgerror.New(pgcode.InvalidFunctionDefinition,
+			"SQL function with unquoted function body cannot have polymorphic arguments"))
 	}
 
 	// Determine OUT parameter based return type.

--- a/pkg/sql/opt/optbuilder/testdata/create_function
+++ b/pkg/sql/opt/optbuilder/testdata/create_function
@@ -132,7 +132,33 @@ create-function
 build
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL BEGIN ATOMIC SELECT 1; END;
 ----
-error (0A000): unimplemented: CREATE FUNCTION...sql_body unimplemented
+create-function
+ ├── CREATE FUNCTION f()
+ │   	RETURNS INT8
+ │   	LANGUAGE SQL
+ │   	AS $$SELECT 1;$$
+ └── no dependencies
+
+# Bare RETURN expr is rewritten to SELECT expr internally.
+build
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL RETURN 1
+----
+create-function
+ ├── CREATE FUNCTION f()
+ │   	RETURNS INT8
+ │   	LANGUAGE SQL
+ │   	AS $$SELECT 1;$$
+ └── no dependencies
+
+build
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLPGSQL BEGIN ATOMIC SELECT 1; END
+----
+error (42P13): inline SQL function body only valid for language SQL
+
+build
+CREATE FUNCTION f(x ANYELEMENT) RETURNS ANYELEMENT LANGUAGE SQL RETURN x
+----
+error (42P13): SQL function with unquoted function body cannot have polymorphic arguments
 
 build
 CREATE FUNCTION f() RETURNS UNKNOWN LANGUAGE SQL AS $$ SELECT NULL; $$;

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -83,7 +83,9 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 		}
 	}
 	if c.RoutineBody != nil {
-		panic(fmt.Errorf("routine body of BEGIN ATOMIC is not supported"))
+		if err := tree.ConvertInlineRoutineBodyToOption(c); err != nil {
+			panic(err)
+		}
 	}
 
 	// Resolve the parameter names and types.

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -83,8 +83,9 @@ type CreateRoutine struct {
 	Options     RoutineOptions
 	// RoutineBody is set during parsing for routines that use SQL-standard
 	// inline body syntax: either BEGIN ATOMIC ... END or a bare RETURN expr
-	// (as opposed to the dollar-quoted AS $$ ... $$ syntax). Currently
-	// unimplemented in the optimizer.
+	// (as opposed to the dollar-quoted AS $$ ... $$ syntax). The opt builder
+	// rewrites it into a RoutineBodyStr option via
+	// ConvertInlineRoutineBodyToOption and clears this field.
 	RoutineBody *RoutineBody
 	// BodyStatements is not assigned during initial parsing of user input. It's
 	// assigned during opt builder for logging purpose at the moment. It stores
@@ -284,6 +285,82 @@ type RoutineBody struct {
 	// Stmts is populated during parsing. Unlike BodyStatements, we don't need
 	// to create separate Annotations for each statement.
 	Stmts Statements
+}
+
+// ConvertInlineRoutineBodyToOption rewrites a parsed inline routine body
+// (the SQL-standard `BEGIN ATOMIC ... END` or bare `RETURN expr` forms) into
+// the legacy string body form by serializing each statement and appending the
+// result as a RoutineBodyStr option. After this runs, cf.RoutineBody is
+// cleared so downstream code can process the routine as if the user had
+// written `AS $$ ... $$`.
+//
+// CockroachDB already does early binding for SQL routines, so the inline and
+// string forms are semantically equivalent; only the input syntax differs.
+//
+// Clearing cf.RoutineBody makes this idempotent, which matters because the opt
+// builder mutates the CreateRoutine AST in place and that AST may be re-built
+// (e.g. on a transaction retry or a re-executed prepared statement). On the
+// second pass cf.RoutineBody is nil, so the caller skips the conversion and the
+// previously appended RoutineBodyStr carries the body. Without the clear, a
+// second pass would append a duplicate body and then fail the hasStringBody
+// check below.
+func ConvertInlineRoutineBodyToOption(cf *CreateRoutine) error {
+	var hasStringBody, hasLang bool
+	var lang RoutineLanguage
+	for _, opt := range cf.Options {
+		switch t := opt.(type) {
+		case RoutineBodyStr:
+			hasStringBody = true
+		case RoutineLanguage:
+			lang = t
+			hasLang = true
+		}
+	}
+	if hasStringBody {
+		return pgerror.New(pgcode.InvalidFunctionDefinition,
+			"duplicate function body specified")
+	}
+	if hasLang && lang != RoutineLangSQL {
+		return pgerror.New(pgcode.InvalidFunctionDefinition,
+			"inline SQL function body only valid for language SQL")
+	}
+
+	fmtCtx := NewFmtCtx(FmtParsable)
+	for i, stmt := range cf.RoutineBody.Stmts {
+		// Reject DDL and DCL in the inline body. Postgres parses BEGIN ATOMIC
+		// bodies at definition time (early binding), so it forbids schema
+		// changes there; stored procedures support DDL only through the
+		// dollar-quoted AS $$ ... $$ form. Blocking it here keeps us consistent
+		// with Postgres and keeps DDL-in-routine support to a single code path.
+		if t := stmt.StatementType(); t == TypeDDL || t == TypeDCL {
+			return errors.WithHint(
+				pgerror.Newf(pgcode.FeatureNotSupported,
+					"%s is not yet supported in unquoted SQL routine body", stmt.StatementTag()),
+				"Use the dollar-quoted AS $$ ... $$ body form.",
+			)
+		}
+		if i > 0 {
+			fmtCtx.WriteString(" ")
+		}
+		// `RETURN expr` is only valid as a routine-body statement, so it
+		// cannot round-trip through the legacy parser. Emit it as `SELECT
+		// expr` instead — semantically equivalent for SQL routines, since
+		// the result is the value of the final query.
+		if r, ok := stmt.(*RoutineReturn); ok {
+			sel := &Select{
+				Select: &SelectClause{
+					Exprs: SelectExprs{{Expr: r.ReturnVal}},
+				},
+			}
+			fmtCtx.FormatNode(sel)
+		} else {
+			fmtCtx.FormatNode(stmt)
+		}
+		fmtCtx.WriteString(";")
+	}
+	cf.Options = append(cf.Options, RoutineBodyStr(fmtCtx.CloseAndGetString()))
+	cf.RoutineBody = nil
+	return nil
 }
 
 // RoutineReturn represent a RETURN statement in a UDF body.


### PR DESCRIPTION
The SQL-standard `BEGIN ATOMIC ... END` and bare `RETURN expr` body forms were already accepted by the parser but rejected at opt build time with `unimplemented`. CockroachDB already does early binding for SQL routines, so the inline forms are semantically equivalent to the existing dollar-quoted `AS $$ ... $$` form — only the input syntax differs.

Translate the parsed inline body into the legacy string body form by serializing the statements and appending them as a `RoutineBodyStr` option, then let the existing optbuilder and descriptor path handle the rest. `RETURN expr` is rewritten as `SELECT expr` since `RETURN` is only valid as a routine-body statement and cannot round-trip through the legacy parser. The descriptor format is unchanged, so mixed-version clusters require no migration.

Match Postgres validation: reject `BEGIN ATOMIC` with non-SQL languages, reject duplicate body specifications, and reject inline bodies on routines with polymorphic IN parameters (early binding requires concrete types at parse time).

Inline-body routines display as `AS $$ ... $$` in `SHOW CREATE` output. Faithful round-tripping would require either a new descriptor field or always re-rendering as `BEGIN ATOMIC`; both are out of scope for this change.

Resolves: #85144

Release note (sql change): CockroachDB now accepts the SQL-standard inline body syntax for SQL routines. `CREATE FUNCTION` and `CREATE PROCEDURE` with `LANGUAGE SQL` may now use either `BEGIN ATOMIC ... END` (with one or more body statements) or a bare `RETURN expr` in place of the dollar-quoted `AS $$ ... $$` form. Routines created with the inline form display as the dollar-quoted form in `SHOW CREATE` output.