### PR TITLE
release-25.4.11-rc: backport GHA migration + follow-ups

### DIFF
--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -1,0 +1,133 @@
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This workflow cuts release staging branches whose Jira "Cut Branch Date"
+# has arrived. For each eligible CRDB Release ticket it creates the staging
+# branch on GitHub, updates the Jira ticket, posts a Slack notification,
+# and creates the matching backport label.
+
+name: Release - Cut Staging Branches
+
+on:
+  # Scheduled trigger disabled for initial rollout — dispatch manually until
+  # we've validated a few cycles end-to-end. Re-enable by uncommenting.
+  # schedule:
+  #   # 12:00 UTC = 7am EST (winter) / 8am EDT (summer). Single entry — accept
+  #   # the one-hour summer drift rather than maintain two cron lines.
+  #   - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no Jira/GitHub mutations; Slack messages prefixed with [DRY RUN])'
+        type: boolean
+        default: true
+      test_issue_key:
+        description: 'In dry-run, treat this Jira issue as the only candidate (e.g. REL-1234)'
+        type: string
+        default: ''
+
+concurrency:
+  group: branch-cut-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  # Scheduled runs default to non-dry-run; manual runs honor the input.
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || '' }}
+  TEST_ISSUE_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.test_issue_key || '' }}
+  # Gated on USE_PROD_GCP so a staging-prod repo (IS_PRODUCTION_REPO=true,
+  # USE_PROD_GCP unset) can rehearse the branch-cut flow against the dev
+  # Secret Manager. There is no inputs.dry_run term — branch-cut's
+  # --dry-run controls Jira/Slack mutations, not which secret-manager
+  # project to read from. Real prod cutover requires both vars set to true.
+  RELEASE_WIF_PROVIDER: ${{ vars.USE_PROD_GCP != 'true' && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ vars.USE_PROD_GCP != 'true' && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_PROJECT: ${{ vars.USE_PROD_GCP != 'true' && 'releases-dev-356314' || 'releases-prod' }}
+
+jobs:
+  cut-staging-branches:
+    # Restrict to the production release repo on master. Forks (variable
+    # unset) get a no-op job, which is what we want for fork-side smoke
+    # testing of the workflow definition itself.
+    if: vars.IS_PRODUCTION_REPO == 'true' && github.ref == 'refs/heads/master'
+    name: Cut staging branches
+    # Not gated behind a GitHub `environment:`. This workflow does not publish
+    # artifacts to customers — it creates a staging branch in the production
+    # release repo and updates Jira. A bad run is recoverable: delete the
+    # branch and re-run. The `if:` above (prod repo + master only) plus the
+    # workflow_dispatch + write-access requirement is the access control here.
+    # The release-ops environment is reserved for the publishing workflow.
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch all four secrets via the official Google action. It auto-
+      # registers each value with ::add-mask:: so they're redacted from
+      # workflow logs without ever going through `echo` in our scripts.
+      #
+      # NOTE on permissions: the workflow-level `permissions:` block only
+      # constrains the built-in $GITHUB_TOKEN. The PAT fetched below has its
+      # own scopes set at provisioning time and is NOT bounded by
+      # `permissions:`.
+      - name: Fetch release secrets
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            jira_api_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-jira-api-token
+            github_pat:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-github-pat
+            slack_bot_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-slack-bot-token
+
+      # The wrapper builds the release binary inside the bazel docker
+      # container (via run_bazel) and invokes it there, so the host
+      # runner doesn't need bazel/Go installed. The DRY_RUN and
+      # TEST_ISSUE_KEY env vars from the workflow-level env: block are
+      # forwarded into the container automatically.
+      - name: Cut staging branches
+        env:
+          JIRA_API_TOKEN: ${{ steps.secrets.outputs.jira_api_token }}
+          JIRA_EMAIL: release-eng-bot@cockroachlabs.com
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.github_pat }}
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+        run: build/github/release-cut-staging-branches.sh
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+          SLACK_PAYLOAD: >-
+            {
+              "channel": "#release-ops",
+              "text": ":x: Release - Cut Staging Branches *failed* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
+              "attachments": [
+                {
+                  "color": "#dc3545",
+                  "fields": [
+                    { "title": "Triggered by", "value": "${{ github.event_name }}", "short": true },
+                    { "title": "Dry run", "value": "${{ env.DRY_RUN || 'false' }}", "short": true }
+                  ]
+                }
+              ]
+            }
+        run: |
+          # If the secrets step failed, $SLACK_TOKEN is empty and curl will
+          # return 401; that's surfaced in the run log even though Slack
+          # gets nothing. The secret value never enters the shell from a
+          # `gcloud` invocation, so there's no echo path to worry about.
+          curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$SLACK_PAYLOAD"

--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -64,7 +64,7 @@ jobs:
     # branch and re-run. The `if:` above (prod repo + master only) plus the
     # workflow_dispatch + write-access requirement is the access control here.
     # The release-ops environment is reserved for the publishing workflow.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write

--- a/.github/workflows/release-branch-cut.yml
+++ b/.github/workflows/release-branch-cut.yml
@@ -38,6 +38,10 @@ env:
   # Scheduled runs default to non-dry-run; manual runs honor the input.
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || '' }}
   TEST_ISSUE_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.test_issue_key || '' }}
+  # Forwarded into the container so the release binary's isProductionRepo()
+  # check sees the same value the workflow's `if:` gate uses. Without this,
+  # the binary defaults to non-prod and routes Slack to #db-release-test.
+  IS_PRODUCTION_REPO: ${{ vars.IS_PRODUCTION_REPO }}
   # Gated on USE_PROD_GCP so a staging-prod repo (IS_PRODUCTION_REPO=true,
   # USE_PROD_GCP unset) can rehearse the branch-cut flow against the dev
   # Secret Manager. There is no inputs.dry_run term — branch-cut's

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -83,7 +83,7 @@ env:
   # in repo Variables. Dry-run forces dev GCP regardless, since it
   # writes to dev GCS / Artifact Registry.
   RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
-  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-artifacts@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-signing@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
 

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -173,7 +173,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -248,7 +248,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -306,7 +306,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 120
     permissions:
       id-token: write
@@ -389,7 +389,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 90
     permissions:
       id-token: write
@@ -440,7 +440,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 90
     permissions:
       id-token: write
@@ -496,7 +496,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -564,7 +564,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -607,7 +607,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -670,7 +670,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -731,7 +731,7 @@ jobs:
          (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -803,7 +803,7 @@ jobs:
       - sentry-panic
       - publish-cloud-only
       - cloud-rollout
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 10
     permissions:
       id-token: write

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -752,6 +752,15 @@ jobs:
         with:
           name: cloud-only-metadata
 
+      # rafa-production's update_versions.sh invokes `go run main.go ...`,
+      # so Go has to be on PATH for the rollout script to succeed. The
+      # version is pinned to match go.mod's toolchain so the rafa tool
+      # builds the same way it would locally.
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.2'
+
       # Fetch the GitHub PAT via the official Google action so it's
       # auto-registered with ::add-mask:: and never has to flow through `echo`
       # in our scripts.

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -84,7 +84,7 @@ env:
   # writes to dev GCS / Artifact Registry.
   RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
   RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
-  RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-signing@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
 
 jobs:

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -1,0 +1,861 @@
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This workflow builds, signs, and publishes CockroachDB release artifacts.
+# It replaces the TeamCity "Build and sign cockroach release" composite build.
+#
+# The dependency graph mirrors the TeamCity structure:
+#
+#   validate-skip-jobs (gates every job below; see skip_jobs input)
+#     |
+#     +-> build-linux (matrix: linux-amd64, linux-arm64, linux-amd64-fips, linux-s390x)
+#     +-> build-nonlinux (matrix: darwin-amd64, darwin-arm64, win-amd64)
+#     +-> build-per-platform-ibm (matrix: 4 linux platforms, no telemetry)
+#           |
+#           +---> build-docker (needs build-linux)
+#           +---> build-docker-ibm (needs IBM linux builds)
+#           |       |
+#           |       +---> publish-cloud-only (needs build-docker)
+#           |               |
+#           |               +---> cloud-rollout (needs publish-cloud-only)
+#           |
+#           +---> macos-signing (needs build-nonlinux)
+#           +---> ibm-signing (needs IBM linux builds)
+#           +---> sentry-panic (needs build-linux)
+#
+#   notify (always, needs all above)
+
+name: Release - Build and Sign
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (use dev buckets and repos)'
+        type: boolean
+        default: true
+      er_release:
+        description: 'Extraordinary release'
+        type: boolean
+        default: false
+      sha:
+        description: 'Git SHA to build (defaults to branch HEAD)'
+        type: string
+        default: ''
+      skip_jobs:
+        description: 'Comma-separated job IDs to skip (no spaces) when resuming after a partial failure. Validated by the validate-skip-jobs job. Valid IDs: build-linux, build-nonlinux, build-per-platform-ibm, build-docker, build-docker-ibm, macos-signing, ibm-signing, sentry-panic, publish-cloud-only, cloud-rollout.'
+        type: string
+        default: ''
+
+concurrency:
+  group: release-build-${{ github.ref_name }}-${{ inputs.sha || github.sha }}
+  cancel-in-progress: false
+
+# Minimal workflow-level permissions; jobs request what they need.
+permissions: {}
+
+# This workflow is intentionally NOT gated behind a GitHub `environment:`.
+# Build and sign produces release candidates that are staged for review but
+# not yet published to customers — if a run goes wrong, it can simply be
+# rebuilt. The customer-facing publish step lives in release-publish.yml,
+# which is gated by the `release-ops` environment (required reviewer +
+# deployment-branch policy). Per-job `if:` checks below restrict dispatch
+# to master / release-*-rc / staging-v* as defense in depth.
+
+env:
+  # DRY_RUN gates which GCS bucket / GCR repo / git tag the underlying
+  # shell scripts touch. Tied to USE_PROD_GCP (not IS_PRODUCTION_REPO):
+  # without prod GCP credentials we literally cannot write to prod
+  # buckets, so any non-prod-GCP run forces DRY_RUN=true regardless of
+  # the operator's dry_run input. On a prod-GCP repo, the input still
+  # works as a per-run toggle (prod creds + dryrun bucket).
+  DRY_RUN: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'true' || '' }}
+  ER_RELEASE: ${{ inputs.er_release && 'true' || '' }}
+  # WIF / GCP configuration — defined once, used by all jobs.
+  #
+  # Gated on USE_PROD_GCP (separate from IS_PRODUCTION_REPO) so a
+  # staging-prod repo (e.g. crlint/cockroach-release) can exercise the
+  # prod control-flow paths via IS_PRODUCTION_REPO=true while still
+  # authenticating against the dev GCP project. Real prod cutover
+  # requires setting BOTH IS_PRODUCTION_REPO=true and USE_PROD_GCP=true
+  # in repo Variables. Dry-run forces dev GCP regardless, since it
+  # writes to dev GCS / Artifact Registry.
+  RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-artifacts@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_SIGNING_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-signing@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Stage 0: Validate skip_jobs input
+  # --------------------------------------------------------------------------
+  # Every skippable job depends on this validator and gates itself with
+  #   !contains(format(',{0},', inputs.skip_jobs), ',<job-id>,')
+  # The format/comma-wrap turns the user's input into ",a,b,c," so that
+  # the contains() check matches whole tokens — without the wrap,
+  # contains('build', 'build-linux') would false-match. Empty input
+  # produces ",," and matches nothing, so the default is "skip nothing".
+  #
+  # The validator catches typos in seconds; without it, an unknown ID
+  # silently runs every job (since no contains() check matches) and the
+  # operator only discovers the typo when the failed job runs again.
+  #
+  # NOTE on the (success || (skipped && in skip_jobs)) gate used by
+  # downstream jobs: GHA reports `'skipped'` for both user-skipped jobs
+  # and cascade-skipped ones (where an upstream `needs:` failed). To
+  # support resume without letting a cascade-failure also resume the
+  # whole pipeline, downstream jobs only treat `'skipped'` as
+  # success-equivalent when the upstream is explicitly in skip_jobs.
+  validate-skip-jobs:
+    name: Validate skip_jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: Validate skip_jobs IDs
+        env:
+          SKIP_JOBS: ${{ inputs.skip_jobs }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SKIP_JOBS" ]]; then
+            echo "skip_jobs is empty; nothing to validate."
+            exit 0
+          fi
+          # Keep this list in sync with the skippable jobs below and the
+          # input description in the workflow_dispatch block.
+          valid_ids=(
+            build-linux
+            build-nonlinux
+            build-per-platform-ibm
+            build-docker
+            build-docker-ibm
+            macos-signing
+            ibm-signing
+            sentry-panic
+            publish-cloud-only
+            cloud-rollout
+          )
+          IFS=',' read -ra requested <<< "$SKIP_JOBS"
+          invalid=()
+          for id in "${requested[@]}"; do
+            if [[ ! " ${valid_ids[*]} " == *" $id "* ]]; then
+              invalid+=("$id")
+            fi
+          done
+          if (( ${#invalid[@]} > 0 )); then
+            echo "::error::Unknown skip_jobs IDs: ${invalid[*]}"
+            echo "Valid IDs: ${valid_ids[*]}"
+            exit 1
+          fi
+          echo "skip_jobs validated: ${requested[*]}"
+
+  # --------------------------------------------------------------------------
+  # Stage 1a: Linux per-platform builds (needed by Docker, sentry)
+  # --------------------------------------------------------------------------
+  # BACKPORT NOTE: on release branches up to and including release-26.1, the
+  # per-platform build script (build-cockroach-release-per-platform.sh) does
+  # an in-job `docker build --platform=linux/<arch>` for the arm64 matrix
+  # entry. master moved that work to a separate build-docker job which
+  # already has docker/setup-qemu-action + docker/setup-buildx-action. If
+  # you backport changes to this job onto a release branch that still has
+  # the in-job docker build, you MUST keep the setup-qemu / setup-buildx
+  # steps on that branch — without QEMU binfmt handlers, the arm64 RUN
+  # steps abort with `exec /bin/sh: exec format error`. Same applies to
+  # build-nonlinux and build-per-platform-ibm below.
+  build-linux:
+    name: 'Build ${{ matrix.platform }}'
+    needs: validate-skip-jobs
+    if: >-
+      ${{ !contains(format(',{0},', inputs.skip_jobs), ',build-linux,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_big_2404]
+    timeout-minutes: 120
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux-amd64
+          - linux-arm64
+          - linux-amd64-fips
+          - linux-s390x
+    steps:
+      - name: Free disk space
+        # Best-effort: GitHub-hosted ubuntu-latest runners need this to fit
+        # the build artifacts on a 14 GB disk; self-hosted runners have
+        # plenty of headroom and may not grant the GHA service user sudo,
+        # so tolerate failures here rather than blocking the job.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || :
+          sudo docker image prune --all --force || :
+          df -h /
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          submodules: true
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      # On release-26.1 the per-platform script does an in-job
+      # `docker build --platform=linux/<arch>` for arm64; without QEMU
+      # binfmt handlers the arm64 RUN steps abort with `exec format error`.
+      # See the BACKPORT NOTE above the build-linux job.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          # Disable the binfmt-installer cache: it warns "Path Validation
+          # Error" on every post-step because the action doesn't write to
+          # the cache path it later tries to save. The image is tiny — the
+          # cache wasn't buying us anything anyway.
+          cache-image: false
+
+      - name: Build and publish release artifacts
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          TC_BUILDTYPE_ID: release-build-${{ matrix.platform }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 1b: Non-Linux per-platform builds (needed by macOS signing)
+  # --------------------------------------------------------------------------
+  build-nonlinux:
+    name: 'Build ${{ matrix.platform }}'
+    needs: validate-skip-jobs
+    if: >-
+      ${{ !contains(format(',{0},', inputs.skip_jobs), ',build-nonlinux,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_big_2404]
+    timeout-minutes: 120
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - darwin-amd64
+          - darwin-arm64
+          - win-amd64
+    steps:
+      - name: Free disk space
+        # Best-effort: GitHub-hosted ubuntu-latest runners need this to fit
+        # the build artifacts on a 14 GB disk; self-hosted runners have
+        # plenty of headroom and may not grant the GHA service user sudo,
+        # so tolerate failures here rather than blocking the job.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || :
+          sudo docker image prune --all --force || :
+          df -h /
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          submodules: true
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Build and publish release artifacts
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          TC_BUILDTYPE_ID: release-build-${{ matrix.platform }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 1b: IBM per-platform builds (no telemetry, parallel with above)
+  # --------------------------------------------------------------------------
+  build-per-platform-ibm:
+    name: 'Build IBM ${{ matrix.platform }}'
+    needs: validate-skip-jobs
+    if: >-
+      ${{ !contains(format(',{0},', inputs.skip_jobs), ',build-per-platform-ibm,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_big_2404]
+    timeout-minutes: 120
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux-amd64
+          - linux-arm64
+          - linux-amd64-fips
+          - linux-s390x
+    steps:
+      - name: Free disk space
+        # Best-effort: GitHub-hosted ubuntu-latest runners need this to fit
+        # the build artifacts on a 14 GB disk; self-hosted runners have
+        # plenty of headroom and may not grant the GHA service user sudo,
+        # so tolerate failures here rather than blocking the job.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || :
+          sudo docker image prune --all --force || :
+          df -h /
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          submodules: true
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      # On release-26.1 the per-platform script does an in-job
+      # `docker build --platform=linux/<arch>` for arm64; without QEMU
+      # binfmt handlers the arm64 RUN steps abort with `exec format error`.
+      # See the BACKPORT NOTE above the build-linux job.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          # Disable the binfmt-installer cache: it warns "Path Validation
+          # Error" on every post-step because the action doesn't write to
+          # the cache path it later tries to save. The image is tiny — the
+          # cache wasn't buying us anything anyway.
+          cache-image: false
+
+      - name: Build and publish release artifacts (no telemetry)
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          TELEMETRY_DISABLED: 'true'
+          COCKROACH_ARCHIVE_PREFIX: cockroach-ibm
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          TC_BUILDTYPE_ID: release-build-ibm-${{ matrix.platform }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 2: Docker images (needs Linux builds only)
+  # --------------------------------------------------------------------------
+  build-docker:
+    name: Build Docker images
+    needs: build-linux
+    # !cancelled() + (success || skipped) lets this job run when build-linux
+    # was skipped via skip_jobs (resume after partial failure where the
+    # linux artifacts are already in GCS from a prior run).
+    if: >-
+      ${{ !cancelled() &&
+        (needs.build-linux.result == 'success' ||
+         (needs.build-linux.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',build-linux,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',build-docker,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_big_2404]
+    timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          # Disable the binfmt-installer cache: it warns "Path Validation
+          # Error" on every post-step because the action doesn't write to
+          # the cache path it later tries to save. The image is tiny — the
+          # cache wasn't buying us anything anyway.
+          cache-image: false
+
+      - name: Build and push Docker images
+        env:
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+
+  build-docker-ibm:
+    name: Build Docker images (IBM, no telemetry)
+    needs: build-per-platform-ibm
+    if: >-
+      ${{ !cancelled() &&
+        (needs.build-per-platform-ibm.result == 'success' ||
+         (needs.build-per-platform-ibm.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',build-per-platform-ibm,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',build-docker-ibm,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_big_2404]
+    timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          # Disable the binfmt-installer cache: it warns "Path Validation
+          # Error" on every post-step because the action doesn't write to
+          # the cache path it later tries to save. The image is tiny — the
+          # cache wasn't buying us anything anyway.
+          cache-image: false
+
+      - name: Build and push Docker images (no telemetry)
+        env:
+          TELEMETRY_DISABLED: 'true'
+          COCKROACH_ARCHIVE_PREFIX: cockroach-ibm
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 2b: macOS signing (needs darwin-arm64 build)
+  # --------------------------------------------------------------------------
+  macos-signing:
+    name: macOS code signing
+    needs: build-nonlinux
+    if: >-
+      ${{ !cancelled() &&
+        (needs.build-nonlinux.result == 'success' ||
+         (needs.build-nonlinux.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',build-nonlinux,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',macos-signing,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_SIGNING_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      # rcodesign signs the customer-facing macOS binaries. Pin both the
+      # version and the upstream-published SHA-256 so the runner verifies
+      # the exact same artifact every time — stronger than `cargo install`
+      # @version (which has no source-package SHA check) and avoids needing
+      # a Rust toolchain on the runner. Bump RCODESIGN_SHA256 alongside
+      # RCODESIGN_VERSION; the published .sha256 file is at
+      # https://github.com/indygreg/apple-platform-rs/releases.
+      - name: Install rcodesign
+        env:
+          RCODESIGN_VERSION: '0.29.0'
+          RCODESIGN_SHA256: 'dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002'
+        run: |
+          set -euo pipefail
+          url="https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tmp="$(mktemp -d)"
+          curl -fsSL --retry 5 --retry-delay 2 "$url" -o "$tmp/rcodesign.tgz"
+          echo "${RCODESIGN_SHA256}  $tmp/rcodesign.tgz" | sha256sum -c -
+          tar -xzf "$tmp/rcodesign.tgz" -C "$tmp" --strip-components=1
+          # Install into a runner-writable directory and prepend it to
+          # PATH so the next step ("Sign macOS binaries") sees rcodesign
+          # without sudo or root-owned bin dirs.
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 0755 "$tmp/rcodesign" "$RUNNER_TEMP/bin/rcodesign"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/rcodesign" --version
+
+      - name: Sign macOS binaries
+        env:
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-sign-macos.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 2c: IBM/GPG signing (needs IBM linux builds)
+  # --------------------------------------------------------------------------
+  ibm-signing:
+    name: IBM GPG signing
+    needs: build-per-platform-ibm
+    if: >-
+      ${{ !cancelled() &&
+        (needs.build-per-platform-ibm.result == 'success' ||
+         (needs.build-per-platform-ibm.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',build-per-platform-ibm,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',ibm-signing,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_SIGNING_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Sign IBM release artifacts (GPG)
+        env:
+          COCKROACH_ARCHIVE_PREFIX: cockroach-ibm
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-sign-ibm.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 2d: Sentry panic (needs linux-amd64 build)
+  # --------------------------------------------------------------------------
+  sentry-panic:
+    name: Generate Sentry panic
+    needs: build-linux
+    if: >-
+      ${{ !cancelled() &&
+        (needs.build-linux.result == 'success' ||
+         (needs.build-linux.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',build-linux,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',sentry-panic,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Free disk space
+        # Best-effort: GitHub-hosted ubuntu-latest runners need this to fit
+        # the build artifacts on a 14 GB disk; self-hosted runners have
+        # plenty of headroom and may not grant the GHA service user sudo,
+        # so tolerate failures here rather than blocking the job.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || :
+          sudo docker image prune --all --force || :
+          df -h /
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          submodules: true
+
+      - name: Authenticate to Google Cloud
+        if: env.DRY_RUN == ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch the Sentry auth token via the official Google action so it's
+      # auto-registered with ::add-mask:: and never has to flow through `echo`
+      # in our scripts. Skipped in dry-run since the script exits early.
+      - name: Fetch Sentry auth token
+        if: env.DRY_RUN == ''
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            sentry_auth_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-sentry-auth-token
+
+      - name: Trigger Sentry panic
+        env:
+          SENTRY_AUTH_TOKEN: ${{ steps.secrets.outputs.sentry_auth_token }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-sentry-panic.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 3: Publish cloud-only candidate (needs Docker images)
+  # --------------------------------------------------------------------------
+  publish-cloud-only:
+    name: Publish cloud-only candidate
+    needs: build-docker
+    if: >-
+      ${{ !cancelled() &&
+        (needs.build-docker.result == 'success' ||
+         (needs.build-docker.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',build-docker,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',publish-cloud-only,') &&
+        !inputs.dry_run && vars.IS_PRODUCTION_REPO == 'true' &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      # cloud-only.sh's verify_docker_image step iterates amd64/arm64/s390x
+      # and `docker run`s each platform variant of the cloud-only manifest.
+      # Without QEMU, the non-amd64 RUN aborts with "exec format error".
+      - name: Set up QEMU for cross-arch RUN steps
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          cache-image: false
+
+      - name: Publish cloud-only candidate
+        env:
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-cloud-only.sh
+
+      - name: Upload cloud-only metadata
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: cloud-only-metadata
+          path: artifacts/metadata.json
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # Stage 4: Cloud rollout RAFA PRs (needs cloud-only candidate)
+  # --------------------------------------------------------------------------
+  cloud-rollout:
+    name: 'Cloud rollout: create RAFA PRs'
+    needs: publish-cloud-only
+    if: >-
+      ${{ !cancelled() &&
+        (needs.publish-cloud-only.result == 'success' ||
+         (needs.publish-cloud-only.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',publish-cloud-only,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',cloud-rollout,') &&
+        !inputs.dry_run && vars.IS_PRODUCTION_REPO == 'true' &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Download cloud-only metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cloud-only-metadata
+
+      # Fetch the GitHub PAT via the official Google action so it's
+      # auto-registered with ::add-mask:: and never has to flow through `echo`
+      # in our scripts.
+      - name: Fetch GitHub PAT
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            github_pat:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-github-pat
+
+      - name: Create cloud rollout PRs
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.github_pat }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-cloud-rollout.sh
+
+  # --------------------------------------------------------------------------
+  # Notification (always runs)
+  # --------------------------------------------------------------------------
+  notify:
+    name: Slack notification
+    if: >-
+      ${{ always() &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    needs:
+      - validate-skip-jobs
+      - build-linux
+      - build-nonlinux
+      - build-per-platform-ibm
+      - build-docker
+      - build-docker-ibm
+      - macos-signing
+      - ibm-signing
+      - sentry-panic
+      - publish-cloud-only
+      - cloud-rollout
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Determine overall status
+        id: status
+        env:
+          HAS_FAILURE: ${{ contains(needs.*.result, 'failure') }}
+          HAS_CANCELLED: ${{ contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [[ "$HAS_FAILURE" == "true" ]]; then
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "color=#dc3545" >> "$GITHUB_OUTPUT"
+            echo "emoji=:x:" >> "$GITHUB_OUTPUT"
+          elif [[ "$HAS_CANCELLED" == "true" ]]; then
+            echo "result=cancelled" >> "$GITHUB_OUTPUT"
+            echo "color=#ffc107" >> "$GITHUB_OUTPUT"
+            echo "emoji=:warning:" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "color=#28a745" >> "$GITHUB_OUTPUT"
+            echo "emoji=:white_check_mark:" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch the Slack token via the official Google action so it's
+      # auto-registered with ::add-mask:: and never has to flow through
+      # `echo` in our scripts.
+      - name: Fetch Slack token
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            slack_bot_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-slack-bot-token
+
+      - name: Post to #release-ops
+        env:
+          SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+          SLACK_PAYLOAD: >-
+            {
+              "channel": "C08H9FA1W3C",
+              "text": "${{ steps.status.outputs.emoji }} Release build *${{ steps.status.outputs.result }}* for `${{ github.ref_name }}` (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
+              "attachments": [
+                {
+                  "color": "${{ steps.status.outputs.color }}",
+                  "fields": [
+                    { "title": "Branch", "value": "`${{ github.ref_name }}`", "short": true },
+                    { "title": "Dry run", "value": "${{ env.DRY_RUN != '' }}", "short": true },
+                    { "title": "Triggered by", "value": "${{ github.actor }}", "short": true }
+                  ]
+                }
+              ]
+            }
+        run: |
+          curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$SLACK_PAYLOAD"

--- a/.github/workflows/release-build-and-sign.yml
+++ b/.github/workflows/release-build-and-sign.yml
@@ -850,7 +850,7 @@ jobs:
           SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
           SLACK_PAYLOAD: >-
             {
-              "channel": "C08H9FA1W3C",
+              "channel": "#release-ops",
               "text": "${{ steps.status.outputs.emoji }} Release build *${{ steps.status.outputs.result }}* for `${{ github.ref_name }}` (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
               "attachments": [
                 {

--- a/.github/workflows/release-pick-sha.yml
+++ b/.github/workflows/release-pick-sha.yml
@@ -1,0 +1,142 @@
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This workflow promotes the tip of a release staging branch into a build-
+# and-sign run once the Jira "Pick SHA Date" arrives. For each eligible
+# CRDB Release ticket it fetches the staging branch tip, dispatches the
+# release-build-and-sign workflow against that branch and SHA, posts a
+# Slack notification, comments on Jira, and transitions the "Pick SHA"
+# subtask to Done.
+name: Release - Pick SHA
+
+on:
+  # Scheduled trigger disabled for initial rollout — dispatch manually until
+  # we've validated a few cycles end-to-end. Re-enable by uncommenting.
+  # schedule:
+  #   # 12:00 UTC = 7am EST (winter) / 8am EDT (summer). Single entry — accept
+  #   # the one-hour summer drift rather than maintain two cron lines.
+  #   - cron: '0 12 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (dispatch build-and-sign with dry_run=true; no Jira mutations on our side; Slack messages prefixed with [DRY RUN])'
+        type: boolean
+        default: true
+      test_issue_key:
+        description: 'Treat this Jira issue as the only candidate, bypassing JQL search and Pick SHA Date readiness check (e.g. REL-1234)'
+        type: string
+        default: ''
+
+concurrency:
+  group: pick-sha-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  # Scheduled runs default to non-dry-run; manual runs honor the input.
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || '' }}
+  TEST_ISSUE_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.test_issue_key || '' }}
+  # Gated on USE_PROD_GCP so a staging-prod repo (IS_PRODUCTION_REPO=true,
+  # USE_PROD_GCP unset) can rehearse the pick-SHA flow against the dev
+  # Secret Manager. There is no inputs.dry_run term — pick-sha's --dry-run
+  # controls Jira/Slack mutations, not which secret-manager project to
+  # read from. Real prod cutover requires both vars set to true.
+  RELEASE_WIF_PROVIDER: ${{ vars.USE_PROD_GCP != 'true' && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ vars.USE_PROD_GCP != 'true' && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_PROJECT: ${{ vars.USE_PROD_GCP != 'true' && 'releases-dev-356314' || 'releases-prod' }}
+
+jobs:
+  pick-sha:
+    # Restrict to the production release repo on master. Forks (variable
+    # unset) get a no-op job, which is what we want for fork-side smoke
+    # testing of the workflow definition itself.
+    if: vars.IS_PRODUCTION_REPO == 'true' && github.ref == 'refs/heads/master'
+    name: Pick SHA and dispatch build-and-sign
+    # Not gated behind a GitHub `environment:`. This workflow only dispatches
+    # the downstream build-and-sign workflow (which itself is not customer-
+    # facing) and updates Jira. A bad run is recoverable: the dispatched
+    # build can be cancelled and re-triggered manually with a different SHA.
+    # The `if:` above (prod repo + master only) plus the workflow_dispatch +
+    # write-access requirement is the access control here. The release-ops
+    # environment is reserved for the publishing workflow.
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch all three secrets via the official Google action. It auto-
+      # registers each value with ::add-mask:: so they're redacted from
+      # workflow logs without ever going through `echo` in our scripts.
+      #
+      # NOTE on permissions: the workflow-level `permissions:` block only
+      # constrains the built-in $GITHUB_TOKEN. The PAT fetched below has its
+      # own scopes set at provisioning time and is NOT bounded by
+      # `permissions:`. `gha-releases-release-github-pat` must be a
+      # fine-grained PAT scoped to cockroachdb/cockroach with:
+      # Contents=read, Metadata=read, Issues=write (transition subtask),
+      # Actions=read & write (dispatch release-build-and-sign.yml). See
+      # RELEASE_REMAINING_ISSUES.md.
+      #
+      - name: Fetch release secrets
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            jira_api_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-jira-api-token
+            github_pat:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-github-pat
+            slack_bot_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-slack-bot-token
+            release_notes_api_key:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-notes-api-key
+
+      # The wrapper builds the release binary inside the bazel docker
+      # container (via run_bazel) and invokes it there, so the host
+      # runner doesn't need bazel/Go installed. The DRY_RUN and
+      # TEST_ISSUE_KEY env vars from the workflow-level env: block are
+      # forwarded into the container automatically.
+      - name: Pick SHA and dispatch build-and-sign
+        env:
+          JIRA_API_TOKEN: ${{ steps.secrets.outputs.jira_api_token }}
+          JIRA_EMAIL: release-eng-bot@cockroachlabs.com
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.github_pat }}
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+          RELEASE_NOTES_API_KEY: ${{ steps.secrets.outputs.release_notes_api_key }}
+        run: build/github/release-pick-sha.sh
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+          SLACK_PAYLOAD: >-
+            {
+              "channel": "#release-ops",
+              "text": ":x: Release - Pick SHA *failed* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
+              "attachments": [
+                {
+                  "color": "#dc3545",
+                  "fields": [
+                    { "title": "Triggered by", "value": "${{ github.event_name }}", "short": true },
+                    { "title": "Dry run", "value": "${{ env.DRY_RUN || 'false' }}", "short": true }
+                  ]
+                }
+              ]
+            }
+        run: |
+          # If the secrets step failed, $SLACK_TOKEN is empty and curl will
+          # return 401; that's surfaced in the run log even though Slack
+          # gets nothing. The secret value never enters the shell from a
+          # `gcloud` invocation, so there's no echo path to worry about.
+          curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+           -d "$SLACK_PAYLOAD"

--- a/.github/workflows/release-pick-sha.yml
+++ b/.github/workflows/release-pick-sha.yml
@@ -39,6 +39,10 @@ env:
   # Scheduled runs default to non-dry-run; manual runs honor the input.
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || '' }}
   TEST_ISSUE_KEY: ${{ github.event_name == 'workflow_dispatch' && inputs.test_issue_key || '' }}
+  # Forwarded into the container so the release binary's isProductionRepo()
+  # check sees the same value the workflow's `if:` gate uses. Without this,
+  # the binary defaults to non-prod and routes Slack to #db-release-test.
+  IS_PRODUCTION_REPO: ${{ vars.IS_PRODUCTION_REPO }}
   # Gated on USE_PROD_GCP so a staging-prod repo (IS_PRODUCTION_REPO=true,
   # USE_PROD_GCP unset) can rehearse the pick-SHA flow against the dev
   # Secret Manager. There is no inputs.dry_run term — pick-sha's --dry-run

--- a/.github/workflows/release-pick-sha.yml
+++ b/.github/workflows/release-pick-sha.yml
@@ -66,7 +66,7 @@ jobs:
     # The `if:` above (prod repo + master only) plus the workflow_dispatch +
     # write-access requirement is the access control here. The release-ops
     # environment is reserved for the publishing workflow.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,565 @@
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This workflow publishes a previously staged CockroachDB release:
+# copies binaries to production GCS, pushes Docker images to DockerHub/GCR,
+# tags the release in GitHub, publishes to Red Hat, and creates RAFA PRs.
+#
+# It replaces the TeamCity "Publish Cockroach Release" composite build.
+#
+#   validate-skip-jobs (gates every job below; see skip_jobs input)
+#     └─► validate-build ─► approve-publish ─┬─► update-versions-master
+#                                            └─► publish-staged ─┬─► publish-redhat
+#                                                                └─► create-rafa-prs
+#   notify (always, needs all above)
+#
+# approve-publish is the single human-approval gate (release-ops env);
+# every downstream job inherits the approval transitively. Reviewer
+# clicks once per dispatch, not once per job.
+
+name: Release - Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (use dev buckets and repos)'
+        type: boolean
+        default: true
+      sha:
+        description: 'Git SHA to build (defaults to branch HEAD)'
+        type: string
+        default: ''
+      dryrun_tag:
+        description: 'Dry-run only: push the release tag to the current repo (e.g. on a fork). Ignored when not in dry-run.'
+        type: boolean
+        default: false
+      skip_jobs:
+        description: 'Comma-separated job IDs to skip (no spaces) when resuming after a partial failure. Validated by the validate-skip-jobs job. Valid IDs: validate-build, update-versions-master, publish-staged, publish-redhat, create-rafa-prs.'
+        type: string
+        default: ''
+
+concurrency:
+  group: release-publish-${{ github.ref_name }}-${{ inputs.sha || github.sha }}
+  cancel-in-progress: false
+
+# Minimal workflow-level permissions; jobs request what they need.
+permissions: {}
+
+env:
+  # DRY_RUN gates which GCS bucket / GCR repo / git tag the publish
+  # scripts touch. Tied to USE_PROD_GCP (not IS_PRODUCTION_REPO): without
+  # prod credentials we cannot write to prod buckets, so any non-prod-GCP
+  # run forces DRY_RUN=true regardless of the operator's dry_run input.
+  DRY_RUN: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'true' || '' }}
+  # WIF / GCP configuration. See release-build-and-sign.yml for the
+  # rationale behind splitting USE_PROD_GCP from IS_PRODUCTION_REPO:
+  # staging-prod repos can run the prod flow against dev GCP. Real prod
+  # cutover requires both vars set to true. Dry-run forces dev GCP.
+  RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-artifacts@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Stage 0: Validate skip_jobs input
+  # --------------------------------------------------------------------------
+  # Every skippable job depends on this validator and gates itself with
+  #   !contains(format(',{0},', inputs.skip_jobs), ',<job-id>,')
+  # The format/comma-wrap turns the user's input into ",a,b,c," so that
+  # the contains() check matches whole tokens — without the wrap,
+  # contains('publish', 'publish-staged') would false-match. Empty input
+  # produces ",," and matches nothing, so the default is "skip nothing".
+  #
+  # The validator catches typos in seconds; without it, an unknown ID
+  # silently runs every job and the operator only discovers the typo
+  # when the failed job runs again.
+  validate-skip-jobs:
+    name: Validate skip_jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: Validate skip_jobs IDs
+        env:
+          SKIP_JOBS: ${{ inputs.skip_jobs }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SKIP_JOBS" ]]; then
+            echo "skip_jobs is empty; nothing to validate."
+            exit 0
+          fi
+          # Keep this list in sync with the skippable jobs below and the
+          # input description in the workflow_dispatch block.
+          valid_ids=(
+            validate-build
+            update-versions-master
+            publish-staged
+            publish-redhat
+            create-rafa-prs
+          )
+          IFS=',' read -ra requested <<< "$SKIP_JOBS"
+          invalid=()
+          for id in "${requested[@]}"; do
+            if [[ ! " ${valid_ids[*]} " == *" $id "* ]]; then
+              invalid+=("$id")
+            fi
+          done
+          if (( ${#invalid[@]} > 0 )); then
+            echo "::error::Unknown skip_jobs IDs: ${invalid[*]}"
+            echo "Valid IDs: ${valid_ids[*]}"
+            exit 1
+          fi
+          echo "skip_jobs validated: ${requested[*]}"
+
+  # --------------------------------------------------------------------------
+  # Pre-check: Verify build-and-sign completed for this SHA
+  # --------------------------------------------------------------------------
+  validate-build:
+    name: Validate build-and-sign
+    needs: validate-skip-jobs
+    if: >-
+      ${{ !contains(format(',{0},', inputs.skip_jobs), ',validate-build,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    steps:
+      - name: Check for successful build-and-sign run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ inputs.sha || github.sha }}
+        run: |
+          echo "Checking for successful 'Release - Build and Sign' run on SHA $TARGET_SHA..."
+          run=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow "Release - Build and Sign" \
+            --commit "$TARGET_SHA" \
+            --status success \
+            --json databaseId,conclusion,headSha \
+            --jq '.[0]' \
+          )
+          if [[ -z "$run" || "$run" == "null" ]]; then
+            echo "::error::No successful 'Release - Build and Sign' run found for SHA $TARGET_SHA"
+            echo "Re-run with skip_jobs=validate-build to bypass this check."
+            exit 1
+          fi
+          echo "Found successful build run: $run"
+
+  # --------------------------------------------------------------------------
+  # Stage 1 gate: single approval covering every job that touches user-
+  # observable state (update-versions-master + publish-staged and
+  # everything they fan out to). GHA's environment-approval is per-job,
+  # so without this gate the reviewer would have to click approve once
+  # per job that uses `release-ops`. Consolidating onto one no-op
+  # approval job keeps the human-in-the-loop boundary in one place.
+  # --------------------------------------------------------------------------
+  approve-publish:
+    name: Approve publish
+    needs: validate-build
+    if: >-
+      ${{ !cancelled() &&
+        (needs.validate-build.result == 'success' ||
+         (needs.validate-build.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',validate-build,'))) &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    environment: release-ops
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions: {}
+    steps:
+      - run: echo "Approved by reviewer; downstream publish jobs unblocked."
+
+  # --------------------------------------------------------------------------
+  # Stage 1a: Bump master to the next dev version and open the
+  # version-update PRs in the satellite repos (homebrew-tap, helm-charts,
+  # baking-branch merges, ...). Runs against master regardless of which
+  # release branch dispatched the workflow.
+  # --------------------------------------------------------------------------
+  update-versions-master:
+    needs: approve-publish
+    if: >-
+      ${{ !cancelled() &&
+        needs.approve-publish.result == 'success' &&
+        !contains(format(',{0},', inputs.skip_jobs), ',update-versions-master,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    name: Update version.txt
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Resolve released version from publish SHA
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_SHA: ${{ inputs.sha || github.sha }}
+        run: |
+          raw=$(gh api "repos/${GITHUB_REPOSITORY}/contents/pkg/build/version.txt?ref=${PUBLISH_SHA}" -q '.content' | base64 -d)
+          version=$(echo "$raw" | grep -v '^#' | head -n1)
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not parse version from pkg/build/version.txt at ${PUBLISH_SHA}"
+            exit 1
+          fi
+          echo "Resolved RELEASED_VERSION=$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Check out master, not the publish SHA — the version-update tool
+      # operates on master and creates PRs against satellite repos.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: master
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      # gha-releases-release-smtp-password must be provisioned in both the
+      # dev and prod Secret Manager projects before this workflow can
+      # succeed; the release tool requires SMTP_PASSWORD even though the
+      # only outbound mail in dry-run goes to dev-inf+release-dev@.
+      - name: Fetch update-versions secrets
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            github_pat:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-github-pat
+            smtp_password:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-smtp-password
+
+      - name: Run update-versions
+        env:
+          # GH_TOKEN serves two purposes here:
+          #   1. The Go binary's pushURL() embeds it for satellite-repo PR
+          #      pushes (homebrew-tap, helm-charts).
+          #   2. update_versions_impl.sh uses it to authenticate the
+          #      `git fetch origin` (and the binary's `git ls-remote
+          #      origin`) against the cockroach repo inside the bazel
+          #      container, via a url.<base>.insteadOf rewrite.
+          GH_TOKEN: ${{ steps.secrets.outputs.github_pat }}
+          SMTP_PASSWORD: ${{ steps.secrets.outputs.smtp_password }}
+          RELEASED_VERSION: ${{ steps.resolve.outputs.version }}
+          IS_PRODUCTION_REPO: ${{ vars.IS_PRODUCTION_REPO }}
+        run: |
+          build/github/release-update-versions.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 1b: Publish staged release (binaries, Docker, git tag)
+  # --------------------------------------------------------------------------
+  publish-staged:
+    # Depends on approve-publish (the single human-approval gate),
+    # parallel to update-versions-master. update-versions-master and
+    # publish-staged are independent: the former operates on master to
+    # bump the dev version and open satellite-repo PRs; the latter
+    # promotes the staged release artifacts. Sequencing them serially
+    # added run time without buying anything.
+    needs: approve-publish
+    if: >-
+      ${{ !cancelled() &&
+        needs.approve-publish.result == 'success' &&
+        !contains(format(',{0},', inputs.skip_jobs), ',publish-staged,') &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    name: Publish staged cockroach release
+    runs-on: [self-hosted, ubuntu_big_2404]
+    timeout-minutes: 90
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          # Don't leave the workflow's auto-issued GITHUB_TOKEN in
+          # .git/config as `http.https://github.com/.extraheader`. On this
+          # org the auto-token is policy-clamped to Contents: read, and
+          # the extraheader's Authorization wins over the URL-embedded
+          # bot PAT we use for the tag push — yielding "Write access to
+          # repository not granted" 403s. With persist-credentials=false
+          # the URL-embedded PAT is the only Authorization git sends.
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          # See release-build-and-sign.yml: avoids the spurious
+          # "Path Validation Error" cache-save warning on every run.
+          cache-image: false
+
+      # Fetch publish secrets via the official Google action so each value is
+      # auto-registered with ::add-mask:: and never has to flow through `echo`
+      # in our scripts.
+      - name: Fetch publish secrets
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            docker_access_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-dockerhub-access-token
+            docker_id:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-dockerhub-username
+            github_pat:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-github-pat
+
+      - name: Publish staged release
+        env:
+          DOCKER_ACCESS_TOKEN: ${{ steps.secrets.outputs.docker_access_token }}
+          DOCKER_ID: ${{ steps.secrets.outputs.docker_id }}
+          # GHA tagging path: HTTPS push using the bot PAT. The PAT must
+          # authorize git_repo_for_tag (the prod repo for real publishes,
+          # and any fork used for dry-run rehearsal). TC tagging path
+          # (SSH deploy key) is unaffected — TC sets
+          # GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY directly and the
+          # script branches on it first.
+          # Use GH_TOKEN (not GITHUB_TOKEN). GHA's runner reserves the
+          # GITHUB_TOKEN name and may shadow our value with the auto-
+          # issued workflow token; GH_TOKEN sidesteps that and matches
+          # the convention used by every other release workflow step.
+          GH_TOKEN: ${{ steps.secrets.outputs.github_pat }}
+          DRYRUN_TAG_REPO: ${{ env.DRY_RUN != '' && inputs.dryrun_tag && github.repository || '' }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-publish-staged.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 2a: Publish to Red Hat (needs publish-staged)
+  # --------------------------------------------------------------------------
+  publish-redhat:
+    name: Publish to Red Hat
+    needs: publish-staged
+    if: >-
+      ${{ !cancelled() &&
+        (needs.publish-staged.result == 'success' ||
+         (needs.publish-staged.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',publish-staged,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',publish-redhat,') &&
+        !inputs.dry_run && vars.IS_PRODUCTION_REPO == 'true' &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    # Reviewer-approval gate is on approve-publish upstream; this job
+    # inherits the gate transitively via its needs chain.
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        with:
+          # See release-build-and-sign.yml: avoids the spurious
+          # "Path Validation Error" cache-save warning on every run.
+          cache-image: false
+
+      # Fetch Red Hat publish secrets via the official Google action so each
+      # value is auto-registered with ::add-mask:: and never has to flow
+      # through `echo` in our scripts.
+      - name: Fetch Red Hat publish secrets
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            quay_registry_key:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-quay-registry-key
+            redhat_api_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-redhat-api-token
+
+      - name: Publish to Red Hat
+        env:
+          QUAY_REGISTRY_KEY: ${{ steps.secrets.outputs.quay_registry_key }}
+          REDHAT_API_TOKEN: ${{ steps.secrets.outputs.redhat_api_token }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-publish-redhat.sh
+
+  # --------------------------------------------------------------------------
+  # Stage 2b: Create RAFA pull requests (needs publish-staged)
+  # --------------------------------------------------------------------------
+  create-rafa-prs:
+    name: Create RAFA pull requests
+    needs: publish-staged
+    if: >-
+      ${{ !cancelled() &&
+        (needs.publish-staged.result == 'success' ||
+         (needs.publish-staged.result == 'skipped' && contains(format(',{0},', inputs.skip_jobs), ',publish-staged,'))) &&
+        !contains(format(',{0},', inputs.skip_jobs), ',create-rafa-prs,') &&
+        !inputs.dry_run && vars.IS_PRODUCTION_REPO == 'true' &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    # Reviewer-approval gate is on approve-publish upstream; this job
+    # inherits the gate transitively via its needs chain.
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch the GitHub PAT via the official Google action so it's
+      # auto-registered with ::add-mask:: and never has to flow through `echo`
+      # in our scripts.
+      - name: Fetch GitHub PAT
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            github_pat:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-github-pat
+
+      - name: Create RAFA pull requests
+        env:
+          GH_TOKEN: ${{ steps.secrets.outputs.github_pat }}
+          # TODO(gh-migration): remove TC_ compat vars once TeamCity is decommissioned.
+          TC_BUILD_BRANCH: ${{ github.ref_name }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+        run: |
+          build/github/release-publish-rafa-prs.sh
+
+  # --------------------------------------------------------------------------
+  # Notification (always runs)
+  # --------------------------------------------------------------------------
+  notify:
+    name: Slack notification
+    if: >-
+      ${{ always() &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    needs:
+      - validate-skip-jobs
+      - validate-build
+      - approve-publish
+      - update-versions-master
+      - publish-staged
+      - publish-redhat
+      - create-rafa-prs
+    # No `environment:` here. The release-ops environment requires a human
+    # reviewer for every job that uses it; that's the right gate for
+    # publish-cloud-only / publish-staged / publish-redhat / create-rafa-prs
+    # because each performs a customer-facing mutation. The notify job
+    # only posts a Slack summary — gating it would block delivery of the
+    # final status (especially failure pings) until the same human
+    # approves an extra step, defeating the point of the notification.
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Determine overall status
+        id: status
+        env:
+          HAS_FAILURE: ${{ contains(needs.*.result, 'failure') }}
+          HAS_CANCELLED: ${{ contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [[ "$HAS_FAILURE" == "true" ]]; then
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "color=#dc3545" >> "$GITHUB_OUTPUT"
+            echo "emoji=:x:" >> "$GITHUB_OUTPUT"
+          elif [[ "$HAS_CANCELLED" == "true" ]]; then
+            echo "result=cancelled" >> "$GITHUB_OUTPUT"
+            echo "color=#ffc107" >> "$GITHUB_OUTPUT"
+            echo "emoji=:warning:" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=success" >> "$GITHUB_OUTPUT"
+            echo "color=#28a745" >> "$GITHUB_OUTPUT"
+            echo "emoji=:white_check_mark:" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch the Slack token via the official Google action so it's
+      # auto-registered with ::add-mask:: and never has to flow through
+      # `echo` in our scripts.
+      - name: Fetch Slack token
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            slack_bot_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-slack-bot-token
+
+      - name: Post to #release-ops
+        env:
+          SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+          SLACK_PAYLOAD: >-
+            {
+              "channel": "C08H9FA1W3C",
+              "text": "${{ steps.status.outputs.emoji }} Release publish *${{ steps.status.outputs.result }}* for `${{ github.ref_name }}` (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
+              "attachments": [
+                {
+                  "color": "${{ steps.status.outputs.color }}",
+                  "fields": [
+                    { "title": "Branch", "value": "`${{ github.ref_name }}`", "short": true },
+                    { "title": "Dry run", "value": "${{ env.DRY_RUN != '' }}", "short": true },
+                    { "title": "Triggered by", "value": "${{ github.actor }}", "short": true }
+                  ]
+                }
+              ]
+            }
+        run: |
+          curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$SLACK_PAYLOAD"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -545,7 +545,7 @@ jobs:
           SLACK_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
           SLACK_PAYLOAD: >-
             {
-              "channel": "C08H9FA1W3C",
+              "channel": "#release-ops",
               "text": "${{ steps.status.outputs.emoji }} Release publish *${{ steps.status.outputs.result }}* for `${{ github.ref_name }}` (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>)",
               "attachments": [
                 {

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -59,7 +59,7 @@ env:
   # staging-prod repos can run the prod flow against dev GCP. Real prod
   # cutover requires both vars set to true. Dry-run forces dev GCP.
   RELEASE_WIF_PROVIDER: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'projects/65523152860/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' || 'projects/182391335559/locations/global/workloadIdentityPools/gha-releases-oidc/providers/gha-releases-oidc' }}
-  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'release-artifacts@releases-prod.iam.gserviceaccount.com' }}
+  RELEASE_GCP_SERVICE_ACCOUNT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'gha-releases@releases-dev-356314.iam.gserviceaccount.com' || 'gha-releases@releases-prod.iam.gserviceaccount.com' }}
   RELEASE_GCP_PROJECT: ${{ (inputs.dry_run || vars.USE_PROD_GCP != 'true') && 'releases-dev-356314' || 'releases-prod' }}
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -195,7 +195,7 @@ jobs:
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
     name: Update version.txt
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -281,7 +281,7 @@ jobs:
          startsWith(github.ref, 'refs/heads/staging-v'))
       }}
     name: Publish staged cockroach release
-    runs-on: [self-hosted, ubuntu_big_2404]
+    runs-on: [self-hosted, ubuntu_big_2004]
     timeout-minutes: 90
     permissions:
       id-token: write
@@ -372,7 +372,7 @@ jobs:
       }}
     # Reviewer-approval gate is on approve-publish upstream; this job
     # inherits the gate transitively via its needs chain.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 60
     permissions:
       id-token: write
@@ -437,7 +437,7 @@ jobs:
       }}
     # Reviewer-approval gate is on approve-publish upstream; this job
     # inherits the gate transitively via its needs chain.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -498,7 +498,7 @@ jobs:
     # only posts a Slack summary — gating it would block delivery of the
     # final status (especially failure pings) until the same human
     # approves an extra step, defeating the point of the notification.
-    runs-on: [self-hosted, ubuntu_2404]
+    runs-on: [self-hosted, ubuntu_2004]
     timeout-minutes: 10
     permissions:
       id-token: write

--- a/build/github/release-cloud-only.sh
+++ b/build/github/release-cloud-only.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for publishing the cloud-only cockroach candidate.
+
+set -euo pipefail
+
+exec build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh

--- a/build/github/release-cloud-rollout.sh
+++ b/build/github/release-cloud-rollout.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for creating cloud rollout RAFA pull requests.
+# Expects GH_TOKEN to be set by the calling workflow step (fetched via
+# google-github-actions/get-secretmanager-secrets, which auto-masks the value
+# with ::add-mask::).
+#
+# NOTE: This script intentionally does NOT use set -x. It handles the
+# GitHub PAT which must never appear in build logs.
+
+set -euo pipefail
+
+if [[ "${ER_RELEASE:-}" == "true" ]]; then
+  echo "ER_RELEASE is set, skipping cloud rollout"
+  exit 0
+fi
+
+# Short-circuit on dry-run. The rafa script doesn't honor DRY_RUN and
+# always does a real `git push` to cockroachlabs/rafa-production —
+# something a dry run must never do, and something a non-prod fork
+# can't do anyway (no PAT scope for the rafa repo). Skip the entire
+# rollout so dry-run completes cleanly without touching prod.
+if [[ "${DRY_RUN:-}" == "true" ]]; then
+  echo "[DRY RUN] would clone cockroachlabs/rafa-production, branch, commit metadata, and push."
+  echo "[DRY RUN] skipping cloud rollout."
+  exit 0
+fi
+
+: "${GH_TOKEN:?must be set by the workflow}"
+
+version=$(grep -v "^#" "pkg/build/version.txt" | head -n1)
+echo "Creating cloud rollout PRs for $version..."
+
+# Clone rafa-production using a credential helper to avoid leaking the PAT.
+# When authenticating with a PAT, GitHub identifies the caller from the
+# token alone; the username is a syntactic placeholder, conventionally
+# "x-access-token". Shallow clone (--depth=1 + --single-branch) — the
+# rafa script only needs to branch from HEAD, commit, and push; it
+# never reads history.
+echo "Cloning rafa-production..."
+git -c "credential.https://github.com.helper=!f(){ echo username=x-access-token; echo password=${GH_TOKEN}; };f" \
+  clone --depth=1 --single-branch \
+  https://github.com/cockroachlabs/rafa-production.git rafa-production
+
+# metadata.json is downloaded by the GHA workflow via actions/download-artifact
+# into the workspace root. Verify it exists.
+if [[ ! -f metadata.json ]]; then
+  echo "ERROR: metadata.json not found. It should be downloaded from the publish-cloud-only job."
+  exit 1
+fi
+
+# Write version file for the rollout script.
+mkdir -p cockroach/pkg/build
+echo "$version" > cockroach/pkg/build/version.txt
+
+# rafa-production's teamcity-create-cloud-rollout-prs.sh assumes:
+#   - its cwd is the PARENT of rafa-production/ (it does its own
+#     `cd rafa-production` early), and
+#   - metadata.json is inside rafa-production/ (read after that cd).
+# So drop a copy of metadata.json into rafa-production/ and invoke the
+# script with a path that doesn't change our cwd.
+cp metadata.json rafa-production/metadata.json
+
+# The rafa script's git push uses the URL form
+#   https://$GH_USERNAME:$GH_TOKEN@github.com/cockroachlabs/rafa-production
+# When authenticating with a PAT, the username is a syntactic placeholder
+# (the PAT alone identifies the caller); GitHub's documented value is
+# "x-access-token". Export it so the rafa child script picks it up —
+# without it the URL becomes https://:$GH_TOKEN@... and auth fails.
+export GH_USERNAME="x-access-token"
+
+echo "Running cloud rollout script..."
+./rafa-production/scripts/release/teamcity-create-cloud-rollout-prs.sh

--- a/build/github/release-cut-staging-branches-impl.sh
+++ b/build/github/release-cut-staging-branches-impl.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Inner half of the branch-cut wrapper. Runs INSIDE the bazel docker
+# container that run_bazel sets up: builds the release binary against
+# the workspace mounted at /go/src/github.com/cockroachdb/cockroach
+# and invokes its `cut-staging-branches` subcommand with the args
+# derived from the calling workflow's DRY_RUN / TEST_ISSUE_KEY env.
+#
+# Secrets (JIRA_API_TOKEN, GITHUB_TOKEN, SLACK_BOT_TOKEN, etc.) are
+# forwarded by the wrapper via the docker -e passthrough; the binary
+# reads them from its own env.
+
+set -euo pipefail
+
+bazel build --config=crosslinux //pkg/cmd/release
+
+args=()
+if [[ "${DRY_RUN:-}" == "true" ]]; then
+  args+=(--dry-run)
+fi
+if [[ -n "${TEST_ISSUE_KEY:-}" ]]; then
+  args+=(--test-issue-key "$TEST_ISSUE_KEY")
+fi
+
+$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
+  cut-staging-branches "${args[@]}"

--- a/build/github/release-cut-staging-branches.sh
+++ b/build/github/release-cut-staging-branches.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for the daily branch-cut workflow. Runs the
+# release binary inside the bazel docker container (via run_bazel) so
+# the workflow doesn't depend on the host runner having a compatible
+# bazel / Go toolchain.
+#
+# Expects to be called by a step that has fetched the release secrets
+# via google-github-actions/get-secretmanager-secrets and bound them
+# to the env vars below. The :? defaults fail fast if the calling
+# workflow drops one.
+#
+# NOTE: This script intentionally does NOT use set -x. It handles
+# secrets that must never appear in build logs.
+
+set -euo pipefail
+
+: "${JIRA_API_TOKEN:?must be set by the workflow}"
+: "${JIRA_EMAIL:?must be set by the workflow}"
+: "${GITHUB_TOKEN:?must be set by the workflow}"
+: "${SLACK_BOT_TOKEN:?must be set by the workflow}"
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$dir/build/teamcity-support.sh"        # for $root
+source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
+
+# Forward the secrets and the workflow-supplied DRY_RUN / TEST_ISSUE_KEY
+# toggles into the container. Everything the impl script and the
+# release binary read must be enumerated here. GITHUB_REPOSITORY is
+# auto-set by the GHA runner and read by the binary's defaultRepo()
+# helper to pick which GitHub repo holds the staging branches; without
+# it the binary falls back to cockroachdb/cockroach and looks for the
+# staging branch in the wrong place.
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e GITHUB_REPOSITORY" \
+  run_bazel build/github/release-cut-staging-branches-impl.sh

--- a/build/github/release-cut-staging-branches.sh
+++ b/build/github/release-cut-staging-branches.sh
@@ -36,5 +36,5 @@ source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
 # helper to pick which GitHub repo holds the staging branches; without
 # it the binary falls back to cockroachdb/cockroach and looks for the
 # staging branch in the wrong place.
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e GITHUB_REPOSITORY" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e GITHUB_REPOSITORY -e IS_PRODUCTION_REPO" \
   run_bazel build/github/release-cut-staging-branches-impl.sh

--- a/build/github/release-pick-sha-impl.sh
+++ b/build/github/release-pick-sha-impl.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Inner half of the pick-SHA wrapper. Runs INSIDE the bazel docker
+# container that run_bazel sets up: builds the release binary against
+# the workspace mounted at /go/src/github.com/cockroachdb/cockroach
+# and invokes its `pick-sha` subcommand with the args derived from the
+# calling workflow's DRY_RUN / TEST_ISSUE_KEY env.
+#
+# Secrets (JIRA_API_TOKEN, GITHUB_TOKEN, SLACK_BOT_TOKEN,
+# RELEASE_NOTES_API_KEY, etc.) are forwarded by the wrapper via the
+# docker -e passthrough; the binary reads them from its own env.
+
+set -euo pipefail
+
+bazel build --config=crosslinux //pkg/cmd/release
+
+args=()
+if [[ "${DRY_RUN:-}" == "true" ]]; then
+  args+=(--dry-run)
+fi
+if [[ -n "${TEST_ISSUE_KEY:-}" ]]; then
+  args+=(--test-issue-key "$TEST_ISSUE_KEY")
+fi
+
+$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
+  pick-sha "${args[@]}"

--- a/build/github/release-pick-sha.sh
+++ b/build/github/release-pick-sha.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for the daily pick-SHA workflow. Runs the
+# release binary inside the bazel docker container (via run_bazel) so
+# the workflow doesn't depend on the host runner having a compatible
+# bazel / Go toolchain.
+#
+# Expects to be called by a step that has fetched the release secrets
+# via google-github-actions/get-secretmanager-secrets and bound them
+# to the env vars below. The :? defaults fail fast if the calling
+# workflow drops one.
+#
+# NOTE: This script intentionally does NOT use set -x. It handles
+# secrets that must never appear in build logs.
+
+set -euo pipefail
+
+: "${JIRA_API_TOKEN:?must be set by the workflow}"
+: "${JIRA_EMAIL:?must be set by the workflow}"
+: "${GITHUB_TOKEN:?must be set by the workflow}"
+: "${SLACK_BOT_TOKEN:?must be set by the workflow}"
+: "${RELEASE_NOTES_API_KEY:?must be set by the workflow}"
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$dir/build/teamcity-support.sh"        # for $root
+source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
+
+# Forward the secrets and the workflow-supplied DRY_RUN / TEST_ISSUE_KEY
+# toggles into the container. Everything the impl script and the
+# release binary read must be enumerated here. GITHUB_REPOSITORY is
+# auto-set by the GHA runner and read by the binary's defaultRepo()
+# helper to pick which GitHub repo holds the staging branches; without
+# it the binary falls back to cockroachdb/cockroach and looks for the
+# staging branch in the wrong place.
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e RELEASE_NOTES_API_KEY -e GITHUB_REPOSITORY" \
+  run_bazel build/github/release-pick-sha-impl.sh

--- a/build/github/release-pick-sha.sh
+++ b/build/github/release-pick-sha.sh
@@ -37,5 +37,5 @@ source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
 # helper to pick which GitHub repo holds the staging branches; without
 # it the binary falls back to cockroachdb/cockroach and looks for the
 # staging branch in the wrong place.
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e RELEASE_NOTES_API_KEY -e GITHUB_REPOSITORY" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e TEST_ISSUE_KEY -e JIRA_API_TOKEN -e JIRA_EMAIL -e GITHUB_TOKEN -e SLACK_BOT_TOKEN -e RELEASE_NOTES_API_KEY -e GITHUB_REPOSITORY -e IS_PRODUCTION_REPO" \
   run_bazel build/github/release-pick-sha-impl.sh

--- a/build/github/release-publish-rafa-prs.sh
+++ b/build/github/release-publish-rafa-prs.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for creating RAFA release pull requests. Expects
+# GH_TOKEN to be set by the calling workflow step (fetched via
+# google-github-actions/get-secretmanager-secrets, which auto-masks the value
+# with ::add-mask::).
+#
+# NOTE: This script intentionally does NOT use set -x. It handles the
+# GitHub PAT which must never appear in build logs.
+
+set -euo pipefail
+
+: "${GH_TOKEN:?must be set by the workflow}"
+
+version=$(grep -v "^#" "pkg/build/version.txt" | head -n1)
+echo "Creating RAFA release PRs for $version..."
+
+# Clone rafa-production using a credential helper to avoid leaking the PAT.
+# When authenticating with a PAT, GitHub identifies the caller from the
+# token alone; the username is a syntactic placeholder, conventionally
+# "x-access-token".
+echo "Cloning rafa-production..."
+git -c "credential.https://github.com.helper=!f(){ echo username=x-access-token; echo password=${GH_TOKEN}; };f" \
+  clone https://github.com/cockroachlabs/rafa-production.git rafa-production
+
+# Write version file for the RAFA script.
+mkdir -p cockroach/pkg/build
+echo "$version" > cockroach/pkg/build/version.txt
+
+# Run the rafa-production release PR script.
+echo "Running RAFA release PR script..."
+./rafa-production/scripts/release/teamcity-create-release-prs.sh

--- a/build/github/release-publish-redhat.sh
+++ b/build/github/release-publish-redhat.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for publishing to Red Hat. Expects QUAY_REGISTRY_KEY
+# and REDHAT_API_TOKEN to be set by the calling workflow step (fetched via
+# google-github-actions/get-secretmanager-secrets, which auto-masks the values
+# with ::add-mask::).
+#
+# NOTE: This script intentionally does NOT use set -x. It handles secrets
+# that must never appear in build logs.
+
+set -euo pipefail
+
+: "${QUAY_REGISTRY_KEY:?must be set by the workflow}"
+: "${REDHAT_API_TOKEN:?must be set by the workflow}"
+
+# Call the existing script.
+exec build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh

--- a/build/github/release-publish-staged.sh
+++ b/build/github/release-publish-staged.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for publishing a staged cockroach release. Expects
+# DOCKER_ACCESS_TOKEN, DOCKER_ID, and (for non-dry-run) GH_TOKEN for git
+# tagging over HTTPS to be set by the calling workflow step (fetched via
+# google-github-actions/get-secretmanager-secrets, which auto-masks the
+# values with ::add-mask::).
+#
+# NOTE: This script intentionally does NOT use set -x. It handles secrets
+# that must never appear in build logs.
+
+set -euo pipefail
+
+: "${DOCKER_ACCESS_TOKEN:?must be set by the workflow}"
+: "${DOCKER_ID:?must be set by the workflow}"
+
+if [[ -z "${DRY_RUN:-}" ]]; then
+  : "${GH_TOKEN:?must be set by the workflow for non-dry-run}"
+fi
+
+# Call the existing script. It sources teamcity-support.sh which provides
+# log_into_gcloud (no-op with WIF), docker_login_gcr (uses gcloud credential
+# helper with WIF), tc_start_block/tc_end_block, etc.
+exec build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh

--- a/build/github/release-sentry-panic.sh
+++ b/build/github/release-sentry-panic.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for triggering a Sentry panic on a new release.
+# Expects SENTRY_AUTH_TOKEN to be set by the calling workflow step (fetched
+# via google-github-actions/get-secretmanager-secrets, which auto-masks the
+# value with ::add-mask::).
+#
+# NOTE: This script intentionally does NOT use set -x. It handles secrets
+# that must never appear in build logs.
+
+set -euo pipefail
+
+if [[ -n "${DRY_RUN:-}" ]] ; then
+  echo "Skipping this step in dry-run mode"
+  exit
+fi
+
+: "${SENTRY_AUTH_TOKEN:?must be set by the workflow}"
+
+export VERSION=$(grep -v "^#" "pkg/build/version.txt" | head -n1)
+echo "Triggering Sentry panic for $VERSION..."
+
+# Call the existing script which runs the sentry tool via Bazel in Docker.
+exec build/teamcity/internal/release/process/trigger-sentry-panic.sh

--- a/build/github/release-sign-ibm.sh
+++ b/build/github/release-sign-ibm.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for IBM GPG signing. Replaces the TeamCity signing
+# agent approach: uses WIF-authenticated gcloud to fetch GPG keys from
+# Secret Manager.
+#
+# NOTE: This script intentionally does NOT use set -x. It handles signing
+# secrets that must never appear in build logs.
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname "${0}")))"
+source "$dir/build/release/teamcity-support.sh"
+
+secrets_dir="${RUNNER_TEMP:-.}/.secrets"
+
+remove_files_on_exit() {
+  rm -f .google-credentials.json
+  rm -rf "$secrets_dir"
+}
+trap remove_files_on_exit EXIT
+
+# Store signing secrets outside the workspace with restrictive permissions.
+echo "Fetching GPG signing secrets from Secret Manager..."
+umask 077
+mkdir -p "$secrets_dir"
+gcloud secrets versions access latest --secret=gha-releases-gpg-private-key | base64 -d > "$secrets_dir/gpg-private-key"
+gcloud secrets versions access latest --secret=gha-releases-gpg-private-key-password | base64 -d > "$secrets_dir/gpg-private-key-password"
+umask 022
+echo "Secrets fetched successfully."
+
+echo "Importing GPG key..."
+gpg --homedir "$secrets_dir" --pinentry-mode loopback \
+  --passphrase-file "$secrets_dir/gpg-private-key-password" \
+  --import "$secrets_dir/gpg-private-key"
+
+# By default, set dry-run variables.
+gcs_staged_bucket="cockroach-release-artifacts-staged-dryrun"
+version=$(grep -v "^#" "$dir/pkg/build/version.txt" | head -n1)
+cockroach_archive_prefix="${COCKROACH_ARCHIVE_PREFIX:?COCKROACH_ARCHIVE_PREFIX must be set}"
+
+# Override dev defaults with production values.
+if [[ -z "${DRY_RUN}" ]] ; then
+  echo "Using production GCS bucket"
+  gcs_staged_bucket="cockroach-release-artifacts-staged-prod"
+fi
+
+# gcloud is already authenticated via WIF; log_into_gcloud is a no-op.
+log_into_gcloud
+
+mkdir -p artifacts
+cd artifacts
+
+for platform in linux-amd64 linux-amd64-fips linux-arm64 linux-s390x; do
+  tarball=${cockroach_archive_prefix}-${version}.${platform}.tgz
+
+  echo "Downloading $tarball..."
+  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$tarball" "$tarball"
+  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$tarball.sha256sum" "$tarball.sha256sum"
+
+  echo "Verifying checksum..."
+  shasum --algorithm 256 --check "$tarball.sha256sum"
+
+  echo "GPG signing $tarball..."
+  gpg --homedir "$secrets_dir" --pinentry-mode loopback \
+    --passphrase-file "$secrets_dir/gpg-private-key-password" \
+    --detach-sign --armor "$tarball"
+  gpg --homedir "$secrets_dir" --verify "$tarball.asc" "$tarball"
+
+  echo "Uploading $tarball.asc..."
+  gsutil -o 'GSUtil:num_retries=5' cp "$tarball.asc" "gs://$gcs_staged_bucket/$tarball.asc"
+done
+echo "IBM GPG signing complete."

--- a/build/github/release-sign-ibm.sh
+++ b/build/github/release-sign-ibm.sh
@@ -60,8 +60,8 @@ for platform in linux-amd64 linux-amd64-fips linux-arm64 linux-s390x; do
   tarball=${cockroach_archive_prefix}-${version}.${platform}.tgz
 
   echo "Downloading $tarball..."
-  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$tarball" "$tarball"
-  gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$tarball.sha256sum" "$tarball.sha256sum"
+  gcloud storage cp "gs://$gcs_staged_bucket/$tarball" "$tarball"
+  gcloud storage cp "gs://$gcs_staged_bucket/$tarball.sha256sum" "$tarball.sha256sum"
 
   echo "Verifying checksum..."
   shasum --algorithm 256 --check "$tarball.sha256sum"
@@ -73,6 +73,6 @@ for platform in linux-amd64 linux-amd64-fips linux-arm64 linux-s390x; do
   gpg --homedir "$secrets_dir" --verify "$tarball.asc" "$tarball"
 
   echo "Uploading $tarball.asc..."
-  gsutil -o 'GSUtil:num_retries=5' cp "$tarball.asc" "gs://$gcs_staged_bucket/$tarball.asc"
+  gcloud storage cp "$tarball.asc" "gs://$gcs_staged_bucket/$tarball.asc"
 done
 echo "IBM GPG signing complete."

--- a/build/github/release-sign-macos.sh
+++ b/build/github/release-sign-macos.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for macOS signing. Replaces the TeamCity signing agent
+# approach: instead of relying on a GCE instance SA, we use WIF-authenticated
+# gcloud to fetch Apple signing secrets from Secret Manager.
+#
+# NOTE: This script intentionally does NOT use set -x. It handles signing
+# secrets that must never appear in build logs.
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname "${0}")))"
+source "$dir/build/release/teamcity-support.sh"
+source "$dir/build/shlib.sh"
+
+secrets_dir="${RUNNER_TEMP:-.}/.secrets"
+
+remove_files_on_exit() {
+  rm -f .google-credentials.json
+  rm -rf "$secrets_dir"
+}
+trap remove_files_on_exit EXIT
+
+# Store signing secrets outside the workspace with restrictive permissions.
+echo "Fetching Apple signing secrets from Secret Manager..."
+umask 077
+mkdir -p "$secrets_dir"
+gcloud secrets versions access latest --secret=gha-releases-apple-signing-cert | base64 -d > "$secrets_dir/cert.p12"
+gcloud secrets versions access latest --secret=gha-releases-apple-signing-cert-password > "$secrets_dir/cert.pass"
+gcloud secrets versions access latest --secret=gha-releases-appstoreconnect-api-key > "$secrets_dir/api_key.json"
+umask 022
+echo "Secrets fetched successfully."
+
+# By default, set dry-run variables.
+gcs_staged_bucket="cockroach-release-artifacts-staged-dryrun"
+version=$(grep -v "^#" "$dir/pkg/build/version.txt" | head -n1)
+
+# Override dev defaults with production values.
+if [[ -z "${DRY_RUN}" ]] ; then
+  echo "Using production GCS bucket"
+  gcs_staged_bucket="cockroach-release-artifacts-staged-prod"
+fi
+
+# gcloud is already authenticated via WIF; log_into_gcloud is a no-op.
+log_into_gcloud
+
+mkdir -p artifacts
+cd artifacts
+
+for product in cockroach cockroach-sql; do
+  for platform in darwin-11.0-arm64; do
+    base=${product}-${version}.${platform}
+    unsigned_base=${product}-${version}.${platform}.unsigned
+    unsigned_file=${unsigned_base}.tgz
+    target=${base}.tgz
+
+    echo "Downloading unsigned archive: $unsigned_file"
+    gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$unsigned_file" "$unsigned_file"
+    gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$unsigned_file.sha256sum" "$unsigned_file.sha256sum"
+
+    echo "Verifying checksum..."
+    shasum --algorithm 256 --check "$unsigned_file.sha256sum"
+
+    tar -xf "$unsigned_file"
+    mv "$unsigned_base" "$base"
+
+    echo "Signing $base/$product..."
+    rcodesign sign \
+      --p12-file "$secrets_dir/cert.p12" --p12-password-file "$secrets_dir/cert.pass" \
+      --code-signature-flags runtime \
+      "$base/$product"
+    tar -czf "$target" "$base"
+
+    echo "Submitting for notarization..."
+    zip crl.zip "$base/$product"
+    retry rcodesign notary-submit \
+      --api-key-file "$secrets_dir/api_key.json" \
+      --wait \
+      crl.zip
+
+    rm -rf "$base" "$unsigned_file" "$unsigned_file.sha256sum" crl.zip
+
+    echo "Uploading signed archive: $target"
+    shasum --algorithm 256 "$target" > "$target.sha256sum"
+    gsutil -o 'GSUtil:num_retries=5' cp "$target" "gs://$gcs_staged_bucket/$target"
+    gsutil -o 'GSUtil:num_retries=5' cp "$target.sha256sum" "gs://$gcs_staged_bucket/$target.sha256sum"
+
+  done
+done
+echo "macOS signing complete."

--- a/build/github/release-sign-macos.sh
+++ b/build/github/release-sign-macos.sh
@@ -60,8 +60,8 @@ for product in cockroach cockroach-sql; do
     target=${base}.tgz
 
     echo "Downloading unsigned archive: $unsigned_file"
-    gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$unsigned_file" "$unsigned_file"
-    gsutil -o 'GSUtil:num_retries=5' cp "gs://$gcs_staged_bucket/$unsigned_file.sha256sum" "$unsigned_file.sha256sum"
+    gcloud storage cp "gs://$gcs_staged_bucket/$unsigned_file" "$unsigned_file"
+    gcloud storage cp "gs://$gcs_staged_bucket/$unsigned_file.sha256sum" "$unsigned_file.sha256sum"
 
     echo "Verifying checksum..."
     shasum --algorithm 256 --check "$unsigned_file.sha256sum"
@@ -87,8 +87,8 @@ for product in cockroach cockroach-sql; do
 
     echo "Uploading signed archive: $target"
     shasum --algorithm 256 "$target" > "$target.sha256sum"
-    gsutil -o 'GSUtil:num_retries=5' cp "$target" "gs://$gcs_staged_bucket/$target"
-    gsutil -o 'GSUtil:num_retries=5' cp "$target.sha256sum" "gs://$gcs_staged_bucket/$target.sha256sum"
+    gcloud storage cp "$target" "gs://$gcs_staged_bucket/$target"
+    gcloud storage cp "$target.sha256sum" "gs://$gcs_staged_bucket/$target.sha256sum"
 
   done
 done

--- a/build/github/release-update-versions.sh
+++ b/build/github/release-update-versions.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for the post-release "create version-update PRs"
+# step. Expects GH_TOKEN, SMTP_PASSWORD, and RELEASED_VERSION to be set by
+# the calling workflow step (secrets fetched via
+# google-github-actions/get-secretmanager-secrets, which auto-masks the
+# values with ::add-mask::).
+#
+# NOTE: This script intentionally does NOT use set -x. It handles secrets
+# that must never appear in build logs.
+
+set -euo pipefail
+
+: "${GH_TOKEN:?must be set by the workflow}"
+: "${SMTP_PASSWORD:?must be set by the workflow}"
+: "${RELEASED_VERSION:?must be set by the workflow}"
+
+# NEXT_VERSION is optional; the release tool computes it from RELEASED_VERSION
+# when empty. Export an explicit empty value so the impl script's `-e
+# NEXT_VERSION` passthrough sees it.
+export NEXT_VERSION="${NEXT_VERSION:-}"
+
+# IS_PRODUCTION_REPO is forwarded from a GHA repository variable (set only
+# on the production release repo). Export an explicit empty default so the
+# impl script's `-e IS_PRODUCTION_REPO` passthrough sees it on forks where
+# the variable is unset.
+export IS_PRODUCTION_REPO="${IS_PRODUCTION_REPO:-}"
+
+exec build/teamcity/internal/cockroach/release/process/update_versions.sh

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -23,7 +23,7 @@ mark_build() {
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
   else
     google_credentials=$GOOGLE_COCKROACH_RELEASE_CREDENTIALS
-    gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
+    gcr_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/cockroach-test"
   fi
   tc_end_block "Variable Setup"
 

--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -16,11 +16,19 @@ remove_files_on_exit() {
 trap remove_files_on_exit EXIT
 
 tc_start_block() {
-  echo "##teamcity[blockOpened name='$1']"
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::group::$1"
+  else
+    echo "##teamcity[blockOpened name='$1']"
+  fi
 }
 
 tc_end_block() {
-  echo "##teamcity[blockClosed name='$1']"
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::endgroup::"
+  else
+    echo "##teamcity[blockClosed name='$1']"
+  fi
 }
 
 docker_login_with_google() {
@@ -30,10 +38,15 @@ docker_login_with_google() {
 
 docker_login_gcr() {
   local repo=$1
-  local credentials=$2
+  local credentials=${2:-}
   local hostname="${repo%%/*}"
-  # https://cloud.google.com/container-registry/docs/advanced-authentication#json-key
-  echo "${credentials}" | docker login -u _json_key --password-stdin "https://${hostname}"
+  if [[ -n "${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE:-}" ]]; then
+    # WIF: use gcloud credential helper for Docker.
+    gcloud auth configure-docker "${hostname}" --quiet
+  else
+    # https://cloud.google.com/container-registry/docs/advanced-authentication#json-key
+    echo "${credentials}" | docker login -u _json_key --password-stdin "https://${hostname}"
+  fi
 }
 
 docker_login() {

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -31,6 +31,10 @@ DOCKER_EXPORT_COCKROACH_VARS=$(env | grep '^COCKROACH_' | cut -d= -f1 | sed -e '
 # image running the given script.
 # BAZEL_SUPPORT_EXTRA_DOCKER_ARGS will be passed on to `docker run` unchanged.
 run_bazel() {
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+        run_bazel_github "$@"
+        return
+    fi
     # Set up volumes.
     # TeamCity uses git alternates, so make sure we mount the path to the real
     # git objects.
@@ -43,6 +47,35 @@ run_bazel() {
     mkdir -p $cache
     vols="${vols} --volume ${root}:/go/src/github.com/cockroachdb/cockroach"
     vols="${vols} --volume ${cache}:/home/roach"
+
+    exit_status=0
+    docker run -i ${tty-} --rm --init \
+        -u "$(id -u):$(id -g)" \
+        --workdir="/go/src/github.com/cockroachdb/cockroach" \
+	${DOCKER_EXPORT_COCKROACH_VARS} \
+	${BAZEL_SUPPORT_EXTRA_DOCKER_ARGS:+$BAZEL_SUPPORT_EXTRA_DOCKER_ARGS} \
+        ${vols} \
+        $BAZEL_IMAGE "$@" || exit_status=$?
+    rm -rf _bazel
+    return $exit_status
+}
+
+# GitHub Actions sibling of run_bazel. Kept separate so the TC body of
+# run_bazel above stays identical to its pre-GHA-migration form, which
+# lets TC-side fixes backport cleanly to release branches that don't
+# carry the GHA migration.
+run_bazel_github() {
+    artifacts_dir=$root/artifacts
+    mkdir -p "$artifacts_dir"
+    vols="--volume ${artifacts_dir}:/artifacts"
+    vols="${vols} --volume ${root}:/go/src/github.com/cockroachdb/cockroach"
+    cache="${RUNNER_TEMP:-/tmp}/.bzlhome"
+    mkdir -p "$cache"
+    vols="${vols} --volume ${cache}:/home/roach"
+    if [[ -n "${GOOGLE_GHA_CREDS_PATH:-}" && -f "${GOOGLE_GHA_CREDS_PATH}" ]]; then
+        vols="${vols} --volume ${GOOGLE_GHA_CREDS_PATH}:${GOOGLE_GHA_CREDS_PATH}:ro"
+        BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="${BAZEL_SUPPORT_EXTRA_DOCKER_ARGS:-} -e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${GOOGLE_GHA_CREDS_PATH} -e GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_GHA_CREDS_PATH}"
+    fi
 
     exit_status=0
     docker run -i ${tty-} --rm --init \

--- a/build/teamcity-common-support.sh
+++ b/build/teamcity-common-support.sh
@@ -12,7 +12,13 @@ common_support_remove_files_on_exit() {
 }
 
 log_into_gcloud() {
-  if [[ "${google_credentials}" ]]; then
+  # When running under Workload Identity Federation (e.g. GitHub Actions), gcloud
+  # is already authenticated via CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE or
+  # GOOGLE_APPLICATION_CREDENTIALS set by the google-github-actions/auth action.
+  if [[ -n "${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE:-}" ]]; then
+    return
+  fi
+  if [[ "${google_credentials:-}" ]]; then
     echo "${google_credentials}" > .google-credentials.json
     gcloud auth activate-service-account --key-file=.google-credentials.json
   else

--- a/build/teamcity/internal/cockroach/release/process/update_versions.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions.sh
@@ -14,6 +14,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run Update Versions Release Phase"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e RELEASED_VERSION -e NEXT_VERSION -e SMTP_PASSWORD -e GH_TOKEN -e VERSION_BUMP_ONLY" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e RELEASED_VERSION -e NEXT_VERSION -e SMTP_PASSWORD -e GH_TOKEN -e VERSION_BUMP_ONLY -e IS_PRODUCTION_REPO -e COCKROACH_REPO -e GITHUB_USERNAME -e GITHUB_REPOSITORY -e TEAMCITY_VERSION" \
   run_bazel build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
 tc_end_block "Run Update Versions Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -11,15 +11,46 @@ set -xeuo pipefail
 to=dev-inf+release-dev@cockroachlabs.com
 dry_run=true
 version_bump_only=false
-# override dev defaults with production values
-if [[ -z "${DRY_RUN}" ]] ; then
+# Production destination (real email, dry_run=false) requires both DRY_RUN
+# unset AND running on the production release repo. IS_PRODUCTION_REPO is
+# forwarded from a GHA repository variable (set only on the canonical repo)
+# and is absent under TeamCity; default to "true" so the TC code path keeps
+# its existing behavior.
+if [[ -z "${DRY_RUN}" && "${IS_PRODUCTION_REPO:-true}" == "true" ]] ; then
   echo "Setting production values"
   to=release-engineering-team@cockroachlabs.com
   dry_run=false
 fi
 
-if [[ -n "${VERSION_BUMP_ONLY}" ]] ; then
+if [[ -n "${VERSION_BUMP_ONLY:-}" ]] ; then
   version_bump_only=true
+fi
+
+# Configure git to authenticate to github.com using GH_TOKEN. Inside the
+# bazel container the auth that actions/checkout writes to the host's
+# .git/config is not reliably picked up, so subsequent `git fetch` /
+# `git ls-remote` invocations would otherwise prompt for a username and
+# abort with:
+#   fatal: could not read Username for 'https://github.com'
+#
+# Embed the token in the URL via insteadOf rewrite (rather than an
+# extraheader, which GitHub's git-over-HTTPS server rejects in the
+# Bearer form). The rewrite only matches https://github.com/* URLs, so
+# under TeamCity (where origin is typically SSH) it is a no-op and the
+# existing TC SSH auth path is preserved.
+#
+# Use GIT_CONFIG_COUNT/_KEY/_VALUE rather than `git config --local` so the
+# credentialed URL exists only in this script's process environment — never
+# on disk in .git/config, which lives on the bind-mounted workspace and
+# would survive the bazel container's --rm. Suppress xtrace around the
+# assignment so `set -x` doesn't echo the token to stderr (where masking
+# may not catch a token embedded inside a URL substring).
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  { set +x; } 2>/dev/null
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf"
+  export GIT_CONFIG_VALUE_0="https://github.com/"
+  set -x
 fi
 
 # run git fetch in order to get all remote branches
@@ -36,6 +67,44 @@ export PATH=$PWD/bin:$PATH
 
 bazel build --config=crosslinux //pkg/cmd/release
 
+# --cockroach-repo picks the push target. Resolution, in order:
+#   1. $COCKROACH_REPO if the operator explicitly set it.
+#   2. $GITHUB_REPOSITORY if we're under GHA (auto-set by the runner;
+#      becomes "owner/name" of whatever repo dispatched the workflow).
+#   3. cockroachdb/cockroach if running under TeamCity ($TEAMCITY_VERSION
+#      set) — historical TC behavior preserved as a literal here, in
+#      the script, rather than baked into the Go binary.
+# Otherwise the binary errors out: --cockroach-repo is required and
+# local/foreign invocations must supply it explicitly.
+if [[ -n "${COCKROACH_REPO:-}" ]]; then
+  cockroach_repo="$COCKROACH_REPO"
+elif [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+  cockroach_repo="$GITHUB_REPOSITORY"
+elif [[ -n "${TEAMCITY_VERSION:-}" ]]; then
+  cockroach_repo="cockroachdb/cockroach"
+else
+  echo "ERROR: cannot derive --cockroach-repo. Set COCKROACH_REPO env var, run under GHA, or run under TeamCity." >&2
+  exit 1
+fi
+
+# Force IS_PRODUCTION_REPO=true under TeamCity (default-on for the
+# historical TC-as-prod assumption). The Go binary's isProductionRepo()
+# is the dry-run override trigger in generateRepoList, replacing the
+# previous flag-equals-literal check; under TC we want that trigger to
+# fire so dry-runs continue to push to crltest/* forks. GHA workflows
+# set IS_PRODUCTION_REPO explicitly via vars.IS_PRODUCTION_REPO; local
+# invocations get false unless the operator sets it.
+if [[ -n "${TEAMCITY_VERSION:-}" ]]; then
+  export IS_PRODUCTION_REPO="${IS_PRODUCTION_REPO:-true}"
+fi
+# --github-username controls which user pushes the PR branches and opens
+# the PRs. TC keeps the historical "cockroach-teamcity" default; the GHA
+# wrapper sets GITHUB_USERNAME to the bot account that owns its PAT
+# (e.g. "crl-release-eng-bot"). prExists() in the binary searches across
+# both authors regardless, so prior PRs aren't re-opened during the
+# migration period.
+github_username="${GITHUB_USERNAME:-cockroach-teamcity}"
+
 $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
   update-versions \
   --dry-run=$dry_run \
@@ -47,4 +116,6 @@ $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
   --smtp-host=smtp.gmail.com \
   --smtp-port=587 \
   --artifacts-dir=/artifacts \
+  --cockroach-repo="$cockroach_repo" \
+  --github-username="$github_username" \
   --to=$to

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -6,7 +6,7 @@
 # included in the /LICENSE file.
 
 
-set -euxo pipefail
+set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
 source "$dir/teamcity-support.sh"  # For log_into_gcloud
@@ -40,29 +40,66 @@ release_branch=$(echo "${version}" | grep -E -o '^v[0-9]+\.[0-9]+')
 if [[ -z "${DRY_RUN}" ]] ; then
   gcs_bucket="cockroach-release-artifacts-prod"
   gcs_staged_bucket="cockroach-release-artifacts-staged-prod"
-  # export the variable to avoid shell escaping
-  export gcs_credentials="$GCS_CREDENTIALS_PROD"
   if [[ $prerelease == false ]] ; then
     dockerhub_repository="docker.io/cockroachdb/cockroach"
   else
     dockerhub_repository="docker.io/cockroachdb/cockroach-unstable"
   fi
   gcr_staged_repository="us-docker.pkg.dev/releases-prod/cockroachdb-staged-releases/cockroach"
-  gcr_staged_credentials="$GCS_CREDENTIALS_PROD"
   gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
-  gcr_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS"
   git_repo_for_tag="cockroachdb/cockroach"
 else
   gcs_bucket="cockroach-release-artifacts-dryrun"
   gcs_staged_bucket="cockroach-release-artifacts-staged-dryrun"
-  # export the variable to avoid shell escaping
-  export gcs_credentials="$GCS_CREDENTIALS_DEV"
   dockerhub_repository="docker.io/cockroachdb/cockroach-misc"
   gcr_staged_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/cockroach"
-  gcr_staged_credentials="$GCS_CREDENTIALS_DEV"
-  gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
-  gcr_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
-  git_repo_for_tag=""
+  gcr_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/cockroach-test"
+  # In dry-run, only tag if the operator opts in by pointing DRYRUN_TAG_REPO at a
+  # writable fork (e.g. user/cockroach).
+  git_repo_for_tag="${DRYRUN_TAG_REPO:-}"
+fi
+
+# With WIF (GitHub Actions), credentials are handled via the environment.
+# With TeamCity, use the JSON key env vars.
+if [[ -n "${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE:-}" ]]; then
+  export gcs_credentials=""
+  gcr_staged_credentials=""
+  gcr_credentials=""
+else
+  if [[ -z "${DRY_RUN}" ]] ; then
+    export gcs_credentials="$GCS_CREDENTIALS_PROD"
+    gcr_staged_credentials="$GCS_CREDENTIALS_PROD"
+    gcr_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS"
+  else
+    export gcs_credentials="$GCS_CREDENTIALS_DEV"
+    gcr_staged_credentials="$GCS_CREDENTIALS_DEV"
+    gcr_credentials="${GOOGLE_COCKROACH_RELEASE_CREDENTIALS:-$GCS_CREDENTIALS_DEV}"
+  fi
+fi
+
+# Pick git tag remote + auth. TeamCity sets the SSH deploy key and uses
+# SSH; GitHub Actions sets a PAT (GH_TOKEN) and uses HTTPS with the
+# token embedded in the URL. The PAT must authorize git_repo_for_tag —
+# the prod repo for real publishes, and any fork used for dry-run
+# rehearsal. The GHA branch reads GH_TOKEN, not GITHUB_TOKEN: GHA's
+# runner reserves GITHUB_TOKEN for the auto-issued workflow token and
+# may shadow values set in the step's env block, so we use GH_TOKEN
+# both here and in the workflow.
+tag_remote=""
+tag_git_cmd=""
+if [[ -n "${git_repo_for_tag}" ]]; then
+  if [[ -n "${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY:-}" ]]; then
+    github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
+    configure_git_ssh_key
+    tag_remote="ssh://git@github.com/${git_repo_for_tag}.git"
+    tag_git_cmd="git_wrapped"
+  elif [[ -n "${GH_TOKEN:-}" ]]; then
+    tag_remote="https://x-access-token:${GH_TOKEN}@github.com/${git_repo_for_tag}.git"
+    tag_git_cmd="git"
+  else
+    echo "ERROR: tag repo ${git_repo_for_tag} configured but neither GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY nor GH_TOKEN is set"
+    exit 1
+  fi
 fi
 
 tc_end_block "Variable Setup"
@@ -70,21 +107,19 @@ tc_end_block "Variable Setup"
 tc_start_block "Verify binaries SHA"
 # Make sure that the linux/amd64 source docker image is built using the same version and SHA. 
 # This is a quick check and it assumes that the docker image was built correctly and based on the tarball binaries.
-docker_login_gcr "$gcr_staged_repository" "$gcr_staged_credentials"
+docker_login_gcr "$gcr_staged_repository" "${gcr_staged_credentials:-}"
 verify_docker_image "${gcr_staged_repository}:${version}" "linux/amd64" "$BUILD_VCS_NUMBER" "$version" false false
 tc_end_block "Verify binaries SHA"
 
 tc_start_block "Check remote tag and tag"
-if [[ -z "${DRY_RUN}" ]]; then
-  github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY}"
-  configure_git_ssh_key
-  if git_wrapped ls-remote --exit-code --tags "ssh://git@github.com/${git_repo_for_tag}.git" "${version}"; then
+if [[ -n "${git_repo_for_tag}" ]]; then
+  if "${tag_git_cmd}" ls-remote --exit-code --tags "${tag_remote}" "${version}"; then
     echo "Tag ${version} already exists"
     exit 1
   fi
   git tag "${version}"
 else
-  echo "Skipping for dry-run"
+  echo "No tag repo configured; skipping"
 fi
 tc_end_block "Check remote tag and tag"
 
@@ -160,11 +195,10 @@ tc_end_block "Make and push FIPS docker image"
 
 
 tc_start_block "Push release tag to GitHub"
-if [[ -z "${DRY_RUN}" ]]; then
-  configure_git_ssh_key
-  git_wrapped push "ssh://git@github.com/${git_repo_for_tag}.git" "$version"
+if [[ -n "${git_repo_for_tag}" ]]; then
+  "${tag_git_cmd}" push "${tag_remote}" "$version"
 else
-  echo "skipping for dry-run"
+  echo "No tag repo configured; skipping"
 fi
 tc_end_block "Push release tag to GitHub"
 

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -139,8 +139,8 @@ for product in cockroach cockroach-sql; do
           archive_suffix=zip
       fi
       archive="$product-$version.$platform.$archive_suffix"
-      gsutil cp "gs://$gcs_staged_bucket/$archive" "gs://$gcs_bucket/$archive"
-      gsutil cp "gs://$gcs_staged_bucket/$archive.sha256sum" "gs://$gcs_bucket/$archive.sha256sum"
+      gcloud storage cp "gs://$gcs_staged_bucket/$archive" "gs://$gcs_bucket/$archive"
+      gcloud storage cp "gs://$gcs_staged_bucket/$archive.sha256sum" "gs://$gcs_bucket/$archive.sha256sum"
   done
 done
 tc_end_block "Copy binaries"
@@ -215,8 +215,8 @@ if [[ -n "${PUBLISH_LATEST}" && $prerelease == false ]]; then
         fi
         from="$product-$version.$platform.$archive_suffix"
         to="$product-latest.$platform.$archive_suffix"
-        gsutil cp "gs://$gcs_bucket/$from" "gs://$gcs_bucket/$to"
-        gsutil cp "gs://$gcs_bucket/$from.sha256sum" "gs://$gcs_bucket/$to.sha256sum"
+        gcloud storage cp "gs://$gcs_bucket/$from" "gs://$gcs_bucket/$to"
+        gcloud storage cp "gs://$gcs_bucket/$from.sha256sum" "gs://$gcs_bucket/$to.sha256sum"
     done
   done
 else

--- a/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
@@ -6,7 +6,7 @@
 # included in the /LICENSE file.
 
 
-set -euxo pipefail
+set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
@@ -15,14 +15,24 @@ tc_start_block "Variable Setup"
 version=$(grep -v "^#" "$dir/../pkg/build/version.txt" | head -n1)
 if [[ -z "${DRY_RUN}" ]] ; then
   gcr_staged_repository="us-docker.pkg.dev/releases-prod/cockroachdb-staged-releases/cockroach"
-  gcr_staged_credentials="$GCS_CREDENTIALS_PROD"
   gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
-  gcr_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS"
 else
   gcr_staged_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/cockroach"
-  gcr_staged_credentials="$GCS_CREDENTIALS_DEV"
   gcr_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/cockroach-cloud-only"
-  gcr_credentials="$GCS_CREDENTIALS_DEV"
+fi
+
+# With WIF (GitHub Actions), credentials are handled via the environment.
+# With TeamCity, use the JSON key env vars.
+gcr_staged_credentials=""
+gcr_credentials=""
+if [[ -z "${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE:-}" ]]; then
+  if [[ -z "${DRY_RUN}" ]] ; then
+    gcr_staged_credentials="$GCS_CREDENTIALS_PROD"
+    gcr_credentials="$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS"
+  else
+    gcr_staged_credentials="$GCS_CREDENTIALS_DEV"
+    gcr_credentials="$GCS_CREDENTIALS_DEV"
+  fi
 fi
 tc_end_block "Variable Setup"
 

--- a/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
@@ -6,7 +6,7 @@
 # included in the /LICENSE file.
 
 
-set -euxo pipefail
+set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
@@ -21,11 +21,21 @@ fi
 
 version=$(grep -v "^#" "$dir/../pkg/build/version.txt" | head -n1)
 if [[ -z "${DRY_RUN}" ]] ; then
-  gcr_credentials="$GCS_CREDENTIALS_PROD"
   gcr_staged_repository="us-docker.pkg.dev/releases-prod/cockroachdb-staged-releases/${cockroach_archive_prefix}"
 else
-  gcr_credentials="$GCS_CREDENTIALS_DEV"
   gcr_staged_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/${cockroach_archive_prefix}"
+fi
+
+# With WIF (GitHub Actions), credentials are handled via mounted credential
+# files rather than JSON key env vars. gcr_credentials may be empty.
+if [[ -n "${GCS_CREDENTIALS_PROD:-}" || -n "${GCS_CREDENTIALS_DEV:-}" ]]; then
+  if [[ -z "${DRY_RUN}" ]] ; then
+    gcr_credentials="$GCS_CREDENTIALS_PROD"
+  else
+    gcr_credentials="$GCS_CREDENTIALS_DEV"
+  fi
+else
+  gcr_credentials=""
 fi
 tc_end_block "Variable Setup"
 

--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -6,7 +6,7 @@
 # included in the /LICENSE file.
 
 
-set -euxo pipefail
+set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
@@ -35,16 +35,25 @@ fi
 
 if [[ -z "${DRY_RUN}" ]] ; then
   gcs_bucket="cockroach-release-artifacts-staged-prod"
-  gcr_credentials="$GCS_CREDENTIALS_PROD"
-  # export the variable to avoid shell escaping
-  export gcs_credentials="$GCS_CREDENTIALS_PROD"
   gcr_staged_repository="us-docker.pkg.dev/releases-prod/cockroachdb-staged-releases/${cockroach_archive_prefix}"
 else
   gcs_bucket="cockroach-release-artifacts-staged-dryrun"
-  gcr_credentials="$GCS_CREDENTIALS_DEV"
-  # export the variable to avoid shell escaping
-  export gcs_credentials="$GCS_CREDENTIALS_DEV"
   gcr_staged_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/${cockroach_archive_prefix}"
+fi
+
+# With WIF (GitHub Actions), credentials are handled via mounted credential
+# files rather than JSON key env vars. gcs_credentials and gcr_credentials may be empty.
+if [[ -n "${GCS_CREDENTIALS_PROD:-}" || -n "${GCS_CREDENTIALS_DEV:-}" ]]; then
+  if [[ -z "${DRY_RUN}" ]] ; then
+    gcr_credentials="$GCS_CREDENTIALS_PROD"
+    export gcs_credentials="$GCS_CREDENTIALS_PROD"
+  else
+    gcr_credentials="$GCS_CREDENTIALS_DEV"
+    export gcs_credentials="$GCS_CREDENTIALS_DEV"
+  fi
+else
+  gcr_credentials=""
+  export gcs_credentials=""
 fi
 
 tc_end_block "Variable Setup"
@@ -57,7 +66,12 @@ BAZEL_BIN=$(bazel info bazel-bin)
 export google_credentials="$gcs_credentials"
 source "build/teamcity-support.sh"  # For log_into_gcloud
 log_into_gcloud
-export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
+# Under WIF (GitHub Actions), GOOGLE_APPLICATION_CREDENTIALS is already set to
+# the mounted credential file. Only override it for TeamCity (service-account
+# key written to .google-credentials.json by log_into_gcloud).
+if [[ -z "${CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE:-}" ]]; then
+  export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
+fi
 
 cat licenses/THIRD-PARTY-NOTICES.txt > /tmp/THIRD-PARTY-NOTICES.txt.tmp
 echo "================================================================================" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -37,8 +37,8 @@ if [[ -z "${DRY_RUN}" ]] ; then
 else
   build_name="${build_name}.dryrun"
   google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
-  gcr_repository="us.gcr.io/cockroach-release/${cockroach_archive_prefix}-test"
-  gcr_hostname="us.gcr.io"
+  gcr_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/${cockroach_archive_prefix}-test"
+  gcr_hostname="us-docker.pkg.dev"
 fi
 
 cat << EOF

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -48,9 +48,9 @@ if [[ -z "${DRY_RUN}" ]] ; then
 else
   gcs_bucket="cockroach-builds-artifacts-dryrun"
   google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
-  gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
+  gcr_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/${cockroach_archive_prefix}-test"
   build_name="${build_name}.dryrun"
-  gcr_hostname="us.gcr.io"
+  gcr_hostname="us-docker.pkg.dev"
   # export the variable to avoid shell escaping
   export gcs_credentials="$GCS_CREDENTIALS_DEV"
 fi

--- a/build/teamcity/internal/release/process/make-and-publish-build.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build.sh
@@ -52,7 +52,7 @@ if [[ -z "${DRY_RUN}" ]]; then
 else
   gcs_bucket="cockroach-builds-artifacts-dryrun"
   google_credentials="$GOOGLE_COCKROACH_RELEASE_CREDENTIALS"
-  gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
+  gcr_repository="us-docker.pkg.dev/releases-dev-356314/cockroachdb-staged-releases/cockroach-test"
   build_name="${build_name}.dryrun"
   gcr_hostname="us.gcr.io"
   metadata_gcs_bucket="cockroach-release-qualification-test"

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -3,9 +3,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "release_lib",
     srcs = [
+        "cut_staging_branches.go",
         "git.go",
+        "github_client.go",
+        "jira_adf.go",
+        "jira_client.go",
         "main.go",
+        "pick_sha.go",
+        "release_notes_api.go",
         "sender.go",
+        "slack_post.go",
         "templates.go",
         "update_brew.go",
         "update_helm.go",
@@ -20,10 +27,14 @@ go_library(
         "//pkg/testutils/release",
         "//pkg/util/httputil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_version//:version",
+        "@com_github_google_go_github_v61//github",
         "@com_github_jordan_wright_email//:email",
+        "@com_github_slack_go_slack//:slack",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 
@@ -36,7 +47,9 @@ go_binary(
 go_test(
     name = "release_test",
     srcs = [
+        "cut_staging_branches_test.go",
         "git_test.go",
+        "pick_sha_test.go",
         "update_releases_test.go",
     ],
     data = glob([
@@ -47,6 +60,7 @@ go_test(
     deps = [
         "//pkg/testutils/release",
         "@com_github_cockroachdb_version//:version",
+        "@com_github_slack_go_slack//:slack",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],

--- a/pkg/cmd/release/cut_staging_branches.go
+++ b/pkg/cmd/release/cut_staging_branches.go
@@ -1,0 +1,843 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/version"
+	"github.com/spf13/cobra"
+)
+
+// JQL used to find release tickets that are ready to have their staging
+// branch cut: type=Release, parented (REL-217 holds historical/template
+// tickets without parents that we don't want to act on), open, and missing
+// a Staging Branch value.
+const cutStagingJQL = `issueType="CRDB Release" and parent is not empty and ` +
+	`status not in (done, cancelled, "Post-Publish Tasks") and ` +
+	`"Staging Branch[Short text]" is empty`
+
+// cutStagingJQLDryRun drops the `parent is not empty` filter so dry runs can
+// rehearse against parent/template tickets (e.g. REL-217 children themselves
+// being parents). We never act on those in production runs.
+const cutStagingJQLDryRun = `issueType="CRDB Release" and ` +
+	`status not in (done, cancelled, "Post-Publish Tasks") and ` +
+	`"Staging Branch[Short text]" is empty`
+
+// Custom field IDs in the cockroachlabs.atlassian.net "CRDB Release" project.
+const (
+	cfReleaseStatus       = "customfield_10584"
+	cfCutBranchDate       = "customfield_10585"
+	cfPickSHADate         = "customfield_10586"
+	cfCloudReleaseNotes   = "customfield_10588"
+	cfPublishBinary       = "customfield_10589"
+	cfStagingBranch       = "customfield_10592"
+	cfReleaseTypeOverride = "customfield_10507"
+	cfBuildSHA            = "customfield_10590"
+)
+
+// Jira workflow transition IDs. These are project-wide and stable.
+const (
+	transitionBaking       = "151" // moves a release ticket into Baking status
+	transitionSubtaskDone  = "51"  // marks a CRDB Sub-task as Done
+	cutStagingSubtaskMatch = "Cut Staging Branch"
+	// bakingStatusName is the workflow status name the ticket lands in after
+	// transitionBaking. processCandidate compares against this to skip the
+	// transition on partial-failure recovery (Jira rejects re-transitioning
+	// to the current state).
+	bakingStatusName = "Baking"
+)
+
+// Release types — used only to choose between the two Slack message
+// templates. The values here are also accepted from Jira's customfield_10507
+// override (case-insensitive); preReleaseType matters in the comparison.
+const (
+	preReleaseType   = "Pre-Release"
+	majorReleaseType = "Major Release"
+	scheduledType    = "Scheduled"
+)
+
+const (
+	// defaultCockroachRepo is the fallback GitHub repo that holds release
+	// branches when neither --repo nor GITHUB_REPOSITORY is set (e.g. local
+	// invocations outside of GitHub Actions).
+	defaultCockroachRepo = "cockroachdb/cockroach"
+	releaseChannel       = "#db-release-status"
+	opsChannel           = "#release-ops"
+	// nonProdChannel keeps Slack noise out of the production channel when
+	// the workflow is exercised against a fork (e.g. user/cockroach).
+	// The repo identity, not --dry-run, decides which channel is used.
+	nonProdChannel = "#db-release-test"
+
+	envJiraToken     = "JIRA_API_TOKEN"
+	envJiraEmail     = "JIRA_EMAIL"
+	envSlackBotToken = "SLACK_BOT_TOKEN"
+	// envCutGitHubToken is the GitHub personal-access token used by the
+	// branch-cut and pick-sha commands. The standard GITHUB_TOKEN name is
+	// used so GitHub Actions forwards the fetched PAT without any extra
+	// env-var renaming in the workflow step.
+	envCutGitHubToken = "GITHUB_TOKEN"
+	// envGitHubRepository is the standard env var GitHub Actions populates
+	// with the owner/name of the running repository.
+	envGitHubRepository = "GITHUB_REPOSITORY"
+)
+
+var cutStagingFlags = struct {
+	dryRun       bool
+	testIssueKey string
+	today        string
+	repo         string
+	channel      string
+	opsChannel   string
+}{}
+
+var cutStagingBranchesCmd = &cobra.Command{
+	Use:   "cut-staging-branches",
+	Short: "Cut release staging branches whose Jira cut date has arrived",
+	Long: `Queries Jira for CRDB Release tickets whose Cut Branch Date is today or
+earlier and whose Staging Branch field is unset, then for each such ticket
+creates the staging branch on GitHub, updates the Jira ticket, posts a Slack
+notification, and creates the matching backport label.
+
+Pre-release tickets (e.g. v25.3.1-alpha.1) get a different Slack template.
+Patch-zero releases are skipped — those .0 builds ship from the existing
+release-X.Y branch.`,
+	RunE: runCutStagingBranches,
+}
+
+// defaultRepo picks the GitHub Actions-provided $GITHUB_REPOSITORY when
+// available so the workflow doesn't need to pass --repo explicitly. It
+// falls back to defaultCockroachRepo for local invocations.
+func defaultRepo() string {
+	if r := os.Getenv(envGitHubRepository); r != "" {
+		return r
+	}
+	return defaultCockroachRepo
+}
+
+func init() {
+	cutStagingBranchesCmd.Flags().BoolVar(&cutStagingFlags.dryRun, "dry-run", false,
+		"print actions and skip Jira/GitHub mutations; Slack messages are prefixed with [DRY RUN]")
+	cutStagingBranchesCmd.Flags().StringVar(&cutStagingFlags.testIssueKey, "test-issue-key", "",
+		"treat the named issue as the only candidate, bypassing the JQL search "+
+			"(use to rehearse in dry-run, or to scope a production run to a single ticket)")
+	cutStagingBranchesCmd.Flags().StringVar(&cutStagingFlags.today, "today", "",
+		"override 'today' for eligibility checks (YYYY-MM-DD)")
+	cutStagingBranchesCmd.Flags().StringVar(&cutStagingFlags.repo, "repo", defaultRepo(),
+		"target GitHub repository in owner/name form (defaults to $GITHUB_REPOSITORY when set)")
+	cutStagingBranchesCmd.Flags().StringVar(&cutStagingFlags.channel, "slack-channel", "",
+		"Slack channel for success notifications (default: "+releaseChannel+
+			" when "+envIsProductionRepo+"=true, "+nonProdChannel+" otherwise)")
+	cutStagingBranchesCmd.Flags().StringVar(&cutStagingFlags.opsChannel, "ops-channel", opsChannel,
+		"Slack channel for failure notifications")
+}
+
+func runCutStagingBranches(_ *cobra.Command, _ []string) error {
+	jiraToken := os.Getenv(envJiraToken)
+	if jiraToken == "" {
+		return errors.Newf("%s is not set", envJiraToken)
+	}
+	jiraEmail := os.Getenv(envJiraEmail)
+	if jiraEmail == "" {
+		return errors.Newf("%s is not set", envJiraEmail)
+	}
+	ghToken := os.Getenv(envCutGitHubToken)
+	if ghToken == "" {
+		return errors.Newf("%s is not set", envCutGitHubToken)
+	}
+	slackToken := os.Getenv(envSlackBotToken)
+	if slackToken == "" {
+		return errors.Newf("%s is not set", envSlackBotToken)
+	}
+
+	owner, repoName, err := splitRepo(cutStagingFlags.repo)
+	if err != nil {
+		return errors.Wrap(err, "parsing --repo")
+	}
+
+	today, err := resolveToday(cutStagingFlags.today)
+	if err != nil {
+		return errors.Wrap(err, "resolving today's date")
+	}
+
+	jira := newJiraClient(jiraEmail, jiraToken)
+	gh := newGitHubClient(ghToken, owner, repoName)
+	sl := newSlackClient(slackToken)
+
+	// When the workflow is exercised against a fork, route Slack to a
+	// non-prod channel so rehearsal traffic doesn't reach #db-release-status.
+	// An explicit --slack-channel always wins.
+	channel := cutStagingFlags.channel
+	if channel == "" {
+		channel = nonProdChannel
+		if isProductionRepo() {
+			channel = releaseChannel
+		}
+	}
+	r := &cutRunner{
+		jira:         jira,
+		gh:           gh,
+		slack:        sl,
+		dryRun:       cutStagingFlags.dryRun,
+		testIssueKey: cutStagingFlags.testIssueKey,
+		today:        today,
+		channel:      channel,
+		opsChannel:   cutStagingFlags.opsChannel,
+		repo:         cutStagingFlags.repo,
+	}
+	return r.run(context.Background())
+}
+
+// cutRunner holds the wired-up dependencies and per-invocation knobs for one
+// run of the branch-cut workflow.
+type cutRunner struct {
+	jira  *jiraClient
+	gh    *githubClient
+	slack *slackClient
+
+	dryRun       bool
+	testIssueKey string
+	today        time.Time
+	channel      string
+	opsChannel   string
+	repo         string
+}
+
+func (r *cutRunner) run(ctx context.Context) error {
+	candidates, err := r.candidates()
+	if err != nil {
+		r.notifyFailure(err)
+		return err
+	}
+	log.Printf("Jira returned %d candidate ticket(s)", len(candidates))
+
+	var firstErr error
+	for _, c := range candidates {
+		if err := r.processCandidate(ctx, c); err != nil {
+			log.Printf("ticket %s failed: %v", c.Key, err)
+			r.notifyFailure(errors.Wrapf(err, "ticket %s", c.Key))
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func (r *cutRunner) processCandidate(ctx context.Context, c jiraIssue) error {
+	v, err := parseReleaseVersion(c.Fields.Summary)
+	if err != nil {
+		// Tracking/template tickets that match the JQL but aren't real
+		// release tickets (e.g. summary "Release: 26.1|25.4|25.2 next
+		// patch") aren't actionable — log and move on rather than
+		// failing the whole run. The relaxed dry-run JQL exposes more
+		// of these than production ever will.
+		log.Printf("ticket %s: skipping unparseable summary: %v", c.Key, err)
+		return nil
+	}
+
+	// Patch .0 releases ship from the existing release-X.Y branch — no
+	// staging branch to cut.
+	if v.Patch() == 0 {
+		log.Printf("ticket %s: skipping patch-zero release %s", c.Key, v)
+		return nil
+	}
+
+	// Cut Branch Date is the one schedule field the workflow can't
+	// proceed without — the rest only feed the Slack/Jira message
+	// templates and may legitimately be filled in later.
+	cutDate, err := c.stringField(cfCutBranchDate)
+	if err != nil {
+		return errors.Wrap(err, "reading cut-branch-date field")
+	}
+	if cutDate == "" {
+		log.Printf("ticket %s: skipping — Cut Branch Date is unset", c.Key)
+		return nil
+	}
+
+	// When --test-issue-key is set the operator picked this ticket
+	// explicitly (rehearsal or one-off recovery), so we bypass the
+	// cut-date readiness check; otherwise a future-dated ticket would
+	// be silently skipped.
+	if r.testIssueKey == "" {
+		ready, err := isCutDateReady(cutDate, r.today)
+		if err != nil {
+			return errors.Wrap(err, "evaluating cut-branch-date readiness")
+		}
+		if !ready {
+			log.Printf("ticket %s: cut date %s not yet reached (today=%s)",
+				c.Key, cutDate, dateOnly(r.today))
+			return nil
+		}
+	}
+
+	full, err := r.jira.GetIssue(c.Key)
+	if err != nil {
+		return errors.Wrapf(err, "fetching full Jira issue %s", c.Key)
+	}
+	issueKey := c.Key
+
+	branchNames := deriveBranchNames(v)
+	baseSHA, branchAlreadyCut, err := r.validate(ctx, full, branchNames)
+	if err != nil {
+		return errors.Wrap(err, "validating ticket and repo state")
+	}
+	now := timeNow()
+	details, err := buildReleaseDetails(v, full, branchNames, baseSHA, now, r.repo)
+	if err != nil {
+		return errors.Wrap(err, "building release details")
+	}
+
+	if !r.dryRun {
+		if branchAlreadyCut {
+			log.Printf("ticket %s: staging branch %s already exists (Jira matches), "+
+				"resuming after prior partial failure",
+				issueKey, branchNames.staging)
+		} else if err := r.gh.CreateBranch(ctx, branchNames.staging, baseSHA); err != nil {
+			return errors.Wrapf(err, "creating staging branch %s at %s",
+				branchNames.staging, baseSHA)
+		}
+		if err := r.jira.UpdateFields(issueKey, map[string]interface{}{
+			cfStagingBranch: details.StagingBranch,
+			cfReleaseStatus: details.ReleaseStatus,
+		}); err != nil {
+			return errors.Wrap(err, "updating Jira staging-branch and release-status fields")
+		}
+		// Skip the transition when the ticket is already Baking — Jira
+		// rejects transitioning into the current state, which would otherwise
+		// wedge a recovery run that previously got past this point but
+		// failed at a later step (label create, Slack post, Jira comment).
+		// Treat an empty status name (older snapshot, parse failure) as
+		// "unknown, proceed" so a fresh ticket is never blocked.
+		if full.statusName() != bakingStatusName {
+			if err := r.jira.Transition(issueKey, transitionBaking); err != nil {
+				return errors.Wrapf(err, "transitioning ticket %s to Baking", issueKey)
+			}
+		} else {
+			log.Printf("ticket %s: already in %s status, skipping transition",
+				issueKey, bakingStatusName)
+		}
+		if subtaskKey := findCutSubtask(full); subtaskKey != "" {
+			if err := r.jira.Transition(subtaskKey, transitionSubtaskDone); err != nil {
+				return errors.Wrapf(err, "transitioning subtask %s to Done", subtaskKey)
+			}
+		}
+		if err := r.gh.CreateLabel(ctx,
+			details.BackportLabel, details.BackportLabelDescription, "f29513"); err != nil {
+			return errors.Wrapf(err, "creating backport label %s", details.BackportLabel)
+		}
+	} else {
+		log.Printf("[DRY RUN] would create branch %s at %s in %s",
+			branchNames.staging, baseSHA, r.repo)
+		log.Printf("[DRY RUN] would update Jira %s: stagingBranch=%s releaseStatus=%s",
+			issueKey, details.StagingBranch, details.ReleaseStatus)
+		log.Printf("[DRY RUN] would transition %s to Baking", issueKey)
+		log.Printf("[DRY RUN] would create label %s (%s)",
+			details.BackportLabel, details.BackportLabelDescription)
+	}
+
+	msg := buildSlackMessage(details, r.dryRun)
+	link, err := r.slack.PostMessage(r.channel, msg)
+	if err != nil {
+		return errors.Wrap(err, "posting Slack message")
+	}
+	if !r.dryRun {
+		if err := r.jira.AddComment(issueKey, buildJiraComment(details, link)); err != nil {
+			return errors.Wrap(err, "adding Jira comment")
+		}
+	} else {
+		log.Printf("[DRY RUN] would add Jira comment on %s with Slack link %q", issueKey, link)
+	}
+	if r.dryRun {
+		log.Printf("[DRY RUN] ticket %s: would cut staging branch %s at %s", issueKey, branchNames.staging, baseSHA)
+	} else {
+		log.Printf("ticket %s: cut staging branch %s at %s", issueKey, branchNames.staging, baseSHA)
+	}
+	return nil
+}
+
+// candidates returns the list of Jira tickets to evaluate. When
+// --test-issue-key is set it bypasses the JQL search and returns just that
+// ticket — so the same flag works for dry-run rehearsals and for scoping a
+// production run to a single ticket (e.g. one-off recovery).
+func (r *cutRunner) candidates() ([]jiraIssue, error) {
+	if r.testIssueKey != "" {
+		issue, err := r.jira.GetIssue(r.testIssueKey)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fetching test issue %s", r.testIssueKey)
+		}
+		return []jiraIssue{*issue}, nil
+	}
+	jql := cutStagingJQL
+	if r.dryRun {
+		jql = cutStagingJQLDryRun
+	}
+	candidates, err := r.jira.SearchJQL(jql, []string{"*all"})
+	if err != nil {
+		return nil, errors.Wrap(err, "searching Jira for candidate tickets")
+	}
+	return candidates, nil
+}
+
+// validate verifies that the ticket and the GitHub repo are in a state where
+// we can cut the staging branch, and returns the SHA the caller should record
+// as "cut at". It distinguishes a missing base branch (errBranchNotFound)
+// from any other GitHub failure, which is propagated as-is so transient
+// infrastructure errors don't get reported as "branch not found".
+//
+// When the staging branch already exists on GitHub *and* Jira's
+// cfStagingBranch field already names it, validate treats this as a recovery
+// from a partially-failed prior run: it returns branchAlreadyCut=true and
+// the existing staging-branch tip SHA, and the caller should skip
+// CreateBranch and re-run the remaining (idempotent) steps. Without this
+// gate, a failure between CreateBranch and the Jira/Slack side effects
+// would wedge the ticket until an operator manually deleted the branch.
+func (r *cutRunner) validate(
+	ctx context.Context, full *jiraIssue, b branchNames,
+) (sha string, branchAlreadyCut bool, _ error) {
+	jiraStaging, err := full.stringField(cfStagingBranch)
+	if err != nil {
+		return "", false, errors.Wrap(err, "reading staging-branch field from Jira")
+	}
+	exists, err := r.gh.BranchExists(ctx, b.staging)
+	if err != nil {
+		return "", false, errors.Wrapf(err, "checking for existing staging branch %s on GitHub", b.staging)
+	}
+	if exists {
+		// The branch is on GitHub. Only resume if Jira agrees this is the
+		// branch for this ticket — otherwise we don't know who created it,
+		// and creating the rest of the side effects on top would mislabel
+		// foreign state as ours.
+		if jiraStaging != b.staging {
+			return "", false, errors.Newf(
+				"staging branch %s already exists on GitHub but cfStagingBranch in Jira is %q",
+				b.staging, jiraStaging)
+		}
+		sha, err := r.gh.GetBranchSHA(ctx, b.staging)
+		if err != nil {
+			return "", false, errors.Wrapf(err,
+				"fetching tip SHA for existing staging branch %s", b.staging)
+		}
+		return sha, true, nil
+	}
+	// The branch isn't on GitHub. If Jira already names a staging branch
+	// the workspace state is inconsistent — refuse to cut silently and let
+	// an operator reconcile.
+	if jiraStaging != "" && !r.dryRun {
+		return "", false, errors.Newf(
+			"cfStagingBranch in Jira is %q but no such branch exists on GitHub",
+			jiraStaging)
+	}
+	baseSHA, err := r.gh.GetBranchSHA(ctx, b.base)
+	if err != nil {
+		if errors.Is(err, errBranchNotFound) {
+			return "", false, errors.Newf("base branch %s does not exist on GitHub", b.base)
+		}
+		return "", false, errors.Wrapf(err, "fetching tip SHA for base branch %s", b.base)
+	}
+	return baseSHA, false, nil
+}
+
+// notifyFailure posts a one-line summary to Slack so operators see "something
+// broke" with a pointer to the GHA run for the full error. We deliberately
+// don't forward err.Error() — upstream API errors can include large response
+// bodies, and a short message keeps #release-ops readable. The full error
+// is still logged via log.Printf in the caller and visible in the run log.
+func (r *cutRunner) notifyFailure(err error) {
+	headline := firstLine(err.Error())
+	msg := fmt.Sprintf(":x: branch-cut failed (%s): %s", r.repo, headline)
+	if link := actionsRunURL(); link != "" {
+		msg += " — see " + link
+	}
+	if r.dryRun {
+		msg = "[DRY RUN] " + msg
+	}
+	if _, postErr := r.slack.PostMessage(r.opsChannel, msg); postErr != nil {
+		log.Printf("failed to post failure to %s: %v", r.opsChannel, postErr)
+	}
+}
+
+// firstLine returns the first line of s, trimmed and capped at 200 chars,
+// suitable for a one-line Slack summary.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.TrimSpace(s)
+	const max = 200
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}
+
+// actionsRunURL returns a link to the current GitHub Actions run when the
+// standard GHA env vars are set, else "".
+func actionsRunURL() string {
+	server := os.Getenv("GITHUB_SERVER_URL")
+	repo := os.Getenv(envGitHubRepository)
+	runID := os.Getenv("GITHUB_RUN_ID")
+	if server == "" || repo == "" || runID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/actions/runs/%s", server, repo, runID)
+}
+
+// branchNames holds the base and staging branch names derived from a
+// release version.
+type branchNames struct {
+	base    string // release-25.4
+	staging string // release-25.4.3-rc
+}
+
+func deriveBranchNames(v version.Version) branchNames {
+	base := fmt.Sprintf("release-%d.%d", v.Major().Year, v.Major().Ordinal)
+	staging := fmt.Sprintf("release-%d.%d.%d-rc", v.Major().Year, v.Major().Ordinal, v.Patch())
+	return branchNames{base: base, staging: staging}
+}
+
+// parseReleaseVersion extracts the version from a Jira summary of the form
+// "Release: vX.Y.Z[ ...]".
+func parseReleaseVersion(summary string) (version.Version, error) {
+	const prefix = "Release: v"
+	if !strings.HasPrefix(summary, prefix) {
+		return version.Version{}, errors.Newf("summary does not start with %q: %s", prefix, summary)
+	}
+	// Take everything after "Release: " and split on whitespace to keep
+	// only the first word (the version itself).
+	rest := strings.TrimPrefix(summary, "Release: ")
+	versionStr := strings.Fields(rest)[0]
+	v, err := version.Parse(versionStr)
+	if err != nil {
+		return version.Version{}, errors.Wrapf(err, "parsing version %q from summary", versionStr)
+	}
+	return v, nil
+}
+
+// isCutDateReady reports whether the cut date string (YYYY-MM-DD) is on or
+// before today. An empty cut date is treated as "not ready" so we never cut
+// a branch for a ticket missing the date.
+func isCutDateReady(cutDate string, today time.Time) (bool, error) {
+	if cutDate == "" {
+		return false, nil
+	}
+	d, err := time.Parse("2006-01-02", cutDate)
+	if err != nil {
+		return false, errors.Wrapf(err, "parsing cut date %q", cutDate)
+	}
+	return !dateOnly(today).Before(d), nil
+}
+
+// resolveToday returns the override date when set, else today's local date.
+func resolveToday(override string) (time.Time, error) {
+	if override == "" {
+		return timeNow(), nil
+	}
+	t, err := time.Parse("2006-01-02", override)
+	if err != nil {
+		return time.Time{}, errors.Wrapf(err, "parsing --today=%q", override)
+	}
+	return t, nil
+}
+
+func dateOnly(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// timeNow is a seam for tests. It returns the current local date.
+var timeNow = func() time.Time { return timeutil.Now() }
+
+// findCutSubtask returns the key of the "Cut Staging Branch" subtask, or ""
+// if none was found.
+func findCutSubtask(issue *jiraIssue) string {
+	return findOpenSubtask(issue, cutStagingSubtaskMatch)
+}
+
+// findSubtask returns the key of the first subtask whose summary contains
+// needle (case-insensitive) and a bool indicating whether that subtask is
+// in the "Done" state. If no matching subtask exists, returns ("", false).
+func findSubtask(issue *jiraIssue, needle string) (key string, done bool) {
+	lower := strings.ToLower(needle)
+	for _, st := range issue.Fields.Subtasks {
+		if !strings.Contains(strings.ToLower(st.Fields.Summary), lower) {
+			continue
+		}
+		return st.Key, strings.EqualFold(st.Fields.Status.Name, "Done")
+	}
+	return "", false
+}
+
+// findOpenSubtask returns the key of the first subtask whose summary contains
+// needle (case-insensitive) and is not already in the "Done" state, or "" if
+// none matches. We only transition open subtasks — re-running the workflow on
+// a ticket whose subtask was already closed must be a no-op.
+func findOpenSubtask(issue *jiraIssue, needle string) string {
+	key, done := findSubtask(issue, needle)
+	if done {
+		return ""
+	}
+	return key
+}
+
+// releaseDetails holds the formatted strings used in Jira updates and Slack
+// messages for one release.
+type releaseDetails struct {
+	Release                  string // v25.4.3
+	FinalRelease             string // v25.4.3 (without -alpha/-beta suffix)
+	Series                   string // 25.4
+	StagingBranch            string // release-25.4.3-rc
+	BaseBranch               string // release-25.4
+	CutAtSHA                 string
+	CutAtCommitURL           string // https://github.com/<repo>/commit/<sha>
+	BranchCutDateTime        string
+	PickSHADate              string
+	CloudReleaseNotesDate    string
+	PublishBinaryDate        string
+	ReleaseStatus            string
+	BackportLabel            string
+	BackportLabelDescription string
+	ReleaseType              string
+}
+
+func buildReleaseDetails(
+	v version.Version, issue *jiraIssue, b branchNames, baseSHA string, now time.Time, repo string,
+) (releaseDetails, error) {
+	pickSHA, err := issue.stringField(cfPickSHADate)
+	if err != nil {
+		return releaseDetails{}, errors.Wrap(err, "reading pick-SHA-date field")
+	}
+	cloudNotes, err := issue.stringField(cfCloudReleaseNotes)
+	if err != nil {
+		return releaseDetails{}, errors.Wrap(err, "reading cloud-release-notes-date field")
+	}
+	publishBin, err := issue.stringField(cfPublishBinary)
+	if err != nil {
+		return releaseDetails{}, errors.Wrap(err, "reading publish-binary-date field")
+	}
+	override, err := issue.optionField(cfReleaseTypeOverride)
+	if err != nil {
+		return releaseDetails{}, errors.Wrap(err, "reading release-type-override field")
+	}
+
+	pickSHAPretty := formatJiraDate(pickSHA, "Monday, 01/02")
+	final := finalReleaseString(v)
+	series := fmt.Sprintf("%d.%d", v.Major().Year, v.Major().Ordinal)
+	releaseStatus := ""
+	if pickSHA != "" {
+		releaseStatus = formatJiraDate(pickSHA, "01/02") + ": pick SHA"
+	}
+	return releaseDetails{
+		Release:                  v.String(),
+		FinalRelease:             final,
+		Series:                   series,
+		StagingBranch:            b.staging,
+		BaseBranch:               b.base,
+		CutAtSHA:                 baseSHA,
+		CutAtCommitURL:           fmt.Sprintf("https://github.com/%s/commit/%s", repo, baseSHA),
+		BranchCutDateTime:        now.Format("2006-01-02 15:04 MST"),
+		PickSHADate:              orTBD(pickSHAPretty),
+		CloudReleaseNotesDate:    orTBD(formatJiraDate(cloudNotes, "Monday, 01/02")),
+		PublishBinaryDate:        orTBD(formatJiraDate(publishBin, "Monday, 01/02")),
+		ReleaseStatus:            releaseStatus,
+		BackportLabel:            "backport-" + strings.TrimPrefix(final, "v") + "-rc",
+		BackportLabelDescription: orTBD(pickSHAPretty) + ": " + b.staging + " will be frozen",
+		ReleaseType:              releaseTypeFor(v, override),
+	}, nil
+}
+
+// orTBD substitutes "TBD" for an empty string so display strings like
+// Slack messages and label descriptions never render as a bare backtick
+// pair or leading colon when a Jira date field hasn't been filled in yet.
+func orTBD(s string) string {
+	if s == "" {
+		return "TBD"
+	}
+	return s
+}
+
+// finalReleaseString returns the version with any -prerelease suffix
+// removed: "v25.3.1-alpha.1" → "v25.3.1".
+func finalReleaseString(v version.Version) string {
+	return fmt.Sprintf("v%d.%d.%d", v.Major().Year, v.Major().Ordinal, v.Patch())
+}
+
+// releaseTypeFor mirrors the Superblocks logic: explicit Jira override wins,
+// then pre-release (any suffix), then patch==0 means a major release,
+// otherwise a scheduled patch.
+func releaseTypeFor(v version.Version, jiraOverride string) string {
+	if jiraOverride != "" {
+		return jiraOverride
+	}
+	if v.IsPrerelease() {
+		return preReleaseType
+	}
+	if v.Patch() == 0 {
+		return majorReleaseType
+	}
+	return scheduledType
+}
+
+func isPreRelease(releaseType string) bool {
+	// Match "pre-release" / "Pre-Release" / "PreRelease" — Jira's
+	// customfield_10507 values aren't fixed in code and we want the
+	// comparison to be tolerant.
+	return strings.Contains(strings.ToLower(releaseType), "pre")
+}
+
+// formatJiraDate formats a YYYY-MM-DD Jira date string using a Go layout.
+// Empty input yields empty output.
+func formatJiraDate(jiraDate, layout string) string {
+	if jiraDate == "" {
+		return ""
+	}
+	t, err := time.Parse("2006-01-02", jiraDate)
+	if err != nil {
+		return jiraDate
+	}
+	return t.Format(layout)
+}
+
+// buildSlackMessage selects the pre-release or scheduled template and fills
+// it from the prepared release details. Both templates match the strings the
+// Superblocks flow produced so downstream readers (release-team channel
+// archives, Jira comments) see the same output.
+func buildSlackMessage(d releaseDetails, dryRun bool) string {
+	var body string
+	if isPreRelease(d.ReleaseType) {
+		body = fmt.Sprintf(`Staging branch `+"`%s`"+` has now been cut and frozen for the RC and final .0:
+• The <https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/1043235321/Database+Backport+Patch+Policy#Backporting-for-major-releases|Database Backport Policy> is now in effect for %s
+
+*If your backport needs to go into `+"`%s`"+` it must*:
+• Be approved by via ER request
+• Be backported to *BOTH* `+"`%s`"+` and `+"`release-%s`"+`
+
+Staging branch `+"`%s`"+`:
+• Cut: `+"`%s`"+`
+• Cut at SHA: <%s|%s>`,
+			d.StagingBranch, d.Series,
+			d.FinalRelease,
+			d.StagingBranch, d.Series,
+			d.StagingBranch, d.BranchCutDateTime, d.CutAtCommitURL, d.CutAtSHA)
+	} else {
+		body = fmt.Sprintf("`%s` staging branch `%s` has been cut:\n"+
+			"• *Pick SHA (Branch Freeze) Date:* `%s`\n"+
+			"• *Cloud Release Notes Date:* `%s`\n"+
+			"• *Publish Binaries Date:* `%s`\n\n"+
+			"Staging branch `%s`:\n"+
+			"• Cut: `%s`\n"+
+			"• Cut at SHA: <%s|%s>",
+			d.Release, d.StagingBranch,
+			d.PickSHADate, d.CloudReleaseNotesDate, d.PublishBinaryDate,
+			d.StagingBranch, d.BranchCutDateTime, d.CutAtCommitURL, d.CutAtSHA)
+	}
+	if dryRun {
+		return "[DRY RUN] " + body
+	}
+	return body
+}
+
+// backportPolicyURL is the wiki page linked from the pre-release Slack and
+// Jira messages. Kept here so both renderers stay in lockstep.
+const backportPolicyURL = "https://cockroachlabs.atlassian.net/wiki/spaces/ENG/pages/1043235321/Database+Backport+Patch+Policy#Backporting-for-major-releases"
+
+// buildJiraComment returns an ADF doc that mirrors buildSlackMessage's
+// content but uses native Jira formatting (strong/code marks, bullet
+// lists, real links) so the comment doesn't show literal `*` and
+// backticks. The Slack permalink, when non-empty, is rendered as the
+// first paragraph for traceability.
+func buildJiraComment(d releaseDetails, slackLink string) map[string]interface{} {
+	var blocks []interface{}
+	if slackLink != "" {
+		blocks = append(blocks, adfPara(adfMarked(slackLink, adfLink(slackLink))))
+	}
+	if isPreRelease(d.ReleaseType) {
+		blocks = append(blocks,
+			adfPara(
+				adfText("Staging branch "),
+				adfMarked(d.StagingBranch, adfCode()),
+				adfText(" has now been cut and frozen for the RC and final .0:"),
+			),
+			adfBullet([]interface{}{
+				adfText("The "),
+				adfMarked("Database Backport Policy", adfLink(backportPolicyURL)),
+				adfText(" is now in effect for " + d.Series),
+			}),
+			adfPara(
+				adfMarked("If your backport needs to go into ", adfStrong()),
+				adfMarked(d.StagingBranch, adfStrong(), adfCode()),
+				adfMarked(" it must:", adfStrong()),
+			),
+			adfBullet(
+				[]interface{}{adfText("Be approved by via ER request")},
+				[]interface{}{
+					adfText("Be backported to "),
+					adfMarked("BOTH", adfStrong()),
+					adfText(" "),
+					adfMarked(d.StagingBranch, adfCode()),
+					adfText(" and "),
+					adfMarked("release-"+d.Series, adfCode()),
+				},
+			),
+		)
+	} else {
+		blocks = append(blocks,
+			adfPara(
+				adfMarked(d.Release, adfCode()),
+				adfText(" staging branch "),
+				adfMarked(d.StagingBranch, adfCode()),
+				adfText(" has been cut:"),
+			),
+			adfBullet(
+				[]interface{}{
+					adfMarked("Pick SHA (Branch Freeze) Date: ", adfStrong()),
+					adfMarked(d.PickSHADate, adfCode()),
+				},
+				[]interface{}{
+					adfMarked("Cloud Release Notes Date: ", adfStrong()),
+					adfMarked(d.CloudReleaseNotesDate, adfCode()),
+				},
+				[]interface{}{
+					adfMarked("Publish Binaries Date: ", adfStrong()),
+					adfMarked(d.PublishBinaryDate, adfCode()),
+				},
+			),
+		)
+	}
+	blocks = append(blocks,
+		adfPara(
+			adfText("Staging branch "),
+			adfMarked(d.StagingBranch, adfCode()),
+			adfText(":"),
+		),
+		adfBullet(
+			[]interface{}{
+				adfText("Cut: "),
+				adfMarked(d.BranchCutDateTime, adfCode()),
+			},
+			[]interface{}{
+				adfText("Cut at SHA: "),
+				adfMarked(d.CutAtSHA, adfLink(d.CutAtCommitURL), adfCode()),
+			},
+		),
+	)
+	return adfDoc(blocks...)
+}
+
+// splitRepo turns "owner/name" into its parts.
+func splitRepo(repo string) (string, string, error) {
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", errors.Newf("invalid repo %q, expected owner/name", repo)
+	}
+	return parts[0], parts[1], nil
+}

--- a/pkg/cmd/release/cut_staging_branches_test.go
+++ b/pkg/cmd/release/cut_staging_branches_test.go
@@ -1,0 +1,734 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/version"
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseVersion(t *testing.T, s string) version.Version {
+	t.Helper()
+	v, err := version.Parse(s)
+	require.NoError(t, err)
+	return v
+}
+
+func TestParseReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		summary         string
+		expectedVersion string
+		expectedErr     string
+	}{
+		{name: "patch release", summary: "Release: v25.3.1", expectedVersion: "v25.3.1"},
+		{name: "trailing text", summary: "Release: v25.3.1 some other text", expectedVersion: "v25.3.1"},
+		{name: "alpha pre-release", summary: "Release: v25.3.1-alpha.1", expectedVersion: "v25.3.1-alpha.1"},
+		{name: "missing prefix", summary: "v25.3.1", expectedErr: "summary does not start with"},
+		{name: "garbage version", summary: "Release: vfoo.bar", expectedErr: "parsing version"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := parseReleaseVersion(tc.summary)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedVersion, v.String())
+		})
+	}
+}
+
+func TestDeriveBranchNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		version         string
+		expectedBase    string
+		expectedStaging string
+	}{
+		{name: "patch release", version: "v25.4.3", expectedBase: "release-25.4", expectedStaging: "release-25.4.3-rc"},
+		{name: "alpha pre-release", version: "v25.3.1-alpha.1", expectedBase: "release-25.3", expectedStaging: "release-25.3.1-rc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := deriveBranchNames(mustParseVersion(t, tc.version))
+			require.Equal(t, tc.expectedBase, b.base)
+			require.Equal(t, tc.expectedStaging, b.staging)
+		})
+	}
+}
+
+func TestIsCutDateReady(t *testing.T) {
+	today := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name          string
+		cutDate       string
+		expectedReady bool
+		expectedErr   string
+	}{
+		{name: "yesterday is ready", cutDate: "2026-04-19", expectedReady: true},
+		{name: "today is ready", cutDate: "2026-04-20", expectedReady: true},
+		{name: "tomorrow not ready", cutDate: "2026-04-21", expectedReady: false},
+		{name: "empty not ready", cutDate: "", expectedReady: false},
+		{name: "garbage rejected", cutDate: "not-a-date", expectedErr: "parsing cut date"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ready, err := isCutDateReady(tc.cutDate, today)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedReady, ready)
+		})
+	}
+}
+
+func TestReleaseTypeFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		version      string
+		jiraOverride string
+		expected     string
+	}{
+		{name: "scheduled patch", version: "v25.4.3", expected: scheduledType},
+		{name: "pre-release derived", version: "v25.3.1-alpha.1", expected: preReleaseType},
+		{name: "patch zero is major", version: "v25.4.0", expected: majorReleaseType},
+		{name: "override beats heuristic", version: "v25.4.3", jiraOverride: "Custom", expected: "Custom"},
+		{name: "override on pre-release", version: "v25.3.1-alpha.1", jiraOverride: "Pre-Release", expected: "Pre-Release"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := releaseTypeFor(mustParseVersion(t, tc.version), tc.jiraOverride)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestIsPreRelease(t *testing.T) {
+	tests := []struct {
+		name        string
+		releaseType string
+		expected    bool
+	}{
+		{name: "exact match", releaseType: "Pre-Release", expected: true},
+		{name: "lowercase", releaseType: "pre-release", expected: true},
+		{name: "no hyphen", releaseType: "PreRelease", expected: true},
+		{name: "scheduled", releaseType: "Scheduled", expected: false},
+		{name: "major", releaseType: "Major Release", expected: false},
+		{name: "empty", releaseType: "", expected: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, isPreRelease(tc.releaseType))
+		})
+	}
+}
+
+func TestFormatJiraDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		jiraDate string
+		layout   string
+		expected string
+	}{
+		{name: "pretty weekday", jiraDate: "2026-04-22", layout: "Monday, 01/02", expected: "Wednesday, 04/22"},
+		{name: "month/day", jiraDate: "2026-04-22", layout: "01/02", expected: "04/22"},
+		{name: "empty input", jiraDate: "", layout: "01/02", expected: ""},
+		{name: "garbage passes through", jiraDate: "not-a-date", layout: "01/02", expected: "not-a-date"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, formatJiraDate(tc.jiraDate, tc.layout))
+		})
+	}
+}
+
+func TestBuildReleaseDetails(t *testing.T) {
+	// Build a Jira issue with the custom fields the function reads.
+	rawFields, err := json.Marshal(map[string]interface{}{
+		"summary":           "Release: v25.4.3",
+		cfPickSHADate:       "2026-04-22",
+		cfCloudReleaseNotes: "2026-04-23",
+		cfPublishBinary:     "2026-04-24",
+	})
+	require.NoError(t, err)
+	var issue jiraIssue
+	require.NoError(t, json.Unmarshal([]byte(`{"key":"REL-1234","fields":`+string(rawFields)+`}`), &issue))
+
+	v := mustParseVersion(t, "v25.4.3")
+	b := deriveBranchNames(v)
+	now := time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC)
+	d, err := buildReleaseDetails(v, &issue, b, "abc1234", now, "cockroachdb/cockroach")
+	require.NoError(t, err)
+
+	require.Equal(t, "v25.4.3", d.Release)
+	require.Equal(t, "v25.4.3", d.FinalRelease)
+	require.Equal(t, "25.4", d.Series)
+	require.Equal(t, "release-25.4.3-rc", d.StagingBranch)
+	require.Equal(t, "release-25.4", d.BaseBranch)
+	require.Equal(t, "abc1234", d.CutAtSHA)
+	require.Equal(t, "https://github.com/cockroachdb/cockroach/commit/abc1234", d.CutAtCommitURL)
+	require.Equal(t, "Wednesday, 04/22", d.PickSHADate)
+	require.Equal(t, "Thursday, 04/23", d.CloudReleaseNotesDate)
+	require.Equal(t, "Friday, 04/24", d.PublishBinaryDate)
+	require.Equal(t, "04/22: pick SHA", d.ReleaseStatus)
+	require.Equal(t, "backport-25.4.3-rc", d.BackportLabel)
+	require.Equal(t, "Wednesday, 04/22: release-25.4.3-rc will be frozen", d.BackportLabelDescription)
+	require.Equal(t, scheduledType, d.ReleaseType)
+}
+
+func TestBuildSlackMessage(t *testing.T) {
+	// CutAtCommitURL uses a placeholder owner/repo so we can prove the template
+	// substitutes the field rather than a hardcoded cockroachdb/cockroach URL.
+	d := releaseDetails{
+		Release:               "v25.4.3",
+		FinalRelease:          "v25.4.3",
+		Series:                "25.4",
+		StagingBranch:         "release-25.4.3-rc",
+		BaseBranch:            "release-25.4",
+		CutAtSHA:              "abc1234",
+		CutAtCommitURL:        "https://github.com/example-org/example-repo/commit/abc1234",
+		BranchCutDateTime:     "2026-04-20 07:00 UTC",
+		PickSHADate:           "Wednesday, 04/22",
+		CloudReleaseNotesDate: "Thursday, 04/23",
+		PublishBinaryDate:     "Friday, 04/24",
+		ReleaseType:           scheduledType,
+	}
+
+	t.Run("scheduled template", func(t *testing.T) {
+		msg := buildSlackMessage(d, false)
+		require.Contains(t, msg, "`v25.4.3` staging branch `release-25.4.3-rc` has been cut")
+		require.Contains(t, msg, "*Pick SHA (Branch Freeze) Date:* `Wednesday, 04/22`")
+		require.Contains(t, msg, "<https://github.com/example-org/example-repo/commit/abc1234|abc1234>")
+		require.False(t, strings.HasPrefix(msg, "[DRY RUN] "))
+	})
+
+	t.Run("dry-run prefix", func(t *testing.T) {
+		msg := buildSlackMessage(d, true)
+		require.True(t, strings.HasPrefix(msg, "[DRY RUN] "))
+	})
+
+	t.Run("pre-release template", func(t *testing.T) {
+		pd := d
+		pd.Release = "v25.3.1-alpha.1"
+		pd.FinalRelease = "v25.3.1"
+		pd.Series = "25.3"
+		pd.StagingBranch = "release-25.3.1-rc"
+		pd.ReleaseType = preReleaseType
+		msg := buildSlackMessage(pd, false)
+		require.Contains(t, msg, "Staging branch `release-25.3.1-rc` has now been cut and frozen for the RC and final .0")
+		require.Contains(t, msg, "Database Backport Policy")
+		require.Contains(t, msg, "If your backport needs to go into `v25.3.1`")
+	})
+}
+
+func TestFindCutSubtask(t *testing.T) {
+	mkIssue := func(subtasks ...jiraSubtask) *jiraIssue {
+		return &jiraIssue{Fields: jiraIssueFields{Subtasks: subtasks}}
+	}
+	mkSubtask := func(key, summary, status string) jiraSubtask {
+		st := jiraSubtask{Key: key}
+		st.Fields.Summary = summary
+		st.Fields.Status.Name = status
+		return st
+	}
+
+	tests := []struct {
+		name        string
+		issue       *jiraIssue
+		expectedKey string
+	}{
+		{
+			name: "matches case insensitively",
+			issue: mkIssue(
+				mkSubtask("REL-2", "Cut Staging Branch", "To Do"),
+			),
+			expectedKey: "REL-2",
+		},
+		{
+			name: "skips already-done subtask",
+			issue: mkIssue(
+				mkSubtask("REL-2", "Cut Staging Branch", "Done"),
+			),
+			expectedKey: "",
+		},
+		{
+			name: "no match returns empty",
+			issue: mkIssue(
+				mkSubtask("REL-2", "Some unrelated work", "To Do"),
+			),
+			expectedKey: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedKey, findCutSubtask(tc.issue))
+		})
+	}
+}
+
+func TestIsProductionRepo(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{name: "empty is non-prod", envValue: "", expected: false},
+		{name: "exact true is prod", envValue: "true", expected: true},
+		{name: "uppercase TRUE is non-prod", envValue: "TRUE", expected: false},
+		{name: "anything else is non-prod", envValue: "1", expected: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envIsProductionRepo, tc.envValue)
+			require.Equal(t, tc.expected, isProductionRepo())
+		})
+	}
+}
+
+// newGitHubClientForTest returns a *githubClient whose underlying go-github
+// HTTP client is redirected at the supplied test server. The caller's handler
+// owns rewriting paths and producing JSON responses; this helper only handles
+// the BaseURL plumbing (go-github requires a trailing slash).
+func newGitHubClientForTest(t *testing.T, srv *httptest.Server) *githubClient {
+	t.Helper()
+	gh := newGitHubClient("test-token", "owner", "repo")
+	u, err := url.Parse(srv.URL + "/")
+	require.NoError(t, err)
+	gh.client.BaseURL = u
+	return gh
+}
+
+// mkRefHandler returns a handler that serves /repos/{owner}/{repo}/git/ref/heads/{branch}
+// from a name->SHA map; missing branches respond 404 so callers can exercise
+// errBranchNotFound without bespoke handler code per case. Note that the
+// upstream GitHub REST endpoint for fetching a single ref uses the singular
+// "ref" — go-github v61 calls `git/ref/heads/...`.
+func mkRefHandler(refs map[string]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "/git/ref/heads/"
+		i := strings.Index(r.URL.Path, prefix)
+		if i < 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		branch := r.URL.Path[i+len(prefix):]
+		sha, ok := refs[branch]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"ref":"refs/heads/%s","object":{"sha":%q}}`, branch, sha)
+	}
+}
+
+// mkJiraIssue builds a *jiraIssue from a summary and a fields map. The fields
+// map is merged with the summary at the JSON level so the custom UnmarshalJSON
+// populates RawFields correctly.
+func mkJiraIssue(t *testing.T, key, summary string, fields map[string]interface{}) *jiraIssue {
+	t.Helper()
+	all := make(map[string]interface{}, len(fields)+1)
+	for k, v := range fields {
+		all[k] = v
+	}
+	all["summary"] = summary
+	raw, err := json.Marshal(all)
+	require.NoError(t, err)
+	var issue jiraIssue
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"key":`+strconv.Quote(key)+`,"fields":`+string(raw)+`}`), &issue))
+	return &issue
+}
+
+func TestCutRunnerValidate(t *testing.T) {
+	bn := branchNames{base: "release-25.4", staging: "release-25.4.3-rc"}
+	const baseSHA = "basesha000"
+	const stagingSHA = "stagingsha111"
+
+	tests := []struct {
+		name               string
+		jiraStaging        string            // value of cfStagingBranch on the issue
+		ghRefs             map[string]string // branches that exist on GitHub
+		dryRun             bool
+		expectedSHA        string
+		expectedAlreadyCut bool
+		expectedErr        string
+	}{
+		{
+			name:        "happy path: nothing exists yet, returns base SHA",
+			ghRefs:      map[string]string{"release-25.4": baseSHA},
+			expectedSHA: baseSHA,
+		},
+		{
+			name:               "idempotent recovery: branch on GitHub and Jira matches",
+			jiraStaging:        "release-25.4.3-rc",
+			ghRefs:             map[string]string{"release-25.4.3-rc": stagingSHA, "release-25.4": baseSHA},
+			expectedSHA:        stagingSHA,
+			expectedAlreadyCut: true,
+		},
+		{
+			name:        "branch on GitHub but Jira empty surfaces conflict",
+			ghRefs:      map[string]string{"release-25.4.3-rc": stagingSHA},
+			expectedErr: "already exists on GitHub but cfStagingBranch in Jira is",
+		},
+		{
+			name:        "branch on GitHub but Jira holds a different branch",
+			jiraStaging: "release-25.4.4-rc",
+			ghRefs:      map[string]string{"release-25.4.3-rc": stagingSHA},
+			expectedErr: "already exists on GitHub but cfStagingBranch in Jira is",
+		},
+		{
+			name:        "Jira already names a staging branch but it isn't on GitHub",
+			jiraStaging: "release-25.4.3-rc",
+			ghRefs:      map[string]string{"release-25.4": baseSHA},
+			expectedErr: "but no such branch exists on GitHub",
+		},
+		{
+			name:        "dry-run lets stale Jira pass through",
+			jiraStaging: "release-25.4.3-rc",
+			ghRefs:      map[string]string{"release-25.4": baseSHA},
+			dryRun:      true,
+			expectedSHA: baseSHA,
+		},
+		{
+			name:        "missing base branch surfaces user-readable error",
+			ghRefs:      map[string]string{},
+			expectedErr: "base branch release-25.4 does not exist on GitHub",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(mkRefHandler(tc.ghRefs))
+			defer srv.Close()
+			r := &cutRunner{
+				gh:     newGitHubClientForTest(t, srv),
+				dryRun: tc.dryRun,
+			}
+			fields := map[string]interface{}{}
+			if tc.jiraStaging != "" {
+				fields[cfStagingBranch] = tc.jiraStaging
+			}
+			issue := mkJiraIssue(t, "REL-1", "Release: v25.4.3", fields)
+			sha, alreadyCut, err := r.validate(context.Background(), issue, bn)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedSHA, sha)
+			require.Equal(t, tc.expectedAlreadyCut, alreadyCut)
+		})
+	}
+}
+
+func TestJiraIssueStatusName(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		expected string
+	}{
+		{
+			name:     "open ticket",
+			body:     `{"key":"REL-1","fields":{"summary":"x","status":{"name":"Open","id":"1"}}}`,
+			expected: "Open",
+		},
+		{
+			name:     "already baking",
+			body:     `{"key":"REL-1","fields":{"summary":"x","status":{"name":"Baking","id":"2"}}}`,
+			expected: "Baking",
+		},
+		{
+			name:     "missing status field",
+			body:     `{"key":"REL-1","fields":{"summary":"x"}}`,
+			expected: "",
+		},
+		{
+			name:     "wrong-shape status returns empty rather than panicking",
+			body:     `{"key":"REL-1","fields":{"summary":"x","status":"unexpected-string"}}`,
+			expected: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var issue jiraIssue
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &issue))
+			require.Equal(t, tc.expected, issue.statusName())
+		})
+	}
+}
+
+// newSlackClientForTest builds a slackClient that talks to the supplied
+// httptest server. slack-go's APIURL option requires a trailing slash.
+func newSlackClientForTest(baseURL string) *slackClient {
+	return &slackClient{
+		api: slack.New("test-token", slack.OptionAPIURL(baseURL+"/")),
+	}
+}
+
+// TestCutRunnerProcessCandidateSkipsBakingTransition exercises the gate that
+// guards Transition(transitionBaking) on full.statusName() so a re-run after
+// a partial failure (where the ticket is already in Baking) doesn't error
+// out at Jira's "transition not valid for current state". The Jira mock
+// fails the test if it sees a /transitions POST against the main ticket;
+// the rest of the recovery flow is allowed through.
+func TestCutRunnerProcessCandidateSkipsBakingTransition(t *testing.T) {
+	today := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	bn := branchNames{base: "release-25.4", staging: "release-25.4.3-rc"}
+
+	// Candidate matches the JQL search shape: cut date is today (ready) and
+	// summary parses. The recovery gate also requires cfStagingBranch to
+	// already be set on the ticket so validate returns branchAlreadyCut.
+	candidate := *mkJiraIssue(t, "REL-1", "Release: v25.4.3", map[string]interface{}{
+		cfCutBranchDate: "2026-04-20",
+		cfStagingBranch: bn.staging,
+	})
+
+	// Full issue (returned by Jira GetIssue) reports the ticket is already
+	// Baking and the cut subtask is Done. Subtasks include a Done
+	// "Cut Staging Branch" so findCutSubtask returns "" and the subtask
+	// transition is skipped naturally.
+	doneSubtask := jiraSubtask{Key: "REL-2"}
+	doneSubtask.Fields.Summary = cutStagingSubtaskMatch
+	doneSubtask.Fields.Status.Name = "Done"
+	subtaskRaw, err := json.Marshal([]jiraSubtask{doneSubtask})
+	require.NoError(t, err)
+	fullFields, err := json.Marshal(map[string]interface{}{
+		"summary":           "Release: v25.4.3",
+		cfCutBranchDate:     "2026-04-20",
+		cfStagingBranch:     bn.staging,
+		cfPickSHADate:       "2026-04-22",
+		cfCloudReleaseNotes: "2026-04-23",
+		cfPublishBinary:     "2026-04-24",
+		"status":            map[string]interface{}{"name": bakingStatusName, "id": "151"},
+		"subtasks":          json.RawMessage(subtaskRaw),
+	})
+	require.NoError(t, err)
+	fullJSON := `{"key":"REL-1","fields":` + string(fullFields) + `}`
+
+	const stagingSHA = "stagingsha000"
+
+	var labelCreated, fieldsUpdated atomic.Bool
+	ghSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/git/ref/heads/"+bn.staging):
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"ref":"refs/heads/%s","object":{"sha":%q}}`, bn.staging, stagingSHA)
+		case strings.HasSuffix(r.URL.Path, "/labels"):
+			labelCreated.Store(true)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected GitHub call: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ghSrv.Close()
+
+	jiraSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/rest/api/3/issue/REL-1"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fullJSON))
+		case r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/rest/api/3/issue/REL-1"):
+			fieldsUpdated.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(r.URL.Path, "/REL-1/transitions"):
+			t.Errorf("Transition(transitionBaking) must be skipped when ticket is already Baking")
+			w.WriteHeader(http.StatusBadRequest)
+		case strings.HasSuffix(r.URL.Path, "/REL-1/comment"):
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected jira call: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer jiraSrv.Close()
+
+	// Slack PostMessage is unconditional in processCandidate. Stub via the
+	// slack-go API URL so the call exits cleanly without our test having to
+	// reach into the slackClient internals.
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C1","ts":"1.2","permalink":"https://slack/x"}`))
+	}))
+	defer slackSrv.Close()
+
+	gh := newGitHubClient("test", "owner", "repo")
+	u, err := url.Parse(ghSrv.URL + "/")
+	require.NoError(t, err)
+	gh.client.BaseURL = u
+
+	jc := newJiraClient("bot@example.com", "test")
+	jc.baseURL = jiraSrv.URL
+
+	r := &cutRunner{
+		jira:    jc,
+		gh:      gh,
+		slack:   newSlackClientForTest(slackSrv.URL),
+		today:   today,
+		repo:    "owner/repo",
+		channel: "test-channel",
+	}
+	require.NoError(t, r.processCandidate(context.Background(), candidate))
+	require.True(t, fieldsUpdated.Load(), "UpdateFields must run on the recovery path")
+	require.True(t, labelCreated.Load(), "CreateLabel must run on the recovery path")
+}
+
+// TestCutRunnerProcessCandidateEarlyReturns covers the early-exit paths in
+// processCandidate that return nil without touching GitHub or Jira: an
+// unparseable summary, a patch-zero release, a missing cut-branch date, and
+// a future cut date. A cutRunner with no jira/gh clients is sufficient
+// because none of the side-effecting paths are reached; if the early returns
+// regress, the test will panic on the nil clients.
+func TestCutRunnerProcessCandidateEarlyReturns(t *testing.T) {
+	today := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		summary   string
+		cutDate   string // value of cfCutBranchDate on the candidate
+		todayFlag string // override r.today via the testIssueKey gate, "" = use today
+	}{
+		{
+			name:    "unparseable summary skipped",
+			summary: "Release: notice this is not parseable",
+		},
+		{
+			name:    "patch-zero release skipped",
+			summary: "Release: v25.4.0",
+		},
+		{
+			name:    "missing cut date skipped",
+			summary: "Release: v25.4.3",
+		},
+		{
+			name:    "future cut date skipped",
+			summary: "Release: v25.4.3",
+			cutDate: "2026-04-25",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &cutRunner{today: today}
+			fields := map[string]interface{}{}
+			if tc.cutDate != "" {
+				fields[cfCutBranchDate] = tc.cutDate
+			}
+			c := mkJiraIssue(t, "REL-1", tc.summary, fields)
+			require.NoError(t, r.processCandidate(context.Background(), *c))
+		})
+	}
+}
+
+func TestBuildJiraComment(t *testing.T) {
+	d := releaseDetails{
+		Release:               "v25.4.3",
+		FinalRelease:          "v25.4.3",
+		Series:                "25.4",
+		StagingBranch:         "release-25.4.3-rc",
+		BaseBranch:            "release-25.4",
+		CutAtSHA:              "deadbeef",
+		CutAtCommitURL:        "https://github.com/example-org/example-repo/commit/deadbeef",
+		BranchCutDateTime:     "2026-04-20 07:00 UTC",
+		PickSHADate:           "Wednesday, 04/22",
+		CloudReleaseNotesDate: "Thursday, 04/23",
+		PublishBinaryDate:     "Friday, 04/24",
+		ReleaseType:           scheduledType,
+	}
+	const slackLink = "https://example.slack.com/archives/C123/p456"
+
+	t.Run("scheduled with slack link", func(t *testing.T) {
+		doc := buildJiraComment(d, slackLink)
+		require.Equal(t, "doc", doc["type"])
+		require.Equal(t, 1, doc["version"])
+		content, ok := doc["content"].([]interface{})
+		require.True(t, ok)
+		// Slack-link paragraph + intro paragraph + dates bullet list +
+		// "Staging branch X:" paragraph + cut/SHA bullet list = 5 blocks.
+		require.Len(t, content, 5)
+
+		encoded, err := json.Marshal(doc)
+		require.NoError(t, err)
+		s := string(encoded)
+		require.Contains(t, s, slackLink)
+		require.Contains(t, s, "release-25.4.3-rc")
+		require.Contains(t, s, "deadbeef")
+		require.Contains(t, s, "Pick SHA (Branch Freeze) Date:")
+		require.Contains(t, s, "Wednesday, 04/22")
+	})
+
+	t.Run("pre-release uses backport-policy template", func(t *testing.T) {
+		pd := d
+		pd.Release = "v25.3.1-alpha.1"
+		pd.FinalRelease = "v25.3.1"
+		pd.Series = "25.3"
+		pd.StagingBranch = "release-25.3.1-rc"
+		pd.ReleaseType = preReleaseType
+		doc := buildJiraComment(pd, "")
+		encoded, err := json.Marshal(doc)
+		require.NoError(t, err)
+		s := string(encoded)
+		require.Contains(t, s, backportPolicyURL)
+		require.Contains(t, s, "release-25.3.1-rc")
+		// Pre-release template doesn't render the date bullets, so
+		// "Pick SHA (Branch Freeze) Date:" must be absent.
+		require.NotContains(t, s, "Pick SHA (Branch Freeze) Date:")
+	})
+
+	t.Run("empty slack link omits leading paragraph", func(t *testing.T) {
+		doc := buildJiraComment(d, "")
+		content, ok := doc["content"].([]interface{})
+		require.True(t, ok)
+		// Same blocks as the scheduled-with-slack case, minus the Slack-link
+		// paragraph: intro + dates + "Staging branch:" para + cut bullets = 4.
+		require.Len(t, content, 4)
+	})
+}
+
+func TestSplitRepo(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedOwner string
+		expectedRepo  string
+		expectedErr   string
+	}{
+		{name: "valid", input: "cockroachdb/cockroach", expectedOwner: "cockroachdb", expectedRepo: "cockroach"},
+		{name: "missing slash", input: "cockroach", expectedErr: "expected owner/name"},
+		{name: "empty owner", input: "/cockroach", expectedErr: "expected owner/name"},
+		{name: "empty repo", input: "cockroachdb/", expectedErr: "expected owner/name"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, err := splitRepo(tc.input)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedOwner, owner)
+			require.Equal(t, tc.expectedRepo, repo)
+		})
+	}
+}

--- a/pkg/cmd/release/github_client.go
+++ b/pkg/cmd/release/github_client.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/google/go-github/v61/github"
+	"golang.org/x/oauth2"
+)
+
+// githubHTTPTimeout caps each go-github call. The oauth2-wrapped client
+// from oauth2.NewClient has no timeout by default, so without this a
+// wedged GitHub API would hang the cron run.
+const githubHTTPTimeout = 30 * time.Second
+
+// errBranchNotFound is returned by GetBranchSHA when the GitHub API responds
+// with 404. Callers can use errors.Is to distinguish "the branch isn't
+// there" from "the request itself failed" (network error, auth, 5xx).
+var errBranchNotFound = errors.New("branch not found")
+
+// githubClient is a thin wrapper around go-github exposing the operations
+// the release-tooling workflows need: read a ref, create a ref, list
+// branches, dispatch a workflow_dispatch event, and create a label.
+type githubClient struct {
+	client *github.Client
+	owner  string
+	repo   string
+}
+
+func newGitHubClient(token, owner, repo string) *githubClient {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(context.Background(), ts)
+	tc.Timeout = githubHTTPTimeout
+	return &githubClient{
+		client: github.NewClient(tc),
+		owner:  owner,
+		repo:   repo,
+	}
+}
+
+// GetBranchSHA returns the commit SHA at the tip of the named branch. It
+// returns errBranchNotFound (wrapped) when the GitHub API responds with 404
+// so callers can distinguish "the branch is gone" from a transport-level
+// failure with errors.Is.
+func (c *githubClient) GetBranchSHA(ctx context.Context, branch string) (string, error) {
+	ref, resp, err := c.client.Git.GetRef(ctx, c.owner, c.repo, "refs/heads/"+branch)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return "", errors.Wrapf(errBranchNotFound, "get ref refs/heads/%s", branch)
+		}
+		return "", errors.Wrapf(err, "get ref refs/heads/%s", branch)
+	}
+	if ref.Object == nil || ref.Object.SHA == nil {
+		return "", errors.Newf("ref refs/heads/%s missing object SHA", branch)
+	}
+	return *ref.Object.SHA, nil
+}
+
+// CreateBranch creates refs/heads/{branch} pointing at sha.
+func (c *githubClient) CreateBranch(ctx context.Context, branch, sha string) error {
+	ref := &github.Reference{
+		Ref:    github.String("refs/heads/" + branch),
+		Object: &github.GitObject{SHA: github.String(sha)},
+	}
+	if _, _, err := c.client.Git.CreateRef(ctx, c.owner, c.repo, ref); err != nil {
+		return errors.Wrapf(err, "create ref refs/heads/%s at %s", branch, sha)
+	}
+	return nil
+}
+
+// BranchExists reports whether the named branch exists. It uses the Git
+// Refs API (one round-trip) rather than paginating ListBranches, which on
+// cockroachdb/cockroach would be O(hundreds-of-branches).
+func (c *githubClient) BranchExists(ctx context.Context, branch string) (bool, error) {
+	if _, err := c.GetBranchSHA(ctx, branch); err != nil {
+		if errors.Is(err, errBranchNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// DispatchWorkflow triggers a workflow_dispatch event on the named workflow
+// file. The ref selects which branch/tag the workflow runs against; inputs
+// are forwarded to the workflow's `inputs:` block. The GitHub API only
+// accepts string-valued inputs for workflow_dispatch (booleans are coerced
+// from "true"/"false"), so the input type is constrained to map[string]string
+// at the wrapper boundary — callers stringify non-strings themselves.
+func (c *githubClient) DispatchWorkflow(
+	ctx context.Context, ref, workflowFileName string, inputs map[string]string,
+) error {
+	// go-github's request type is map[string]interface{} (the workflow_dispatch
+	// REST API technically accepts other JSON scalars too, but GitHub coerces
+	// everything to string on receipt). Promote our typed map into theirs at
+	// the boundary so the wrapper's contract stays string-only.
+	apiInputs := make(map[string]interface{}, len(inputs))
+	for k, v := range inputs {
+		apiInputs[k] = v
+	}
+	event := github.CreateWorkflowDispatchEventRequest{
+		Ref:    ref,
+		Inputs: apiInputs,
+	}
+	if _, err := c.client.Actions.CreateWorkflowDispatchEventByFileName(
+		ctx, c.owner, c.repo, workflowFileName, event,
+	); err != nil {
+		return errors.Wrapf(err, "dispatch workflow %s on %s", workflowFileName, ref)
+	}
+	return nil
+}
+
+// CreateLabel creates a repository label. If the label already exists (HTTP
+// 422 with "already_exists"), the call is treated as a no-op.
+func (c *githubClient) CreateLabel(ctx context.Context, name, description, color string) error {
+	label := &github.Label{
+		Name:        github.String(name),
+		Description: github.String(description),
+		Color:       github.String(color),
+	}
+	_, _, err := c.client.Issues.CreateLabel(ctx, c.owner, c.repo, label)
+	if err == nil {
+		return nil
+	}
+	var errResp *github.ErrorResponse
+	if errors.As(err, &errResp) && errResp.Response != nil &&
+		errResp.Response.StatusCode == http.StatusUnprocessableEntity {
+		// Treat "already_exists" as success — re-running the workflow on the
+		// same release shouldn't fail just because the label survived.
+		return nil
+	}
+	return errors.Wrapf(err, "create label %s", name)
+}

--- a/pkg/cmd/release/jira_adf.go
+++ b/pkg/cmd/release/jira_adf.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+// Helpers for building Atlassian Document Format (ADF) values to send to the
+// Jira REST v3 comment API. ADF is a JSON tree of typed nodes; we model it as
+// nested map[string]interface{} since the surface we use is small enough that
+// a typed schema would be more boilerplate than help.
+//
+// Spec: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+
+// adfDoc wraps a sequence of block-level nodes in the top-level doc envelope
+// that the comment API expects.
+func adfDoc(blocks ...interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    "doc",
+		"version": 1,
+		"content": blocks,
+	}
+}
+
+// adfPara builds a paragraph block from the given inline nodes.
+func adfPara(inlines ...interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    "paragraph",
+		"content": inlines,
+	}
+}
+
+// adfBullet builds a bullet list. Each argument is the slice of inline nodes
+// for one item; the helper wraps each in the listItem/paragraph nesting that
+// ADF requires.
+func adfBullet(items ...[]interface{}) map[string]interface{} {
+	listItems := make([]interface{}, len(items))
+	for i, item := range items {
+		listItems[i] = map[string]interface{}{
+			"type":    "listItem",
+			"content": []interface{}{adfPara(item...)},
+		}
+	}
+	return map[string]interface{}{
+		"type":    "bulletList",
+		"content": listItems,
+	}
+}
+
+// adfText returns a plain text inline node.
+func adfText(s string) map[string]interface{} {
+	return map[string]interface{}{"type": "text", "text": s}
+}
+
+// adfMarked returns a text inline node with one or more marks
+// (strong, code, link, ...) applied.
+func adfMarked(s string, marks ...map[string]interface{}) map[string]interface{} {
+	m := make([]interface{}, len(marks))
+	for i, mark := range marks {
+		m[i] = mark
+	}
+	return map[string]interface{}{
+		"type":  "text",
+		"text":  s,
+		"marks": m,
+	}
+}
+
+func adfStrong() map[string]interface{} { return map[string]interface{}{"type": "strong"} }
+func adfCode() map[string]interface{}   { return map[string]interface{}{"type": "code"} }
+func adfLink(href string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":  "link",
+		"attrs": map[string]interface{}{"href": href},
+	}
+}

--- a/pkg/cmd/release/jira_client.go
+++ b/pkg/cmd/release/jira_client.go
@@ -1,0 +1,289 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/errors"
+)
+
+const jiraBaseURL = "https://cockroachlabs.atlassian.net"
+
+// jiraClient calls a small subset of the Jira Cloud REST v3 API: JQL search,
+// issue fetch, field update, transition, and comment. It uses HTTP basic auth
+// with the bot user's email and a token, both rotated through GCP Secret
+// Manager.
+type jiraClient struct {
+	baseURL string
+	email   string
+	token   string
+	http    *http.Client
+}
+
+// jiraHTTPTimeout caps the time a single Jira REST call (including JQL
+// search, which can be slow on large result sets) may spend in flight.
+// Without it a wedged Atlassian endpoint would hang the cron run until
+// the GHA job timeout fires, with no failure-notify Slack post.
+const jiraHTTPTimeout = 30 * time.Second
+
+func newJiraClient(email, token string) *jiraClient {
+	return &jiraClient{
+		baseURL: jiraBaseURL,
+		email:   email,
+		token:   token,
+		http:    httputil.NewClientWithTimeout(jiraHTTPTimeout).Client,
+	}
+}
+
+// jiraIssue is a partial decoding of a Jira issue. Both Fields and RawFields
+// are populated atomically by the custom UnmarshalJSON below: Fields holds
+// typed accessors for the few entries (summary, subtasks) the bot reads on
+// every ticket, and RawFields exposes the same payload as a name->RawMessage
+// map so callers can pull arbitrary custom fields (customfield_10585 etc.)
+// by ID without us having to model each one. The json:"-" on RawFields
+// prevents json.Marshal from double-emitting the "fields" object — it does
+// not exclude RawFields from unmarshaling, which UnmarshalJSON drives directly.
+type jiraIssue struct {
+	Key       string                     `json:"key"`
+	Fields    jiraIssueFields            `json:"fields"`
+	RawFields map[string]json.RawMessage `json:"-"`
+}
+
+type jiraIssueFields struct {
+	Summary  string        `json:"summary"`
+	Subtasks []jiraSubtask `json:"subtasks"`
+}
+
+type jiraSubtask struct {
+	Key    string `json:"key"`
+	Fields struct {
+		Summary string `json:"summary"`
+		Status  struct {
+			Name string `json:"name"`
+		} `json:"status"`
+	} `json:"fields"`
+}
+
+// UnmarshalJSON captures both the typed fields (summary, subtasks) and the
+// raw map of all fields (so callers can pull arbitrary custom fields).
+func (i *jiraIssue) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		Key    string                     `json:"key"`
+		Fields map[string]json.RawMessage `json:"fields"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return errors.Wrap(err, "decoding Jira issue envelope")
+	}
+	i.Key = aux.Key
+	i.RawFields = aux.Fields
+	if raw, ok := aux.Fields["summary"]; ok {
+		if err := json.Unmarshal(raw, &i.Fields.Summary); err != nil {
+			return errors.Wrap(err, "decoding summary")
+		}
+	}
+	if raw, ok := aux.Fields["subtasks"]; ok {
+		if err := json.Unmarshal(raw, &i.Fields.Subtasks); err != nil {
+			return errors.Wrap(err, "decoding subtasks")
+		}
+	}
+	return nil
+}
+
+// stringField returns the value of a string custom field, or "" if the field
+// is absent or null.
+func (i *jiraIssue) stringField(name string) (string, error) {
+	raw, ok := i.RawFields[name]
+	if !ok {
+		return "", nil
+	}
+	if string(raw) == "null" {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", errors.Wrapf(err, "field %s is not a string", name)
+	}
+	return s, nil
+}
+
+// statusName returns the issue's current workflow status name (e.g.
+// "Baking", "Done"), reading from RawFields["status"]. Jira represents
+// status as {"name":"…","id":"…"} — distinct from the {"value":"…"}
+// shape optionField handles — so a dedicated accessor is needed.
+// Returns "" when the field is absent or unparseable; callers use the
+// result to gate idempotent state transitions and treat "" as "unknown,
+// proceed with the transition" so a fresh ticket is never blocked.
+func (i *jiraIssue) statusName() string {
+	raw, ok := i.RawFields["status"]
+	if !ok {
+		return ""
+	}
+	var s struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s.Name
+}
+
+// optionField returns the .value of a single-select custom field (Jira
+// represents these as objects with id/value/self), or "" if absent.
+func (i *jiraIssue) optionField(name string) (string, error) {
+	raw, ok := i.RawFields[name]
+	if !ok || string(raw) == "null" {
+		return "", nil
+	}
+	var obj struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return "", errors.Wrapf(err, "field %s is not an option object", name)
+	}
+	return obj.Value, nil
+}
+
+// SearchJQL executes a JQL query and returns matching issues. It pages through
+// the results using Jira's nextPageToken (the v3 /search/jql endpoint).
+func (c *jiraClient) SearchJQL(jql string, fields []string) ([]jiraIssue, error) {
+	var all []jiraIssue
+	pageToken := ""
+	for {
+		body := map[string]interface{}{
+			"jql":          jql,
+			"fields":       fields,
+			"fieldsByKeys": false,
+		}
+		if pageToken != "" {
+			body["nextPageToken"] = pageToken
+		}
+		var resp struct {
+			Issues        []jiraIssue `json:"issues"`
+			NextPageToken string      `json:"nextPageToken"`
+			IsLast        bool        `json:"isLast"`
+		}
+		if err := c.do("POST", "/rest/api/3/search/jql", body, &resp); err != nil {
+			return nil, errors.Wrap(err, "jira JQL search")
+		}
+		all = append(all, resp.Issues...)
+		if resp.IsLast || resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return all, nil
+}
+
+// GetIssue fetches a single issue by key.
+func (c *jiraClient) GetIssue(key string) (*jiraIssue, error) {
+	var issue jiraIssue
+	path := "/rest/api/3/issue/" + url.PathEscape(key)
+	if err := c.do("GET", path, nil, &issue); err != nil {
+		return nil, errors.Wrapf(err, "fetching Jira issue %s", key)
+	}
+	return &issue, nil
+}
+
+// UpdateFields sets the given fields on an issue (PUT /issue/{key}).
+func (c *jiraClient) UpdateFields(key string, fields map[string]interface{}) error {
+	body := map[string]interface{}{"fields": fields}
+	path := "/rest/api/3/issue/" + url.PathEscape(key)
+	return c.do("PUT", path, body, nil)
+}
+
+// Transition advances the issue's workflow state using a transition ID.
+func (c *jiraClient) Transition(key string, transitionID string) error {
+	body := map[string]interface{}{
+		"transition": map[string]string{"id": transitionID},
+	}
+	path := "/rest/api/3/issue/" + url.PathEscape(key) + "/transitions"
+	return c.do("POST", path, body, nil)
+}
+
+// AddComment posts a comment whose body is the supplied Atlassian Document
+// Format doc (built via the adf* helpers in jira_adf.go). Callers own the
+// formatting; this method only handles the API envelope and POST.
+func (c *jiraClient) AddComment(key string, doc map[string]interface{}) error {
+	body := map[string]interface{}{"body": doc}
+	path := "/rest/api/3/issue/" + url.PathEscape(key) + "/comment"
+	return c.do("POST", path, body, nil)
+}
+
+// do issues an authenticated request and decodes the JSON response into out
+// (when non-nil). 2xx is treated as success; any other status returns an error
+// that includes the response body.
+func (c *jiraClient) do(method, path string, reqBody, out interface{}) error {
+	var body io.Reader
+	if reqBody != nil {
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(reqBody); err != nil {
+			return errors.Wrap(err, "encoding request body")
+		}
+		body = buf
+	}
+	req, err := http.NewRequest(method, c.baseURL+path, body)
+	if err != nil {
+		return errors.Wrap(err, "building request")
+	}
+	req.SetBasicAuth(c.email, c.token)
+	req.Header.Set("Accept", "application/json")
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "%s %s", method, path)
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "reading response")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return errors.Newf("%s %s: %s: %s", method, path, resp.Status, sanitizeBody(respBytes))
+	}
+	if out == nil || len(respBytes) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(respBytes, out); err != nil {
+		return errors.Wrapf(err, "decoding response\nbody: %s", sanitizeBody(respBytes))
+	}
+	return nil
+}
+
+// maxErrorBodyBytes caps the amount of upstream response we keep in error
+// messages. Long HTML error pages or stack traces from a misbehaving proxy
+// otherwise blow up Slack messages and GHA logs.
+const maxErrorBodyBytes = 512
+
+// sanitizeBody truncates b to maxErrorBodyBytes and removes any line that
+// looks like an Authorization header — defense-in-depth in case an upstream
+// or intermediary ever echoes the request headers back in an error body.
+func sanitizeBody(b []byte) string {
+	s := string(b)
+	if len(s) > maxErrorBodyBytes {
+		s = s[:maxErrorBodyBytes] + "…(truncated)"
+	}
+	// Drop any Authorization: / Bearer ... fragments that might appear in
+	// echoed-back request dumps.
+	for _, needle := range []string{"Authorization:", "authorization:", "Bearer "} {
+		if i := strings.Index(s, needle); i >= 0 {
+			s = s[:i] + "[redacted]"
+			break
+		}
+	}
+	return s
+}

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -5,7 +5,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 var rootCmd = &cobra.Command{Use: "release"}
 var artifactsDir string
@@ -27,7 +31,23 @@ const (
 	dryRun          = "dry-run"
 
 	fromEmailFormat = "Justin Beaver <%s>"
+
+	// envIsProductionRepo is the env var the GHA workflow forwards from a
+	// repository variable that's set only on the production release repo.
+	// It's the single signal this binary uses to choose between prod and
+	// non-prod side-effect targets (e.g. Slack channels). When unset
+	// (TeamCity, local invocations, forks) we treat the run as non-prod.
+	envIsProductionRepo = "IS_PRODUCTION_REPO"
 )
+
+// isProductionRepo reports whether the binary is running under the
+// production release repo, as signalled by the IS_PRODUCTION_REPO env var
+// (forwarded from a GHA repository variable that's only set on the
+// canonical repo). When unset (TeamCity, local invocations, forks) the
+// default is false — non-prod paths are safer.
+func isProductionRepo() bool {
+	return os.Getenv(envIsProductionRepo) == "true"
+}
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
@@ -36,6 +56,8 @@ func main() {
 }
 
 func init() {
+	rootCmd.AddCommand(cutStagingBranchesCmd)
+	rootCmd.AddCommand(pickSHACmd)
 	rootCmd.AddCommand(updateReleasesTestFilesCmd)
 	rootCmd.AddCommand(updateVersionsCmd)
 }

--- a/pkg/cmd/release/pick_sha.go
+++ b/pkg/cmd/release/pick_sha.go
@@ -1,0 +1,582 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// pickSHAJQL builds the candidate set for the pick-SHA workflow:
+// type=Release, parented (REL-217 holds historical/template tickets without
+// parents that we don't want to act on), still open, and with a Staging
+// Branch already set (which the cut-staging-branches workflow does first).
+// The Pick SHA Date readiness check happens client-side in processCandidate
+// after the search returns — JQL date arithmetic on custom fields is fiddly
+// and the daily candidate set is small enough that the extra round-trip
+// doesn't matter.
+const pickSHAJQL = `issueType="CRDB Release" and parent is not empty and ` +
+	`status not in (done, cancelled, "Post-Publish Tasks") and ` +
+	`"Staging Branch[Short text]" is not empty`
+
+// pickSHAJQLDryRun drops the `parent is not empty` filter so dry runs can
+// rehearse against parent/template tickets, mirroring cutStagingJQLDryRun.
+const pickSHAJQLDryRun = `issueType="CRDB Release" and ` +
+	`status not in (done, cancelled, "Post-Publish Tasks") and ` +
+	`"Staging Branch[Short text]" is not empty`
+
+// pickSHASubtaskMatch is the case-insensitive substring used to find the
+// "Pick SHA" subtask on a release ticket.
+const pickSHASubtaskMatch = "Pick SHA"
+
+// defaultBuildWorkflow is the workflow file dispatched by `pick-sha`. It
+// must accept `dry_run` and `sha` workflow_dispatch inputs.
+const defaultBuildWorkflow = "release-build-and-sign.yml"
+
+var pickSHAFlags = struct {
+	dryRun        bool
+	testIssueKey  string
+	today         string
+	repo          string
+	channel       string
+	opsChannel    string
+	buildWorkflow string
+}{}
+
+var pickSHACmd = &cobra.Command{
+	Use:   "pick-sha",
+	Short: "Pick the staging branch tip and trigger build-and-sign for due tickets",
+	Long: `Queries Jira for open CRDB Release tickets that have a Staging Branch
+set, then for each one whose Pick SHA Date is today or earlier fetches the
+tip SHA of the staging branch, dispatches the build-and-sign workflow
+against that branch and SHA, posts a Slack notification, comments on the
+Jira ticket, and transitions the "Pick SHA" subtask to Done.
+
+Dry-run still dispatches build-and-sign but with dry_run=true so the entire
+chain is exercised end-to-end against dev infra; no Jira mutations happen on
+our side and Slack messages are prefixed with [DRY RUN]. Slack channel
+selection is based on the IS_PRODUCTION_REPO env var, not --dry-run, so a
+dry-run from the production repo still posts to the production channel.`,
+	RunE: runPickSHA,
+}
+
+func init() {
+	pickSHACmd.Flags().BoolVar(&pickSHAFlags.dryRun, "dry-run", false,
+		"pass dry_run=true to the dispatched build-and-sign workflow and skip "+
+			"our Jira mutations; Slack messages are prefixed with [DRY RUN]")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.testIssueKey, "test-issue-key", "",
+		"treat the named issue as the only candidate, bypassing the JQL search "+
+			"and the Pick SHA Date readiness check (use to rehearse in dry-run, "+
+			"or to scope a production run to a single ticket)")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.today, "today", "",
+		"override 'today' for eligibility checks (YYYY-MM-DD)")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.repo, "repo", defaultRepo(),
+		"target GitHub repository in owner/name form (defaults to $GITHUB_REPOSITORY when set)")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.channel, "slack-channel", "",
+		"Slack channel for success notifications (default: "+releaseChannel+
+			" when "+envIsProductionRepo+"=true, "+nonProdChannel+" otherwise)")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.opsChannel, "ops-channel", opsChannel,
+		"Slack channel for failure notifications")
+	pickSHACmd.Flags().StringVar(&pickSHAFlags.buildWorkflow, "build-workflow", defaultBuildWorkflow,
+		"name of the workflow file (in .github/workflows) to dispatch")
+}
+
+func runPickSHA(_ *cobra.Command, _ []string) error {
+	jiraToken := os.Getenv(envJiraToken)
+	if jiraToken == "" {
+		return errors.Newf("%s is not set", envJiraToken)
+	}
+	jiraEmail := os.Getenv(envJiraEmail)
+	if jiraEmail == "" {
+		return errors.Newf("%s is not set", envJiraEmail)
+	}
+	ghToken := os.Getenv(envCutGitHubToken)
+	if ghToken == "" {
+		return errors.Newf("%s is not set", envCutGitHubToken)
+	}
+	slackToken := os.Getenv(envSlackBotToken)
+	if slackToken == "" {
+		return errors.Newf("%s is not set", envSlackBotToken)
+	}
+	releaseNotesAPIKey := os.Getenv(envReleaseNotesAPIKey)
+	if releaseNotesAPIKey == "" {
+		return errors.Newf("%s is not set", envReleaseNotesAPIKey)
+	}
+
+	owner, repoName, err := splitRepo(pickSHAFlags.repo)
+	if err != nil {
+		return errors.Wrap(err, "parsing --repo")
+	}
+
+	today, err := resolveToday(pickSHAFlags.today)
+	if err != nil {
+		return errors.Wrap(err, "resolving today's date")
+	}
+
+	jira := newJiraClient(jiraEmail, jiraToken)
+	gh := newGitHubClient(ghToken, owner, repoName)
+	sl := newSlackClient(slackToken)
+
+	// Repo identity (not --dry-run) decides which channel to post to: a fork
+	// rehearsal must not echo into #db-release-status. Explicit
+	// --slack-channel always wins.
+	channel := pickSHAFlags.channel
+	if channel == "" {
+		channel = nonProdChannel
+		if isProductionRepo() {
+			channel = releaseChannel
+		}
+	}
+	r := &pickSHARunner{
+		jira:               jira,
+		gh:                 gh,
+		slack:              sl,
+		dryRun:             pickSHAFlags.dryRun,
+		testIssueKey:       pickSHAFlags.testIssueKey,
+		today:              today,
+		channel:            channel,
+		opsChannel:         pickSHAFlags.opsChannel,
+		repo:               pickSHAFlags.repo,
+		buildWorkflow:      pickSHAFlags.buildWorkflow,
+		releaseNotesAPIKey: releaseNotesAPIKey,
+	}
+	return r.run(context.Background())
+}
+
+// pickSHARunner holds the wired-up dependencies and per-invocation knobs for
+// one run of the pick-sha workflow.
+type pickSHARunner struct {
+	jira  *jiraClient
+	gh    *githubClient
+	slack *slackClient
+
+	dryRun        bool
+	testIssueKey  string
+	today         time.Time
+	channel       string
+	opsChannel    string
+	repo          string
+	buildWorkflow string
+	// releaseNotesAPIKey is the X-API-Key for the docs release-notes
+	// automation endpoint. Required at startup; per-candidate API failures
+	// are non-fatal (warning to #release-ops, continue).
+	releaseNotesAPIKey string
+}
+
+func (r *pickSHARunner) run(ctx context.Context) error {
+	candidates, err := r.candidates()
+	if err != nil {
+		r.notifyFailure(err)
+		return err
+	}
+	log.Printf("Jira returned %d candidate ticket(s)", len(candidates))
+
+	var firstErr error
+	for _, c := range candidates {
+		if err := r.processCandidate(ctx, c); err != nil {
+			log.Printf("ticket %s failed: %v", c.Key, err)
+			r.notifyFailure(errors.Wrapf(err, "ticket %s", c.Key))
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func (r *pickSHARunner) processCandidate(ctx context.Context, c jiraIssue) error {
+	if _, err := parseReleaseVersion(c.Fields.Summary); err != nil {
+		// Tracking/template tickets that match the JQL but aren't real
+		// release tickets (e.g. summary "Release: 26.1|25.4|25.2 next
+		// patch") aren't actionable — log and move on rather than
+		// failing the whole run. The relaxed dry-run JQL exposes more
+		// of these than production ever will.
+		log.Printf("ticket %s: skipping unparseable summary: %v", c.Key, err)
+		return nil
+	}
+
+	pickDate, err := c.stringField(cfPickSHADate)
+	if err != nil {
+		return errors.Wrap(err, "reading pick-SHA-date field")
+	}
+	if pickDate == "" {
+		log.Printf("ticket %s: skipping — Pick SHA Date is unset", c.Key)
+		return nil
+	}
+
+	// When --test-issue-key is set the operator picked this ticket
+	// explicitly (rehearsal or one-off recovery), so we bypass the
+	// pick-date readiness check; otherwise a future-dated ticket would
+	// be silently skipped.
+	if r.testIssueKey == "" {
+		ready, err := isCutDateReady(pickDate, r.today)
+		if err != nil {
+			return errors.Wrap(err, "evaluating pick-SHA-date readiness")
+		}
+		if !ready {
+			log.Printf("ticket %s: pick SHA date %s not yet reached (today=%s)",
+				c.Key, pickDate, dateOnly(r.today))
+			return nil
+		}
+	}
+
+	full, err := r.jira.GetIssue(c.Key)
+	if err != nil {
+		return errors.Wrapf(err, "fetching full Jira issue %s", c.Key)
+	}
+
+	// Idempotency gate. The JQL doesn't filter on subtask state, so a
+	// failure between DispatchWorkflow and the Slack/Jira side effects
+	// would otherwise let the next cron re-fire build-and-sign — an
+	// expensive, days-long workflow. Treat a Done Pick SHA subtask as
+	// "already handled". A missing subtask (e.g. a template ticket
+	// exposed by the dry-run JQL) falls through, since that path is
+	// only reachable in dry-run.
+	//
+	// Residual risk: if DispatchWorkflow succeeds but the subtask
+	// transition below fails, the next run will re-dispatch. The
+	// failure-notify Slack post should catch this within the cron
+	// window so an operator can intervene.
+	subtaskKey, subtaskDone := findSubtask(full, pickSHASubtaskMatch)
+	if subtaskDone {
+		log.Printf("ticket %s: Pick SHA subtask already Done, skipping re-dispatch", c.Key)
+		return nil
+	}
+
+	staging, err := full.stringField(cfStagingBranch)
+	if err != nil {
+		return errors.Wrap(err, "reading staging-branch field")
+	}
+	if staging == "" {
+		return errors.Newf("ticket %s has no Staging Branch set", c.Key)
+	}
+	sha, err := r.gh.GetBranchSHA(ctx, staging)
+	if err != nil {
+		return errors.Wrapf(err, "fetching tip SHA for staging branch %s", staging)
+	}
+
+	details, err := buildPickSHADetails(full, staging, sha, r.repo, r.buildWorkflow)
+	if err != nil {
+		return errors.Wrap(err, "building pick-SHA details")
+	}
+
+	ref := "refs/heads/" + staging
+	// The workflow_dispatch REST endpoint requires every input value to be
+	// a JSON string — booleans typed in workflow YAML are coerced from
+	// "true"/"false" on receipt — so we stringify dry_run rather than
+	// passing a Go bool.
+	inputs := map[string]string{
+		"sha":     sha,
+		"dry_run": strconv.FormatBool(r.dryRun),
+	}
+	if err := r.gh.DispatchWorkflow(ctx, ref, r.buildWorkflow, inputs); err != nil {
+		return errors.Wrapf(err, "dispatching %s on %s", r.buildWorkflow, ref)
+	}
+
+	if !r.dryRun {
+		if subtaskKey != "" {
+			if err := r.jira.Transition(subtaskKey, transitionSubtaskDone); err != nil {
+				return errors.Wrapf(err, "transitioning subtask %s to Done", subtaskKey)
+			}
+		}
+		if err := r.jira.UpdateFields(c.Key, map[string]interface{}{
+			cfBuildSHA: sha,
+		}); err != nil {
+			return errors.Wrapf(err, "updating SHA field on %s", c.Key)
+		}
+	} else {
+		log.Printf("[DRY RUN] would transition Pick SHA subtask of %s to Done", c.Key)
+		log.Printf("[DRY RUN] would set SHA field on %s to %s", c.Key, sha)
+	}
+
+	msg := buildPickSHASlackMessage(details, r.dryRun)
+	link, err := r.slack.PostMessage(r.channel, msg)
+	if err != nil {
+		return errors.Wrap(err, "posting Slack message")
+	}
+	if !r.dryRun {
+		if err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link)); err != nil {
+			return errors.Wrap(err, "adding Jira comment")
+		}
+	} else {
+		log.Printf("[DRY RUN] would add Jira comment on %s with Slack link %q", c.Key, link)
+	}
+
+	// Notify the docs release-notes API last, after every other side effect
+	// has succeeded. Failures here are non-fatal: we already dispatched
+	// build-and-sign and updated Jira/Slack, so failing the candidate would
+	// re-fire those (expensive) side effects on the next cron. A Slack
+	// warning to #release-ops gives operators a chance to re-trigger
+	// generation manually.
+	r.notifyReleaseNotes(c.Key, full, sha)
+
+	log.Printf("ticket %s: dispatched %s on %s at %s", c.Key, r.buildWorkflow, ref, sha)
+	return nil
+}
+
+// notifyReleaseNotes builds the release-notes API payload from the Jira
+// issue and POSTs it. Skipped (with a log line) under --dry-run, since the
+// API has no non-prod endpoint and a dry-run call would create real docs
+// drafts. Errors are swallowed after a warning is posted to #release-ops:
+// see the call site for why.
+//
+// Idempotency: the call is also skipped when the docs subtask is already
+// marked Done, because that means the docs team has already opened (and
+// likely shipped) the release-notes draft for this release. Re-POSTing
+// would create a duplicate draft. The pick-SHA-subtask gate in
+// processCandidate normally prevents re-entry on the same ticket, but a
+// transition failure between DispatchWorkflow and the subtask transition
+// could re-fire the rest of the chain — this gate covers that window.
+func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha string) {
+	if r.dryRun {
+		log.Printf("[DRY RUN] would call release-notes API for %s", key)
+		return
+	}
+	if _, docsDone := findSubtask(full, docsSubtaskMatch); docsDone {
+		log.Printf("ticket %s: docs subtask already Done, skipping release-notes API call", key)
+		return
+	}
+	payload, err := buildReleaseNotesPayload(full, sha)
+	if err != nil {
+		// We never built the payload, so the warning has nothing to dump.
+		// Pass the zero value; buildReleaseNotesWarning falls back to the
+		// ticket key in the headline.
+		log.Printf("ticket %s: building release-notes payload failed: %v", key, err)
+		r.warnReleaseNotes(key, releaseNotesPayload{}, err)
+		return
+	}
+	if err := postReleaseNotes(releaseNotesAPIURL, r.releaseNotesAPIKey, payload); err != nil {
+		log.Printf("ticket %s: release-notes API call failed: %v", key, err)
+		r.warnReleaseNotes(key, payload, err)
+	}
+}
+
+func (r *pickSHARunner) warnReleaseNotes(key string, payload releaseNotesPayload, err error) {
+	msg := buildReleaseNotesWarning(key, payload, err)
+	if _, postErr := r.slack.PostMessage(r.opsChannel, msg); postErr != nil {
+		log.Printf("failed to post release-notes warning to %s: %v", r.opsChannel, postErr)
+	}
+}
+
+// jiraBrowseBaseURL is the public Jira base URL for issue links rendered
+// into Slack notifications. The cockroachlabs.atlassian.net host is fixed.
+const jiraBrowseBaseURL = "https://cockroachlabs.atlassian.net/browse"
+
+// docsInfraSlackLink is a pre-rendered Slack mrkdwn link to the
+// #docs-infrastructure-team channel — the team that owns the
+// release-notes-automation API. The channel ID is hardcoded so an
+// operator who reads the warning has a direct hop to the right channel.
+const docsInfraSlackLink = "<https://cockroachlabs.slack.com/archives/C03TH7EEMAA|#docs-infrastructure-team>"
+
+// buildReleaseNotesWarning renders the Slack message posted to
+// #release-ops when the release-notes API call (or its payload
+// construction) fails. The shape mirrors the Superblocks message this
+// replaces so docs-infrastructure-team eyes can recognize it. Payload may
+// be the zero value when the failure happened before the payload was
+// built; in that case the *Payload* block is omitted and the headline
+// falls back to the Jira ticket key.
+func buildReleaseNotesWarning(ticketKey string, payload releaseNotesPayload, err error) string {
+	headline := payload.CurrentRelease
+	if headline == "" {
+		headline = ticketKey
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, ":x: *release-notes-api failed for %s*\n\n", headline)
+	fmt.Fprintf(&b, "*Release*: <%s/%s|%s>\n\n", jiraBrowseBaseURL, ticketKey, ticketKey)
+	fmt.Fprintf(&b, "*Error*: %s\n\n", err)
+	if payload != (releaseNotesPayload{}) {
+		// json.MarshalIndent with a tab indent matches the Superblocks
+		// formatting verbatim; an unindented dump would be hard to read in
+		// Slack. Marshalling a fixed struct cannot fail in practice, but
+		// guard for it anyway — losing the payload section is preferable
+		// to dropping the whole warning.
+		if pretty, jerr := json.MarshalIndent(payload, "", "\t"); jerr == nil {
+			fmt.Fprintf(&b, "*Payload*: ```%s```\n\n", pretty)
+		}
+	}
+	fmt.Fprintf(&b, "Please forward this to the %s\n", docsInfraSlackLink)
+	return b.String()
+}
+
+// buildReleaseNotesPayload extracts the fields the docs API needs from the
+// Jira issue. release_date prefers the cloud-release-notes date and falls
+// back to the publish-binary date (matching the prior Superblocks logic).
+// cloud is true for Scheduled and Major Release types — pre-release builds
+// don't generate cloud notes.
+func buildReleaseNotesPayload(issue *jiraIssue, sha string) (releaseNotesPayload, error) {
+	v, err := parseReleaseVersion(issue.Fields.Summary)
+	if err != nil {
+		return releaseNotesPayload{}, errors.Wrap(err, "parsing release version")
+	}
+	cloudNotes, err := issue.stringField(cfCloudReleaseNotes)
+	if err != nil {
+		return releaseNotesPayload{}, errors.Wrap(err, "reading cloud-release-notes-date field")
+	}
+	publishBin, err := issue.stringField(cfPublishBinary)
+	if err != nil {
+		return releaseNotesPayload{}, errors.Wrap(err, "reading publish-binary-date field")
+	}
+	override, err := issue.optionField(cfReleaseTypeOverride)
+	if err != nil {
+		return releaseNotesPayload{}, errors.Wrap(err, "reading release-type-override field")
+	}
+
+	releaseDate := cloudNotes
+	if releaseDate == "" {
+		releaseDate = publishBin
+	}
+	releaseType := releaseTypeFor(v, override)
+	docsTicket, _ := findSubtask(issue, docsSubtaskMatch)
+
+	return releaseNotesPayload{
+		CurrentRelease: v.String(),
+		ReleaseDate:    releaseDate,
+		ReleaseSHA:     sha,
+		Cloud:          releaseType == scheduledType || releaseType == majorReleaseType,
+		DocsTicket:     docsTicket,
+	}, nil
+}
+
+// candidates returns the list of Jira tickets to evaluate. When
+// --test-issue-key is set it bypasses the JQL search and returns just that
+// ticket — so the same flag works for dry-run rehearsals and for scoping a
+// production run to a single ticket (e.g. one-off recovery).
+func (r *pickSHARunner) candidates() ([]jiraIssue, error) {
+	if r.testIssueKey != "" {
+		issue, err := r.jira.GetIssue(r.testIssueKey)
+		if err != nil {
+			return nil, errors.Wrapf(err, "fetching test issue %s", r.testIssueKey)
+		}
+		return []jiraIssue{*issue}, nil
+	}
+	jql := pickSHAJQL
+	if r.dryRun {
+		jql = pickSHAJQLDryRun
+	}
+	candidates, err := r.jira.SearchJQL(jql, []string{"*all"})
+	if err != nil {
+		return nil, errors.Wrap(err, "searching Jira for candidate tickets")
+	}
+	return candidates, nil
+}
+
+// notifyFailure posts a one-line :x: alert to #release-ops with a link to
+// the GHA run for the full error trace.
+func (r *pickSHARunner) notifyFailure(err error) {
+	headline := firstLine(err.Error())
+	msg := fmt.Sprintf(":x: pick-sha failed (%s): %s", r.repo, headline)
+	if link := actionsRunURL(); link != "" {
+		msg += " — see " + link
+	}
+	if r.dryRun {
+		msg = "[DRY RUN] " + msg
+	}
+	if _, postErr := r.slack.PostMessage(r.opsChannel, msg); postErr != nil {
+		log.Printf("failed to post failure to %s: %v", r.opsChannel, postErr)
+	}
+}
+
+// pickSHADetails holds the formatted strings used in the Slack and Jira
+// announcements for one pick-sha dispatch.
+type pickSHADetails struct {
+	StagingBranch         string // release-25.4.3-rc
+	PickedSHA             string
+	PickedCommitURL       string // https://github.com/<repo>/commit/<sha>
+	BuildRunListURL       string // https://github.com/<repo>/actions/workflows/<file>
+	CloudReleaseNotesDate string
+	PublishBinaryDate     string
+}
+
+// buildPickSHADetails reads the date custom fields from the Jira issue and
+// assembles the display strings needed by buildPickSHASlackMessage and
+// buildPickSHAJiraComment. BuildRunListURL is best-effort: the
+// workflow_dispatch REST endpoint returns no run ID, so the announcement
+// links to the workflow's run list rather than the specific run.
+func buildPickSHADetails(
+	issue *jiraIssue, stagingBranch, sha, repo, buildWorkflow string,
+) (pickSHADetails, error) {
+	cloudNotes, err := issue.stringField(cfCloudReleaseNotes)
+	if err != nil {
+		return pickSHADetails{}, errors.Wrap(err, "reading cloud-release-notes-date field")
+	}
+	publishBin, err := issue.stringField(cfPublishBinary)
+	if err != nil {
+		return pickSHADetails{}, errors.Wrap(err, "reading publish-binary-date field")
+	}
+	return pickSHADetails{
+		StagingBranch:         stagingBranch,
+		PickedSHA:             sha,
+		PickedCommitURL:       fmt.Sprintf("https://github.com/%s/commit/%s", repo, sha),
+		BuildRunListURL:       fmt.Sprintf("https://github.com/%s/actions/workflows/%s", repo, buildWorkflow),
+		CloudReleaseNotesDate: orTBD(formatJiraDate(cloudNotes, "Monday, 01/02")),
+		PublishBinaryDate:     orTBD(formatJiraDate(publishBin, "Monday, 01/02")),
+	}, nil
+}
+
+// buildPickSHASlackMessage renders the announcement that goes to
+// #db-release-status (or the non-prod channel for fork rehearsals).
+func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
+	body := fmt.Sprintf("SHA picked for `%s` — build-and-sign triggered:\n"+
+		"• Picked SHA: <%s|%s>\n"+
+		"• Build run: <%s|view in Actions>\n"+
+		"• *Cloud Release Notes Date:* `%s`\n"+
+		"• *Publish Binaries Date:* `%s`",
+		d.StagingBranch,
+		d.PickedCommitURL, d.PickedSHA,
+		d.BuildRunListURL,
+		d.CloudReleaseNotesDate,
+		d.PublishBinaryDate)
+	if dryRun {
+		return "[DRY RUN] " + body
+	}
+	return body
+}
+
+// buildPickSHAJiraComment returns an ADF doc that mirrors the Slack message
+// using native Jira marks (strong, code, link) so the comment doesn't show
+// literal `*` and backticks. The Slack permalink, when non-empty, is
+// rendered as the first paragraph for traceability.
+func buildPickSHAJiraComment(d pickSHADetails, slackLink string) map[string]interface{} {
+	var blocks []interface{}
+	if slackLink != "" {
+		blocks = append(blocks, adfPara(adfMarked(slackLink, adfLink(slackLink))))
+	}
+	blocks = append(blocks,
+		adfPara(
+			adfText("SHA picked for "),
+			adfMarked(d.StagingBranch, adfCode()),
+			adfText(" — build-and-sign triggered:"),
+		),
+		adfBullet(
+			[]interface{}{
+				adfMarked("Picked SHA: ", adfStrong()),
+				adfMarked(d.PickedSHA, adfLink(d.PickedCommitURL), adfCode()),
+			},
+			[]interface{}{
+				adfMarked("Build run: ", adfStrong()),
+				adfMarked("view in Actions", adfLink(d.BuildRunListURL)),
+			},
+			[]interface{}{
+				adfMarked("Cloud Release Notes Date: ", adfStrong()),
+				adfMarked(d.CloudReleaseNotesDate, adfCode()),
+			},
+			[]interface{}{
+				adfMarked("Publish Binaries Date: ", adfStrong()),
+				adfMarked(d.PublishBinaryDate, adfCode()),
+			},
+		),
+	)
+	return adfDoc(blocks...)
+}

--- a/pkg/cmd/release/pick_sha.go
+++ b/pkg/cmd/release/pick_sha.go
@@ -41,6 +41,16 @@ const pickSHAJQLDryRun = `issueType="CRDB Release" and ` +
 // "Pick SHA" subtask on a release ticket.
 const pickSHASubtaskMatch = "Pick SHA"
 
+// pickSHA success notifications go to the release-ops channels — a
+// RelEng-only audience. This deliberately differs from the wider
+// #db-release-status / #db-release-test channels that branch-cut uses,
+// because the "build-and-sign triggered" announcement is operational
+// noise that doesn't need to reach the broader release audience.
+const (
+	pickSHASlackChannel        = "#release-ops"
+	pickSHASlackStagingChannel = "#release-ops-staging"
+)
+
 // defaultBuildWorkflow is the workflow file dispatched by `pick-sha`. It
 // must accept `dry_run` and `sha` workflow_dispatch inputs.
 const defaultBuildWorkflow = "release-build-and-sign.yml"
@@ -85,8 +95,8 @@ func init() {
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.repo, "repo", defaultRepo(),
 		"target GitHub repository in owner/name form (defaults to $GITHUB_REPOSITORY when set)")
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.channel, "slack-channel", "",
-		"Slack channel for success notifications (default: "+releaseChannel+
-			" when "+envIsProductionRepo+"=true, "+nonProdChannel+" otherwise)")
+		"Slack channel for success notifications (default: "+pickSHASlackChannel+
+			" when "+envIsProductionRepo+"=true, "+pickSHASlackStagingChannel+" otherwise)")
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.opsChannel, "ops-channel", opsChannel,
 		"Slack channel for failure notifications")
 	pickSHACmd.Flags().StringVar(&pickSHAFlags.buildWorkflow, "build-workflow", defaultBuildWorkflow,
@@ -130,13 +140,13 @@ func runPickSHA(_ *cobra.Command, _ []string) error {
 	sl := newSlackClient(slackToken)
 
 	// Repo identity (not --dry-run) decides which channel to post to: a fork
-	// rehearsal must not echo into #db-release-status. Explicit
-	// --slack-channel always wins.
+	// rehearsal must not echo into #release-ops. Explicit --slack-channel
+	// always wins.
 	channel := pickSHAFlags.channel
 	if channel == "" {
-		channel = nonProdChannel
+		channel = pickSHASlackStagingChannel
 		if isProductionRepo() {
-			channel = releaseChannel
+			channel = pickSHASlackChannel
 		}
 	}
 	r := &pickSHARunner{
@@ -301,36 +311,53 @@ func (r *pickSHARunner) processCandidate(ctx context.Context, c jiraIssue) error
 		log.Printf("[DRY RUN] would set SHA field on %s to %s", c.Key, sha)
 	}
 
-	msg := buildPickSHASlackMessage(details, r.dryRun)
+	// Trigger the docs release-notes draft before composing the Slack
+	// message so we can include the generated PR's URL inline (operators
+	// linked to it from the old Superblocks notification). It's safe to
+	// call here because the Pick SHA subtask was transitioned to Done
+	// above: the gate at the top of processCandidate skips this entire
+	// path on retry, so a transient slack/jira failure below can't
+	// re-fire the API and produce a duplicate docs draft. API failures
+	// remain non-fatal — see notifyReleaseNotes.
+	releaseNotesPRURL := r.notifyReleaseNotes(c.Key, full, sha)
+	// Log the PR URL eagerly so the docs draft link survives in the GHA
+	// run log even if PostMessage/AddComment below fail — the
+	// idempotency gate at the top of processCandidate prevents the
+	// retry from re-posting, so the log is the only durable record.
+	if releaseNotesPRURL != "" {
+		log.Printf("ticket %s: release-notes PR created: %s", c.Key, releaseNotesPRURL)
+	}
+
+	msg := buildPickSHASlackMessage(details, releaseNotesPRURL, r.dryRun)
 	link, err := r.slack.PostMessage(r.channel, msg)
 	if err != nil {
 		return errors.Wrap(err, "posting Slack message")
 	}
 	if !r.dryRun {
-		if err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link)); err != nil {
+		if err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link, releaseNotesPRURL)); err != nil {
 			return errors.Wrap(err, "adding Jira comment")
 		}
 	} else {
 		log.Printf("[DRY RUN] would add Jira comment on %s with Slack link %q", c.Key, link)
 	}
 
-	// Notify the docs release-notes API last, after every other side effect
-	// has succeeded. Failures here are non-fatal: we already dispatched
-	// build-and-sign and updated Jira/Slack, so failing the candidate would
-	// re-fire those (expensive) side effects on the next cron. A Slack
-	// warning to #release-ops gives operators a chance to re-trigger
-	// generation manually.
-	r.notifyReleaseNotes(c.Key, full, sha)
-
 	log.Printf("ticket %s: dispatched %s on %s at %s", c.Key, r.buildWorkflow, ref, sha)
 	return nil
 }
 
 // notifyReleaseNotes builds the release-notes API payload from the Jira
-// issue and POSTs it. Skipped (with a log line) under --dry-run, since the
-// API has no non-prod endpoint and a dry-run call would create real docs
-// drafts. Errors are swallowed after a warning is posted to #release-ops:
-// see the call site for why.
+// issue and POSTs it. Returns the generated docs PR URL on success, or
+// "" on dry-run, idempotency skip, or any error (after warning to
+// #release-ops). The caller surfaces the URL in the success Slack and
+// Jira messages; it isn't load-bearing for correctness.
+//
+// Skipped (with a log line) under --dry-run, since the API has no
+// non-prod endpoint and a dry-run call would create real docs drafts.
+// Errors are swallowed after a warning is posted to #release-ops:
+// failing the candidate would re-fire the (expensive) build-and-sign
+// dispatch on the next cron run, which is too costly to risk over a
+// non-critical docs draft. Operators can re-trigger generation
+// manually from the warning.
 //
 // Idempotency: the call is also skipped when the docs subtask is already
 // marked Done, because that means the docs team has already opened (and
@@ -339,14 +366,14 @@ func (r *pickSHARunner) processCandidate(ctx context.Context, c jiraIssue) error
 // processCandidate normally prevents re-entry on the same ticket, but a
 // transition failure between DispatchWorkflow and the subtask transition
 // could re-fire the rest of the chain — this gate covers that window.
-func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha string) {
+func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha string) string {
 	if r.dryRun {
 		log.Printf("[DRY RUN] would call release-notes API for %s", key)
-		return
+		return ""
 	}
 	if _, docsDone := findSubtask(full, docsSubtaskMatch); docsDone {
 		log.Printf("ticket %s: docs subtask already Done, skipping release-notes API call", key)
-		return
+		return ""
 	}
 	payload, err := buildReleaseNotesPayload(full, sha)
 	if err != nil {
@@ -355,12 +382,15 @@ func (r *pickSHARunner) notifyReleaseNotes(key string, full *jiraIssue, sha stri
 		// ticket key in the headline.
 		log.Printf("ticket %s: building release-notes payload failed: %v", key, err)
 		r.warnReleaseNotes(key, releaseNotesPayload{}, err)
-		return
+		return ""
 	}
-	if err := postReleaseNotes(releaseNotesAPIURL, r.releaseNotesAPIKey, payload); err != nil {
+	resp, err := postReleaseNotes(releaseNotesAPIURL, r.releaseNotesAPIKey, payload)
+	if err != nil {
 		log.Printf("ticket %s: release-notes API call failed: %v", key, err)
 		r.warnReleaseNotes(key, payload, err)
+		return ""
 	}
+	return resp.PullRequestURL
 }
 
 func (r *pickSHARunner) warnReleaseNotes(key string, payload releaseNotesPayload, err error) {
@@ -526,8 +556,11 @@ func buildPickSHADetails(
 }
 
 // buildPickSHASlackMessage renders the announcement that goes to
-// #db-release-status (or the non-prod channel for fork rehearsals).
-func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
+// #release-ops (or the staging channel for fork rehearsals).
+// releaseNotesPRURL is the docs PR opened by the release-notes API and
+// is rendered as an extra bullet when non-empty; an empty value (dry-run,
+// API failure, or idempotency skip) just omits the bullet.
+func buildPickSHASlackMessage(d pickSHADetails, releaseNotesPRURL string, dryRun bool) string {
 	body := fmt.Sprintf("SHA picked for `%s` — build-and-sign triggered:\n"+
 		"• Picked SHA: <%s|%s>\n"+
 		"• Build run: <%s|view in Actions>\n"+
@@ -538,6 +571,9 @@ func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
 		d.BuildRunListURL,
 		d.CloudReleaseNotesDate,
 		d.PublishBinaryDate)
+	if releaseNotesPRURL != "" {
+		body += fmt.Sprintf("\n• *Release notes PR:* <%s|%s>", releaseNotesPRURL, releaseNotesPRURL)
+	}
 	if dryRun {
 		return "[DRY RUN] " + body
 	}
@@ -547,11 +583,39 @@ func buildPickSHASlackMessage(d pickSHADetails, dryRun bool) string {
 // buildPickSHAJiraComment returns an ADF doc that mirrors the Slack message
 // using native Jira marks (strong, code, link) so the comment doesn't show
 // literal `*` and backticks. The Slack permalink, when non-empty, is
-// rendered as the first paragraph for traceability.
-func buildPickSHAJiraComment(d pickSHADetails, slackLink string) map[string]interface{} {
+// rendered as the first paragraph for traceability. The release-notes PR
+// URL, when non-empty, becomes an extra bullet — symmetric with the Slack
+// message.
+func buildPickSHAJiraComment(
+	d pickSHADetails, slackLink, releaseNotesPRURL string,
+) map[string]interface{} {
 	var blocks []interface{}
 	if slackLink != "" {
 		blocks = append(blocks, adfPara(adfMarked(slackLink, adfLink(slackLink))))
+	}
+	bullets := [][]interface{}{
+		{
+			adfMarked("Picked SHA: ", adfStrong()),
+			adfMarked(d.PickedSHA, adfLink(d.PickedCommitURL), adfCode()),
+		},
+		{
+			adfMarked("Build run: ", adfStrong()),
+			adfMarked("view in Actions", adfLink(d.BuildRunListURL)),
+		},
+		{
+			adfMarked("Cloud Release Notes Date: ", adfStrong()),
+			adfMarked(d.CloudReleaseNotesDate, adfCode()),
+		},
+		{
+			adfMarked("Publish Binaries Date: ", adfStrong()),
+			adfMarked(d.PublishBinaryDate, adfCode()),
+		},
+	}
+	if releaseNotesPRURL != "" {
+		bullets = append(bullets, []interface{}{
+			adfMarked("Release notes PR: ", adfStrong()),
+			adfMarked(releaseNotesPRURL, adfLink(releaseNotesPRURL)),
+		})
 	}
 	blocks = append(blocks,
 		adfPara(
@@ -559,24 +623,7 @@ func buildPickSHAJiraComment(d pickSHADetails, slackLink string) map[string]inte
 			adfMarked(d.StagingBranch, adfCode()),
 			adfText(" — build-and-sign triggered:"),
 		),
-		adfBullet(
-			[]interface{}{
-				adfMarked("Picked SHA: ", adfStrong()),
-				adfMarked(d.PickedSHA, adfLink(d.PickedCommitURL), adfCode()),
-			},
-			[]interface{}{
-				adfMarked("Build run: ", adfStrong()),
-				adfMarked("view in Actions", adfLink(d.BuildRunListURL)),
-			},
-			[]interface{}{
-				adfMarked("Cloud Release Notes Date: ", adfStrong()),
-				adfMarked(d.CloudReleaseNotesDate, adfCode()),
-			},
-			[]interface{}{
-				adfMarked("Publish Binaries Date: ", adfStrong()),
-				adfMarked(d.PublishBinaryDate, adfCode()),
-			},
-		),
+		adfBullet(bullets...),
 	)
 	return adfDoc(blocks...)
 }

--- a/pkg/cmd/release/pick_sha_test.go
+++ b/pkg/cmd/release/pick_sha_test.go
@@ -1,0 +1,552 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPickSHAJQL(t *testing.T) {
+	// Production JQL keeps `parent is not empty` to skip template tickets.
+	require.Equal(t,
+		`issueType="CRDB Release" and parent is not empty and `+
+			`status not in (done, cancelled, "Post-Publish Tasks") and `+
+			`"Staging Branch[Short text]" is not empty`,
+		pickSHAJQL)
+
+	// Dry-run JQL drops the parent filter so rehearsals can target template
+	// tickets.
+	require.NotContains(t, pickSHAJQLDryRun, "parent is not empty")
+	require.Contains(t, pickSHAJQLDryRun, `"Staging Branch[Short text]" is not empty`)
+}
+
+func TestBuildPickSHADetails(t *testing.T) {
+	rawFields, err := json.Marshal(map[string]interface{}{
+		"summary":           "Release: v25.4.3",
+		cfStagingBranch:     "release-25.4.3-rc",
+		cfCloudReleaseNotes: "2026-04-23",
+		cfPublishBinary:     "2026-04-24",
+	})
+	require.NoError(t, err)
+	var issue jiraIssue
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"key":"REL-1234","fields":`+string(rawFields)+`}`), &issue))
+
+	d, err := buildPickSHADetails(
+		&issue, "release-25.4.3-rc", "deadbeef", "example-org/example-repo", "release-build-and-sign.yml")
+	require.NoError(t, err)
+	require.Equal(t, "release-25.4.3-rc", d.StagingBranch)
+	require.Equal(t, "deadbeef", d.PickedSHA)
+	require.Equal(t, "https://github.com/example-org/example-repo/commit/deadbeef", d.PickedCommitURL)
+	require.Equal(t,
+		"https://github.com/example-org/example-repo/actions/workflows/release-build-and-sign.yml",
+		d.BuildRunListURL)
+	require.Equal(t, "Thursday, 04/23", d.CloudReleaseNotesDate)
+	require.Equal(t, "Friday, 04/24", d.PublishBinaryDate)
+}
+
+func TestBuildPickSHADetailsTBD(t *testing.T) {
+	// Empty date fields collapse to "TBD" so the rendered message doesn't
+	// show a bare backtick pair.
+	var issue jiraIssue
+	require.NoError(t, json.Unmarshal([]byte(`{"key":"REL-1","fields":{}}`), &issue))
+	d, err := buildPickSHADetails(&issue, "release-25.4.3-rc", "abc", "o/r", "w.yml")
+	require.NoError(t, err)
+	require.Equal(t, "TBD", d.CloudReleaseNotesDate)
+	require.Equal(t, "TBD", d.PublishBinaryDate)
+}
+
+func TestBuildPickSHASlackMessage(t *testing.T) {
+	d := pickSHADetails{
+		StagingBranch:         "release-25.4.3-rc",
+		PickedSHA:             "deadbeef",
+		PickedCommitURL:       "https://github.com/example-org/example-repo/commit/deadbeef",
+		BuildRunListURL:       "https://github.com/example-org/example-repo/actions/workflows/release-build-and-sign.yml",
+		CloudReleaseNotesDate: "Thursday, 04/23",
+		PublishBinaryDate:     "Friday, 04/24",
+	}
+
+	t.Run("regular message", func(t *testing.T) {
+		msg := buildPickSHASlackMessage(d, false)
+		require.Contains(t, msg, "SHA picked for `release-25.4.3-rc`")
+		require.Contains(t, msg, "<https://github.com/example-org/example-repo/commit/deadbeef|deadbeef>")
+		require.Contains(t, msg,
+			"<https://github.com/example-org/example-repo/actions/workflows/release-build-and-sign.yml|view in Actions>")
+		require.Contains(t, msg, "*Cloud Release Notes Date:* `Thursday, 04/23`")
+		require.Contains(t, msg, "*Publish Binaries Date:* `Friday, 04/24`")
+		require.False(t, strings.HasPrefix(msg, "[DRY RUN] "))
+	})
+
+	t.Run("dry-run prefix", func(t *testing.T) {
+		require.True(t, strings.HasPrefix(buildPickSHASlackMessage(d, true), "[DRY RUN] "))
+	})
+}
+
+func TestBuildPickSHAJiraComment(t *testing.T) {
+	d := pickSHADetails{
+		StagingBranch:         "release-25.4.3-rc",
+		PickedSHA:             "deadbeef",
+		PickedCommitURL:       "https://github.com/example-org/example-repo/commit/deadbeef",
+		BuildRunListURL:       "https://github.com/example-org/example-repo/actions/workflows/release-build-and-sign.yml",
+		CloudReleaseNotesDate: "Thursday, 04/23",
+		PublishBinaryDate:     "Friday, 04/24",
+	}
+	const slackLink = "https://example.slack.com/archives/C123/p456"
+
+	doc := buildPickSHAJiraComment(d, slackLink)
+	require.Equal(t, "doc", doc["type"])
+	require.Equal(t, 1, doc["version"])
+	content, ok := doc["content"].([]interface{})
+	require.True(t, ok)
+
+	// Expect: Slack-link paragraph, intro paragraph, bullet list.
+	require.Len(t, content, 3)
+	require.Equal(t, "paragraph", content[0].(map[string]interface{})["type"])
+	require.Equal(t, "paragraph", content[1].(map[string]interface{})["type"])
+	require.Equal(t, "bulletList", content[2].(map[string]interface{})["type"])
+
+	// Encode and inspect for the high-signal substrings rather than walking
+	// every node — the structural assertions above are the contract; the
+	// JSON check is a smoke test that data flows through the marks.
+	encoded, err := json.Marshal(doc)
+	require.NoError(t, err)
+	asString := string(encoded)
+	require.Contains(t, asString, slackLink)
+	require.Contains(t, asString, "release-25.4.3-rc")
+	require.Contains(t, asString, "deadbeef")
+	require.Contains(t, asString, d.PickedCommitURL)
+	require.Contains(t, asString, d.BuildRunListURL)
+	require.Contains(t, asString, "Cloud Release Notes Date:")
+	require.Contains(t, asString, "Thursday, 04/23")
+}
+
+func TestBuildPickSHAJiraCommentNoSlackLink(t *testing.T) {
+	d := pickSHADetails{
+		StagingBranch:         "release-25.4.3-rc",
+		PickedSHA:             "abc",
+		PickedCommitURL:       "https://example.test/commit/abc",
+		BuildRunListURL:       "https://example.test/actions",
+		CloudReleaseNotesDate: "TBD",
+		PublishBinaryDate:     "TBD",
+	}
+	doc := buildPickSHAJiraComment(d, "")
+	content, ok := doc["content"].([]interface{})
+	require.True(t, ok)
+	// No Slack-link paragraph: just intro paragraph + bullet list.
+	require.Len(t, content, 2)
+	require.Equal(t, "paragraph", content[0].(map[string]interface{})["type"])
+	require.Equal(t, "bulletList", content[1].(map[string]interface{})["type"])
+}
+
+func TestFindSubtask(t *testing.T) {
+	mkIssue := func(subtasks ...jiraSubtask) *jiraIssue {
+		return &jiraIssue{Fields: jiraIssueFields{Subtasks: subtasks}}
+	}
+	mkSubtask := func(key, summary, status string) jiraSubtask {
+		st := jiraSubtask{Key: key}
+		st.Fields.Summary = summary
+		st.Fields.Status.Name = status
+		return st
+	}
+
+	tests := []struct {
+		name         string
+		issue        *jiraIssue
+		needle       string
+		expectedKey  string
+		expectedDone bool
+	}{
+		{
+			name:        "open subtask returns key and not-done",
+			issue:       mkIssue(mkSubtask("REL-2", "Pick SHA", "To Do")),
+			needle:      "Pick SHA",
+			expectedKey: "REL-2",
+		},
+		{
+			name:         "done subtask returns key and done",
+			issue:        mkIssue(mkSubtask("REL-2", "Pick SHA", "Done")),
+			needle:       "Pick SHA",
+			expectedKey:  "REL-2",
+			expectedDone: true,
+		},
+		{
+			name:   "missing subtask returns empty and not-done",
+			issue:  mkIssue(mkSubtask("REL-2", "Some unrelated work", "To Do")),
+			needle: "Pick SHA",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key, done := findSubtask(tc.issue, tc.needle)
+			require.Equal(t, tc.expectedKey, key)
+			require.Equal(t, tc.expectedDone, done)
+		})
+	}
+}
+
+func TestBuildReleaseNotesPayload(t *testing.T) {
+	mkIssue := func(summary string, fields map[string]interface{}, subtasks ...jiraSubtask) *jiraIssue {
+		fields["summary"] = summary
+		raw, err := json.Marshal(fields)
+		require.NoError(t, err)
+		var issue jiraIssue
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"key":"REL-1","fields":`+string(raw)+`}`), &issue))
+		issue.Fields.Subtasks = subtasks
+		return &issue
+	}
+	docsSubtask := jiraSubtask{Key: "DOC-42"}
+	docsSubtask.Fields.Summary = docsSubtaskMatch
+	docsSubtask.Fields.Status.Name = "To Do"
+
+	tests := []struct {
+		name             string
+		issue            *jiraIssue
+		sha              string
+		expected         releaseNotesPayload
+		expectErrContain string
+	}{
+		{
+			name: "scheduled patch with cloud notes date and docs subtask",
+			issue: mkIssue("Release: v25.4.3", map[string]interface{}{
+				cfCloudReleaseNotes: "2026-04-23",
+				cfPublishBinary:     "2026-04-24",
+			}, docsSubtask),
+			sha: "deadbeef",
+			expected: releaseNotesPayload{
+				CurrentRelease: "v25.4.3",
+				ReleaseDate:    "2026-04-23",
+				ReleaseSHA:     "deadbeef",
+				Cloud:          true,
+				DocsTicket:     "DOC-42",
+			},
+		},
+		{
+			name: "major release patch zero",
+			issue: mkIssue("Release: v25.4.0", map[string]interface{}{
+				cfCloudReleaseNotes: "2026-04-23",
+			}),
+			sha: "abc",
+			expected: releaseNotesPayload{
+				CurrentRelease: "v25.4.0",
+				ReleaseDate:    "2026-04-23",
+				ReleaseSHA:     "abc",
+				Cloud:          true,
+				DocsTicket:     "",
+			},
+		},
+		{
+			name: "pre-release suppresses cloud flag",
+			issue: mkIssue("Release: v25.4.0-alpha.1", map[string]interface{}{
+				cfPublishBinary: "2026-04-24",
+			}),
+			sha: "abc",
+			expected: releaseNotesPayload{
+				CurrentRelease: "v25.4.0-alpha.1",
+				ReleaseDate:    "2026-04-24",
+				ReleaseSHA:     "abc",
+				Cloud:          false,
+			},
+		},
+		{
+			name: "release date falls back to publish-binary date",
+			issue: mkIssue("Release: v25.4.3", map[string]interface{}{
+				cfPublishBinary: "2026-04-24",
+			}),
+			sha: "abc",
+			expected: releaseNotesPayload{
+				CurrentRelease: "v25.4.3",
+				ReleaseDate:    "2026-04-24",
+				ReleaseSHA:     "abc",
+				Cloud:          true,
+			},
+		},
+		{
+			name:  "both date fields empty yields empty release date",
+			issue: mkIssue("Release: v25.4.3", map[string]interface{}{}),
+			sha:   "abc",
+			expected: releaseNotesPayload{
+				CurrentRelease: "v25.4.3",
+				ReleaseDate:    "",
+				ReleaseSHA:     "abc",
+				Cloud:          true,
+			},
+		},
+		{
+			name: "jira override forces release type",
+			issue: mkIssue("Release: v25.4.3", map[string]interface{}{
+				cfReleaseTypeOverride: map[string]interface{}{"value": preReleaseType},
+				cfCloudReleaseNotes:   "2026-04-23",
+			}),
+			sha: "abc",
+			expected: releaseNotesPayload{
+				CurrentRelease: "v25.4.3",
+				ReleaseDate:    "2026-04-23",
+				ReleaseSHA:     "abc",
+				Cloud:          false,
+			},
+		},
+		{
+			name:             "unparseable summary returns error",
+			issue:            mkIssue("not a release ticket", map[string]interface{}{}),
+			sha:              "abc",
+			expectErrContain: "parsing release version",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildReleaseNotesPayload(tc.issue, tc.sha)
+			if tc.expectErrContain != "" {
+				require.ErrorContains(t, err, tc.expectErrContain)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestBuildReleaseNotesWarning(t *testing.T) {
+	payload := releaseNotesPayload{
+		CurrentRelease: "v25.4.3",
+		ReleaseDate:    "2026-04-23",
+		ReleaseSHA:     "deadbeef",
+		Cloud:          true,
+		DocsTicket:     "DOC-42",
+	}
+
+	t.Run("with payload renders headline, jira link, payload, and forward line", func(t *testing.T) {
+		msg := buildReleaseNotesWarning("REL-1234", payload, fmt.Errorf("500 Internal Server Error"))
+		require.Contains(t, msg, ":x: *release-notes-api failed for v25.4.3*")
+		require.Contains(t, msg,
+			"*Release*: <https://cockroachlabs.atlassian.net/browse/REL-1234|REL-1234>")
+		require.Contains(t, msg, "*Error*: 500 Internal Server Error")
+		require.Contains(t, msg, "*Payload*: ```")
+		require.Contains(t, msg, `"current_release": "v25.4.3"`)
+		require.Contains(t, msg, `"docs_ticket": "DOC-42"`)
+		require.Contains(t, msg, "#docs-infrastructure-team")
+	})
+
+	t.Run("zero payload omits payload block and falls back to ticket key headline", func(t *testing.T) {
+		msg := buildReleaseNotesWarning("REL-1234", releaseNotesPayload{}, fmt.Errorf("bad jira data"))
+		require.Contains(t, msg, ":x: *release-notes-api failed for REL-1234*")
+		require.Contains(t, msg, "*Error*: bad jira data")
+		require.NotContains(t, msg, "*Payload*:")
+		require.Contains(t, msg, "#docs-infrastructure-team")
+	})
+}
+
+func TestPostReleaseNotes(t *testing.T) {
+	payload := releaseNotesPayload{
+		CurrentRelease: "v25.4.3",
+		ReleaseDate:    "2026-04-23",
+		ReleaseSHA:     "deadbeef",
+		Cloud:          true,
+		DocsTicket:     "DOC-42",
+	}
+
+	t.Run("posts payload with X-API-Key header on success", func(t *testing.T) {
+		var gotMethod, gotKey, gotContentType string
+		var gotBody []byte
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotKey = r.Header.Get("X-API-Key")
+			gotContentType = r.Header.Get("Content-Type")
+			gotBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		require.NoError(t, postReleaseNotes(srv.URL, "secret-key", payload))
+		require.Equal(t, http.MethodPost, gotMethod)
+		require.Equal(t, "secret-key", gotKey)
+		require.Equal(t, "application/json", gotContentType)
+
+		// The Go function wraps the payload in {"ReleaseNotesPayload": ...}
+		// so the docs API consumer keeps its existing field name.
+		var wrapped struct {
+			ReleaseNotesPayload releaseNotesPayload `json:"ReleaseNotesPayload"`
+		}
+		require.NoError(t, json.Unmarshal(gotBody, &wrapped))
+		require.Equal(t, payload, wrapped.ReleaseNotesPayload)
+	})
+
+	t.Run("non-2xx returns error including status and body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer srv.Close()
+
+		err := postReleaseNotes(srv.URL, "k", payload)
+		require.ErrorContains(t, err, "500")
+		require.ErrorContains(t, err, "boom")
+	})
+}
+
+// TestPickSHARunnerProcessCandidateIdempotent exercises the gate at the top
+// of processCandidate: when the Pick SHA subtask is already Done, the runner
+// must skip the entire candidate — no GitHub call, no Jira mutation. The test
+// fails the GitHub mock loudly (handler errors the test) so a regression that
+// re-dispatches build-and-sign is caught.
+func TestPickSHARunnerProcessCandidateIdempotent(t *testing.T) {
+	today := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	// Candidate has the bare fields the runner reads up to the gate:
+	// summary parses as v25.4.3 and pick-date is today (so the readiness
+	// check passes).
+	candidate := mkPickSHACandidate(t, "2026-04-20")
+
+	// Full issue (returned by Jira GetIssue) must include a Done Pick SHA
+	// subtask so findSubtask reports done=true.
+	doneSubtask := jiraSubtask{Key: "REL-2"}
+	doneSubtask.Fields.Summary = "Pick SHA"
+	doneSubtask.Fields.Status.Name = "Done"
+
+	var ghCalls atomic.Int64
+	ghSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		ghCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ghSrv.Close()
+
+	jiraSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Only GetIssue is allowed past the gate; everything else (UpdateFields,
+		// Transition, AddComment) means a regression.
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/rest/api/3/issue/REL-1") {
+			t.Errorf("unexpected jira call: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		issue := mkPickSHAFullIssueJSON(t, "release-25.4.3-rc", []jiraSubtask{doneSubtask})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(issue))
+	}))
+	defer jiraSrv.Close()
+
+	r := newPickSHARunnerForTest(t, ghSrv, jiraSrv, today)
+	require.NoError(t, r.processCandidate(context.Background(), candidate))
+	require.Equal(t, int64(0), ghCalls.Load(),
+		"GitHub must not be called when Pick SHA subtask is already Done")
+}
+
+// mkPickSHACandidate builds a candidate jiraIssue suitable for the JQL search
+// result: summary parses, pickDate is set, and no further fields are needed
+// because processCandidate refetches the full issue via Jira.
+func mkPickSHACandidate(t *testing.T, pickDate string) jiraIssue {
+	t.Helper()
+	rawFields, err := json.Marshal(map[string]interface{}{
+		"summary":     "Release: v25.4.3",
+		cfPickSHADate: pickDate,
+	})
+	require.NoError(t, err)
+	var issue jiraIssue
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"key":"REL-1","fields":`+string(rawFields)+`}`), &issue))
+	return issue
+}
+
+// mkPickSHAFullIssueJSON builds the JSON the Jira GetIssue mock returns for
+// REL-1 with a given staging branch and subtask set.
+func mkPickSHAFullIssueJSON(t *testing.T, staging string, subtasks []jiraSubtask) string {
+	t.Helper()
+	subtaskRaw, err := json.Marshal(subtasks)
+	require.NoError(t, err)
+	rawFields, err := json.Marshal(map[string]interface{}{
+		"summary":       "Release: v25.4.3",
+		cfStagingBranch: staging,
+		cfPickSHADate:   "2026-04-20",
+		cfPublishBinary: "2026-04-24",
+		"subtasks":      json.RawMessage(subtaskRaw),
+	})
+	require.NoError(t, err)
+	return `{"key":"REL-1","fields":` + string(rawFields) + `}`
+}
+
+func newPickSHARunnerForTest(
+	t *testing.T, ghSrv, jiraSrv *httptest.Server, today time.Time,
+) *pickSHARunner {
+	t.Helper()
+	gh := newGitHubClient("test-token", "owner", "repo")
+	u, err := url.Parse(ghSrv.URL + "/")
+	require.NoError(t, err)
+	gh.client.BaseURL = u
+
+	jira := newJiraClient("bot@example.com", "test-token")
+	jira.baseURL = jiraSrv.URL
+
+	return &pickSHARunner{
+		jira:          jira,
+		gh:            gh,
+		dryRun:        false,
+		today:         today,
+		buildWorkflow: defaultBuildWorkflow,
+	}
+}
+
+func TestFindOpenSubtask(t *testing.T) {
+	mkIssue := func(subtasks ...jiraSubtask) *jiraIssue {
+		return &jiraIssue{Fields: jiraIssueFields{Subtasks: subtasks}}
+	}
+	mkSubtask := func(key, summary, status string) jiraSubtask {
+		st := jiraSubtask{Key: key}
+		st.Fields.Summary = summary
+		st.Fields.Status.Name = status
+		return st
+	}
+
+	tests := []struct {
+		name        string
+		issue       *jiraIssue
+		needle      string
+		expectedKey string
+	}{
+		{
+			name:        "matches case insensitively",
+			issue:       mkIssue(mkSubtask("REL-2", "Pick SHA for v25.4.3", "To Do")),
+			needle:      "pick sha",
+			expectedKey: "REL-2",
+		},
+		{
+			name:        "skips already-done subtask",
+			issue:       mkIssue(mkSubtask("REL-2", "Pick SHA", "Done")),
+			needle:      "Pick SHA",
+			expectedKey: "",
+		},
+		{
+			name:        "no match returns empty",
+			issue:       mkIssue(mkSubtask("REL-2", "Some unrelated work", "To Do")),
+			needle:      "Pick SHA",
+			expectedKey: "",
+		},
+		{
+			name: "first matching open subtask wins",
+			issue: mkIssue(
+				mkSubtask("REL-1", "Cut Staging Branch", "To Do"),
+				mkSubtask("REL-2", "Pick SHA", "To Do"),
+			),
+			needle:      "Pick SHA",
+			expectedKey: "REL-2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedKey, findOpenSubtask(tc.issue, tc.needle))
+		})
+	}
+}

--- a/pkg/cmd/release/pick_sha_test.go
+++ b/pkg/cmd/release/pick_sha_test.go
@@ -377,13 +377,12 @@ func TestPostReleaseNotes(t *testing.T) {
 		require.Equal(t, "secret-key", gotKey)
 		require.Equal(t, "application/json", gotContentType)
 
-		// The Go function wraps the payload in {"ReleaseNotesPayload": ...}
-		// so the docs API consumer keeps its existing field name.
-		var wrapped struct {
-			ReleaseNotesPayload releaseNotesPayload `json:"ReleaseNotesPayload"`
-		}
-		require.NoError(t, json.Unmarshal(gotBody, &wrapped))
-		require.Equal(t, payload, wrapped.ReleaseNotesPayload)
+		// The docs API expects the payload fields at the top level of the
+		// request body; an envelope causes 400s on the required-field
+		// validators (Request.CurrentRelease / ReleaseDate / ReleaseSHA).
+		var got releaseNotesPayload
+		require.NoError(t, json.Unmarshal(gotBody, &got))
+		require.Equal(t, payload, got)
 	})
 
 	t.Run("non-2xx returns error including status and body", func(t *testing.T) {

--- a/pkg/cmd/release/pick_sha_test.go
+++ b/pkg/cmd/release/pick_sha_test.go
@@ -82,7 +82,7 @@ func TestBuildPickSHASlackMessage(t *testing.T) {
 	}
 
 	t.Run("regular message", func(t *testing.T) {
-		msg := buildPickSHASlackMessage(d, false)
+		msg := buildPickSHASlackMessage(d, "", false)
 		require.Contains(t, msg, "SHA picked for `release-25.4.3-rc`")
 		require.Contains(t, msg, "<https://github.com/example-org/example-repo/commit/deadbeef|deadbeef>")
 		require.Contains(t, msg,
@@ -90,10 +90,17 @@ func TestBuildPickSHASlackMessage(t *testing.T) {
 		require.Contains(t, msg, "*Cloud Release Notes Date:* `Thursday, 04/23`")
 		require.Contains(t, msg, "*Publish Binaries Date:* `Friday, 04/24`")
 		require.False(t, strings.HasPrefix(msg, "[DRY RUN] "))
+		require.NotContains(t, msg, "Release notes PR")
+	})
+
+	t.Run("with release-notes PR", func(t *testing.T) {
+		const prURL = "https://github.com/cockroachdb/docs/pull/23375"
+		msg := buildPickSHASlackMessage(d, prURL, false)
+		require.Contains(t, msg, "*Release notes PR:* <"+prURL+"|"+prURL+">")
 	})
 
 	t.Run("dry-run prefix", func(t *testing.T) {
-		require.True(t, strings.HasPrefix(buildPickSHASlackMessage(d, true), "[DRY RUN] "))
+		require.True(t, strings.HasPrefix(buildPickSHASlackMessage(d, "", true), "[DRY RUN] "))
 	})
 }
 
@@ -108,7 +115,7 @@ func TestBuildPickSHAJiraComment(t *testing.T) {
 	}
 	const slackLink = "https://example.slack.com/archives/C123/p456"
 
-	doc := buildPickSHAJiraComment(d, slackLink)
+	doc := buildPickSHAJiraComment(d, slackLink, "")
 	require.Equal(t, "doc", doc["type"])
 	require.Equal(t, 1, doc["version"])
 	content, ok := doc["content"].([]interface{})
@@ -144,7 +151,7 @@ func TestBuildPickSHAJiraCommentNoSlackLink(t *testing.T) {
 		CloudReleaseNotesDate: "TBD",
 		PublishBinaryDate:     "TBD",
 	}
-	doc := buildPickSHAJiraComment(d, "")
+	doc := buildPickSHAJiraComment(d, "", "")
 	content, ok := doc["content"].([]interface{})
 	require.True(t, ok)
 	// No Slack-link paragraph: just intro paragraph + bullet list.
@@ -360,7 +367,7 @@ func TestPostReleaseNotes(t *testing.T) {
 		DocsTicket:     "DOC-42",
 	}
 
-	t.Run("posts payload with X-API-Key header on success", func(t *testing.T) {
+	t.Run("posts payload and decodes pull_request_url on success", func(t *testing.T) {
 		var gotMethod, gotKey, gotContentType string
 		var gotBody []byte
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -369,13 +376,16 @@ func TestPostReleaseNotes(t *testing.T) {
 			gotContentType = r.Header.Get("Content-Type")
 			gotBody, _ = io.ReadAll(r.Body)
 			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"pull_request_url":"https://github.com/cockroachdb/docs/pull/123"}`))
 		}))
 		defer srv.Close()
 
-		require.NoError(t, postReleaseNotes(srv.URL, "secret-key", payload))
+		resp, err := postReleaseNotes(srv.URL, "secret-key", payload)
+		require.NoError(t, err)
 		require.Equal(t, http.MethodPost, gotMethod)
 		require.Equal(t, "secret-key", gotKey)
 		require.Equal(t, "application/json", gotContentType)
+		require.Equal(t, "https://github.com/cockroachdb/docs/pull/123", resp.PullRequestURL)
 
 		// The docs API expects the payload fields at the top level of the
 		// request body; an envelope causes 400s on the required-field
@@ -385,6 +395,17 @@ func TestPostReleaseNotes(t *testing.T) {
 		require.Equal(t, payload, got)
 	})
 
+	t.Run("empty body yields zero-value response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		resp, err := postReleaseNotes(srv.URL, "k", payload)
+		require.NoError(t, err)
+		require.Empty(t, resp.PullRequestURL)
+	})
+
 	t.Run("non-2xx returns error including status and body", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -392,7 +413,7 @@ func TestPostReleaseNotes(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		err := postReleaseNotes(srv.URL, "k", payload)
+		_, err := postReleaseNotes(srv.URL, "k", payload)
 		require.ErrorContains(t, err, "500")
 		require.ErrorContains(t, err, "boom")
 	})

--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/errors"
+)
+
+// releaseNotesAPIURL is the docs team's release-notes-automation endpoint.
+// Posting here kicks off the cloud release-notes draft workflow on their
+// side. There is no separate non-prod endpoint, so dry runs skip the call
+// entirely (see pickSHARunner.processCandidate).
+const releaseNotesAPIURL = "https://us-central1-release-notes-automation-prod.cloudfunctions.net/release-notes-api/generate-release-epic"
+
+// envReleaseNotesAPIKey is the env var that holds the X-API-Key value for
+// the release-notes-automation endpoint. The pick-sha workflow fetches it
+// from Secret Manager (gha-releases-release-notes-api-key); pick-sha
+// requires it at startup.
+const envReleaseNotesAPIKey = "RELEASE_NOTES_API_KEY"
+
+// docsSubtaskMatch is the (case-insensitive) substring used to find the
+// docs subtask whose key is forwarded to the release-notes API as
+// docs_ticket. Subtask summaries are created by the same Jira automation
+// that owns the release ticket template.
+const docsSubtaskMatch = "[Docs] Generate release notes"
+
+// releaseNotesPayload is the per-release information the docs API needs to
+// open the cloud release-notes draft. Field names and JSON shape mirror the
+// Superblocks payload this replaces; do not rename without coordinating
+// with the docs team.
+type releaseNotesPayload struct {
+	CurrentRelease string `json:"current_release"` // e.g. v25.4.0
+	ReleaseDate    string `json:"release_date"`    // YYYY-MM-DD
+	ReleaseSHA     string `json:"release_sha"`
+	Cloud          bool   `json:"cloud"`
+	DocsTicket     string `json:"docs_ticket"`
+}
+
+// postReleaseNotes POSTs payload to url with the X-API-Key header. Returns
+// nil on a 2xx response, otherwise an error containing the response status
+// and (truncated) body. Caller is expected to treat failures as a warning,
+// not a fatal error: the rest of pick-sha has already succeeded and the
+// docs team can re-trigger manually. URL is injected (rather than reading
+// the constant directly) so tests can point at an httptest server.
+func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
+	body, err := json.Marshal(map[string]interface{}{
+		"ReleaseNotesPayload": p,
+	})
+	if err != nil {
+		return errors.Wrap(err, "marshalling payload")
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return errors.Wrap(err, "building request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", apiKey)
+	client := httputil.NewClientWithTimeout(30 * time.Second)
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "posting to release-notes API")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return errors.Newf("release-notes API returned %s: %s", resp.Status, respBody)
+	}
+	return nil
+}

--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -46,20 +46,30 @@ type releaseNotesPayload struct {
 	DocsTicket     string `json:"docs_ticket"`
 }
 
-// postReleaseNotes POSTs payload to url with the X-API-Key header. Returns
-// nil on a 2xx response, otherwise an error containing the response status
-// and (truncated) body. Caller is expected to treat failures as a warning,
-// not a fatal error: the rest of pick-sha has already succeeded and the
-// docs team can re-trigger manually. URL is injected (rather than reading
-// the constant directly) so tests can point at an httptest server.
-func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
+// releaseNotesResponse is the JSON body the docs API returns on success.
+// PullRequestURL points at the cockroachdb/docs PR that holds the
+// generated release-notes draft. Other fields the API may return are
+// intentionally not modelled — callers only need the PR link today.
+type releaseNotesResponse struct {
+	PullRequestURL string `json:"pull_request_url"`
+}
+
+// postReleaseNotes POSTs payload to url with the X-API-Key header. On a 2xx
+// response it returns the parsed body (which may have an empty
+// PullRequestURL if the API omits it); on non-2xx it returns an error
+// containing the response status and (truncated) body. Caller is expected
+// to treat failures as a warning, not a fatal error: the rest of pick-sha
+// has already succeeded and the docs team can re-trigger manually. URL is
+// injected (rather than reading the constant directly) so tests can point
+// at an httptest server.
+func postReleaseNotes(url, apiKey string, p releaseNotesPayload) (releaseNotesResponse, error) {
 	body, err := json.Marshal(p)
 	if err != nil {
-		return errors.Wrap(err, "marshalling payload")
+		return releaseNotesResponse{}, errors.Wrap(err, "marshalling payload")
 	}
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return errors.Wrap(err, "building request")
+		return releaseNotesResponse{}, errors.Wrap(err, "building request")
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", apiKey)
@@ -69,12 +79,27 @@ func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
 	client := httputil.NewClientWithTimeout(2 * time.Minute)
 	resp, err := client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "posting to release-notes API")
+		return releaseNotesResponse{}, errors.Wrap(err, "posting to release-notes API")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 300 {
+		// The body is diagnostic-only on top of an already-known error;
+		// a read failure here doesn't change the outcome, so the error
+		// is intentionally dropped.
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return errors.Newf("release-notes API returned %s: %s", resp.Status, respBody)
+		return releaseNotesResponse{}, errors.Newf("release-notes API returned %s: %s", resp.Status, respBody)
 	}
-	return nil
+	// Bound the read so a runaway response can't exhaust memory. 16 KiB
+	// is well above the small JSON the API actually returns.
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
+	if err != nil {
+		return releaseNotesResponse{}, errors.Wrap(err, "reading release-notes response")
+	}
+	var out releaseNotesResponse
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &out); err != nil {
+			return releaseNotesResponse{}, errors.Wrap(err, "decoding release-notes response")
+		}
+	}
+	return out, nil
 }

--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -53,9 +53,7 @@ type releaseNotesPayload struct {
 // docs team can re-trigger manually. URL is injected (rather than reading
 // the constant directly) so tests can point at an httptest server.
 func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
-	body, err := json.Marshal(map[string]interface{}{
-		"ReleaseNotesPayload": p,
-	})
+	body, err := json.Marshal(p)
 	if err != nil {
 		return errors.Wrap(err, "marshalling payload")
 	}

--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -63,7 +63,10 @@ func postReleaseNotes(url, apiKey string, p releaseNotesPayload) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", apiKey)
-	client := httputil.NewClientWithTimeout(30 * time.Second)
+	// The endpoint is a Cloud Function that synthesizes a release-notes
+	// draft; cold starts plus the docs work itself can easily exceed
+	// 30s, so allow a couple of minutes before giving up.
+	client := httputil.NewClientWithTimeout(2 * time.Minute)
 	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "posting to release-notes API")

--- a/pkg/cmd/release/sentry/main.go
+++ b/pkg/cmd/release/sentry/main.go
@@ -225,10 +225,16 @@ func main() {
 	}
 	artifactName := fmt.Sprintf("cockroach-%s.%s.tgz", version, platform)
 	log.Printf("Downloading artifact: %s", artifactName)
-	gsutilCmd := exec.Command("gsutil", "cp",
+	// Use `gcloud storage cp` rather than `gsutil cp`: under Workload
+	// Identity Federation, gsutil does not honor the credentials file
+	// google-github-actions/auth writes and silently falls back to the
+	// runner VM's metadata service account.
+	downloadCmd := exec.Command("gcloud", "storage", "cp",
 		fmt.Sprintf("gs://cockroach-release-artifacts-staged-prod/%s", artifactName),
 		"./")
-	if err := gsutilCmd.Run(); err != nil {
+	downloadCmd.Stdout = os.Stdout
+	downloadCmd.Stderr = os.Stderr
+	if err := downloadCmd.Run(); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Downloaded artifact: %s", artifactName)

--- a/pkg/cmd/release/slack_post.go
+++ b/pkg/cmd/release/slack_post.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/errors"
+	"github.com/slack-go/slack"
+)
+
+// slackClient posts a single message to a Slack channel and returns a
+// permalink so we can embed it in the Jira comment that mirrors the
+// notification.
+type slackClient struct {
+	api *slack.Client
+}
+
+// slackHTTPTimeout bounds each Slack API call. The slack-go library defaults
+// to http.DefaultClient (no timeout); without this option a wedged Slack
+// endpoint would hang the run.
+const slackHTTPTimeout = 15 * time.Second
+
+func newSlackClient(token string) *slackClient {
+	return &slackClient{
+		api: slack.New(token,
+			slack.OptionHTTPClient(httputil.NewClientWithTimeout(slackHTTPTimeout).Client),
+		),
+	}
+}
+
+// PostMessage posts text to the named channel and returns the message
+// permalink (or "" if the link can't be retrieved).
+func (s *slackClient) PostMessage(channel, text string) (string, error) {
+	channelID, ts, err := s.api.PostMessage(channel,
+		slack.MsgOptionText(text, false),
+		slack.MsgOptionDisableLinkUnfurl(),
+	)
+	if err != nil {
+		return "", errors.Wrapf(err, "posting to %s", channel)
+	}
+	link, err := s.api.GetPermalink(&slack.PermalinkParameters{
+		Channel: channelID,
+		Ts:      ts,
+	})
+	if err != nil {
+		// A missing permalink isn't fatal — the message was delivered, and
+		// callers fall back to embedding the bare message body in the Jira
+		// comment when the link is empty.
+		log.Printf("warning: get permalink for %s/%s: %v", channelID, ts, err)
+		return "", nil
+	}
+	return link, nil
+}

--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -36,8 +36,23 @@ const (
 	releasedVersionFlag = "released-version"
 	nextVersionFlag     = "next-version"
 	versionBumpOnly     = "version-bump-only"
+	cockroachRepoFlag   = "cockroach-repo"
+	githubUsernameFlag  = "github-username"
 	versionFile         = "pkg/build/version.txt"
+
+	defaultGithubUsernameFlag = "cockroach-teamcity"
 )
+
+// knownGithubUsernames lists every GitHub user under whose identity
+// version-bump PRs may have been opened, historically or currently. The
+// prExists() check searches for prior PRs from any of these so that a
+// run under one identity (say, the GHA bot crl-release-eng-bot) doesn't
+// re-open a PR that an earlier TC run already opened as cockroach-teamcity.
+// Keep this in sync with every value --github-username has ever taken.
+var knownGithubUsernames = []string{
+	"cockroach-teamcity",
+	"crl-release-eng-bot",
+}
 
 var updateVersionsFlags = struct {
 	dryRun             bool
@@ -49,6 +64,21 @@ var updateVersionsFlags = struct {
 	smtpPort           int
 	emailAddresses     []string
 	versionBumpOnly    bool
+	// cockroachRepo is the GitHub destination for cockroach version-bump
+	// PRs and merge PRs, in `owner/name` form. Satellite repos
+	// (homebrew-tap, helm-charts) keep their well-known names but inherit
+	// the owner from this flag's owner part. Set this when the canonical
+	// cockroach repo moves to a different owner or name (e.g. an org
+	// rename or fork-promotion); otherwise the default points at the
+	// historical cockroachdb/cockroach.
+	cockroachRepo string
+	// githubUsername is the GitHub user under which PR branches are
+	// pushed and PRs are opened. TC runs default to "cockroach-teamcity"
+	// (the historical value); GHA runs override to the bot account whose
+	// PAT they use (e.g. "crl-release-eng-bot"). The user's fork
+	// $githubUsername/$repo must exist and be writable by the PAT for
+	// non-pushToOrigin repos.
+	githubUsername string
 }{}
 
 var updateVersionsCmd = &cobra.Command{
@@ -68,12 +98,17 @@ func init() {
 	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.smtpHost, smtpHost, "", "SMTP host")
 	updateVersionsCmd.Flags().IntVar(&updateVersionsFlags.smtpPort, smtpPort, 0, "SMTP port")
 	updateVersionsCmd.Flags().StringArrayVar(&updateVersionsFlags.emailAddresses, emailAddresses, []string{}, "email addresses")
+	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.cockroachRepo, cockroachRepoFlag, "",
+		"cockroach repo to push to, as owner/name (also seeds the owner used for homebrew-tap and helm-charts pushes); required")
+	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.githubUsername, githubUsernameFlag, defaultGithubUsernameFlag,
+		"GitHub user under which PR branches are pushed and PRs are opened (the user's fork must exist and be writable by the configured token)")
 	requiredFlags := []string{
 		releasedVersionFlag,
 		smtpUser,
 		smtpHost,
 		smtpPort,
 		emailAddresses,
+		cockroachRepoFlag,
 	}
 	for _, flag := range requiredFlags {
 		if err := updateVersionsCmd.MarkFlagRequired(flag); err != nil {
@@ -178,33 +213,45 @@ func (r prRepo) commit() error {
 // prExists checks whether a PR (represented as an instance of
 // `prRepo`) already exists. Returns a description of the PR when it
 // exists and any errors found in the process.
+//
+// Searches across every author in knownGithubUsernames, not just
+// r.githubUsername, so that a run as one bot identity (e.g. the GHA
+// crl-release-eng-bot) finds — and skips re-opening — a PR that an
+// earlier run as a different identity (e.g. the TC cockroach-teamcity)
+// already opened. `gh pr list --search` doesn't OR multiple `author:`
+// qualifiers reliably (GitHub's search treats space-separated
+// qualifiers as AND for non-multi-value fields), so we issue one query
+// per author and stop at the first hit.
 func (r prRepo) prExists() (string, error) {
 	title := strings.Split(r.commitMessage, "\n")[0]
-	log.Printf("checking if PR %q already exists", title)
+	log.Printf("checking if PR %q already exists (authors: %s)",
+		title, strings.Join(knownGithubUsernames, ", "))
 	query := fmt.Sprintf("in:title %q", title)
-	args := []string{
-		"pr", "list", "--search", query, "--author", r.githubUsername, "--json", "number,title",
-	}
-	cmd := exec.Command("gh", args...)
-	cmd.Dir = r.checkoutDir()
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed searching for existing PRs: %w\nOutput: %s", err, string(out))
-	}
+	for _, author := range knownGithubUsernames {
+		args := []string{
+			"pr", "list", "--search", query, "--author", author, "--json", "number,title",
+		}
+		cmd := exec.Command("gh", args...)
+		cmd.Dir = r.checkoutDir()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", fmt.Errorf("failed searching for existing PRs by %s: %w\nOutput: %s",
+				author, err, string(out))
+		}
 
-	var prs []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-	}
-	if err := json.Unmarshal(out, &prs); err != nil {
-		return "", fmt.Errorf("failed to parse PR search result: %w\nOutput: %s", err, string(out))
-	}
+		var prs []struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+		}
+		if err := json.Unmarshal(out, &prs); err != nil {
+			return "", fmt.Errorf("failed to parse PR search result: %w\nOutput: %s", err, string(out))
+		}
 
-	if len(prs) == 0 {
-		return "", nil
+		if len(prs) > 0 {
+			return fmt.Sprintf("#%d: %s (author: %s)", prs[0].Number, prs[0].Title, author), nil
+		}
 	}
-
-	return fmt.Sprintf("#%d: %s", prs[0].Number, prs[0].Title), nil
+	return "", nil
 }
 
 func (r prRepo) push() error {
@@ -291,11 +338,16 @@ func updateVersions(_ *cobra.Command, _ []string) error {
 	log.Printf("repos to work on: %s\n", reposToWorkOn)
 	var prs []string
 	var workOnRepoErrors []error
-	for _, repo := range reposToWorkOn {
-		err := workOnRepo(repo)
-		repo.workOnRepoError = err
-		if repo.workOnRepoError != nil {
-			err = fmt.Errorf("workOnRepo: error occurred while working on repo %s: %w", repo.name(), err)
+	// Index iteration is required: prRepo is a value type, so a `for _, repo
+	// := range reposToWorkOn` loop binds repo to a copy and the workOnRepoError
+	// assignment below would never reach the slice element — silently turning
+	// the second loop's skip check into dead code and letting failed repos
+	// proceed to push() and createPullRequest().
+	for i := range reposToWorkOn {
+		err := workOnRepo(reposToWorkOn[i])
+		reposToWorkOn[i].workOnRepoError = err
+		if err != nil {
+			err = fmt.Errorf("workOnRepo: error occurred while working on repo %s: %w", reposToWorkOn[i].name(), err)
 			workOnRepoErrors = append(workOnRepoErrors, err)
 			log.Printf("%s", err)
 		}
@@ -411,12 +463,36 @@ func randomString(n int) string {
 	return string(s)
 }
 
+// parseRepoFlag splits an `owner/name` string into its two parts and
+// validates both halves are non-empty. The single-string form is what
+// the --cockroach-repo flag accepts (matching `gh repo` argument shape).
+func parseRepoFlag(s string) (owner, name string, err error) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("expected owner/name, got %q", s)
+	}
+	return parts[0], parts[1], nil
+}
+
 func generateRepoList(
 	releasedVersion version.Version, nextVersion version.Version, isLatest bool, dryRun bool,
 ) ([]prRepo, error) {
-	owner := "cockroachdb"
+	cockroachOwner, cockroachRepoName, err := parseRepoFlag(updateVersionsFlags.cockroachRepo)
+	if err != nil {
+		return nil, fmt.Errorf("parsing --%s: %w", cockroachRepoFlag, err)
+	}
+	// Satellite repos (homebrew-tap, helm-charts) inherit the owner from
+	// --cockroach-repo and keep their well-known names. Dry-run mirrors
+	// the historical convention of pushing into a `crltest`-owned set
+	// of fork-prefixed repos, but only on the canonical prod release
+	// repo (signalled by IS_PRODUCTION_REPO=true) — on a fork or local
+	// invocation, dry-run pushes to whatever --cockroach-repo points at
+	// (the operator's explicit choice). Triggering on
+	// isProductionRepo() rather than a hardcoded literal means the
+	// canonical repo can be renamed without code changes here.
+	owner := cockroachOwner
 	prefix := ""
-	if dryRun {
+	if dryRun && isProductionRepo() {
 		// For test/dry-run purposes, we need to create "base repos" and "forked repos". The PRs will be submitted against the
 		// base repos and the branches will be created in the forked repos.
 		// for repo in cockroach, homebrew-tap, helm-charts; do
@@ -425,6 +501,8 @@ func generateRepoList(
 		//   # fork the repo to crltest-$repo
 		// done
 		owner = "crltest"
+		cockroachOwner = "crltest"
+		cockroachRepoName = "cockroach"
 		prefix = "crltest-"
 	}
 	// Repos we want to create PRs against
@@ -484,11 +562,11 @@ func generateRepoList(
 			commitMessagePrefix = branch
 		}
 		repo := prRepo{
-			owner:          owner,
-			repo:           prefix + "cockroach",
+			owner:          cockroachOwner,
+			repo:           cockroachRepoName,
 			branch:         branch,
 			prBranch:       prBranch,
-			githubUsername: "cockroach-teamcity",
+			githubUsername: updateVersionsFlags.githubUsername,
 			commitMessage:  generateCommitMessage(commitMessagePrefix, releasedVersion, nextVersion),
 			fn: func(gitDir string) error {
 				contents := []byte(nextVersion.String() + "\n")
@@ -513,7 +591,7 @@ func generateRepoList(
 			repo:           prefix + "homebrew-tap",
 			pushToOrigin:   true,
 			branch:         "master",
-			githubUsername: "cockroach-teamcity",
+			githubUsername: updateVersionsFlags.githubUsername,
 			prBranch:       fmt.Sprintf("update-versions-%s-%s", releasedVersion.String(), randomString(4)),
 			commitMessage:  fmt.Sprintf("release: advance to %s", releasedVersion.String()),
 			fn: func(gitDir string) error {
@@ -532,7 +610,7 @@ func generateRepoList(
 			repo:           prefix + "helm-charts",
 			pushToOrigin:   true,
 			branch:         "master",
-			githubUsername: "cockroach-teamcity",
+			githubUsername: updateVersionsFlags.githubUsername,
 			prBranch:       fmt.Sprintf("update-versions-%s-%s", releasedVersion.String(), randomString(4)),
 			commitMessage:  fmt.Sprintf("release: advance to %s", releasedVersion.String()),
 			fn: func(gitDir string) error {
@@ -591,11 +669,11 @@ func generateRepoList(
 		commitMessage := generateCommitMessage(fmt.Sprintf("merge %s to %s", mergeBranch, baseBranch), releasedVersion, nextVersion)
 		commitMessage += "\nDocs: noop merge\n"
 		repo := prRepo{
-			owner:          owner,
-			repo:           prefix + "cockroach",
+			owner:          cockroachOwner,
+			repo:           cockroachRepoName,
 			branch:         baseBranch,
 			prBranch:       fmt.Sprintf("merge-%s-to-%s-%s", mergeBranch, baseBranch, randomString(4)),
-			githubUsername: "cockroach-teamcity",
+			githubUsername: updateVersionsFlags.githubUsername,
 			commitMessage:  commitMessage,
 			fn: func(gitDir string) error {
 				cmd := exec.Command("git", "merge", "-s", "ours", "--no-commit", remoteOrigin+"/"+mergeBranch)
@@ -646,11 +724,11 @@ func generateRepoList(
 			continue
 		}
 		repo := prRepo{
-			owner:          owner,
-			repo:           prefix + "cockroach",
+			owner:          cockroachOwner,
+			repo:           cockroachRepoName,
 			branch:         nextRCBranch,
 			prBranch:       fmt.Sprintf("merge-%s-to-%s-%s", mergeBranch, nextRCBranch, randomString(4)),
-			githubUsername: "cockroach-teamcity",
+			githubUsername: updateVersionsFlags.githubUsername,
 			commitMessage:  generateCommitMessage(fmt.Sprintf("merge %s to %s", mergeBranch, nextRCBranch), releasedVersion, nextVersion),
 			fn: func(gitDir string) error {
 				cmd := exec.Command("git", "merge", "-X", "ours", "--strategy=recursive", "--no-commit", "--no-ff", remoteOrigin+"/"+mergeBranch)


### PR DESCRIPTION
The staging branch \`release-25.4.11-rc\` was cut before the GHA migration
landed on \`release-25.4\`. Without these release-workflow files, the
v25.4.11 release can only be driven via TeamCity.

Cherry-picks all 9 commits from #170804 and #170919 (in order):
1. \`3d772334b14\` release: migrate release pipelines from TeamCity to GitHub Actions
2. \`4ef6b464dd1\` build,release: forward IS_PRODUCTION_REPO into the release binary
3. \`ebf3c671677\` release: fix two prod release-workflow bugs
4. \`9c518942bff\` release: bump release-notes API client timeout to 2 minutes
5. \`fc436bb4d4a\` release: fix two more prod release-workflow auth bugs
6. \`96ad4249f60\` release/sentry: use 'gcloud storage cp' to download artifact
7. \`506f65ba50d\` release: follow-ups to the pick-sha + cloud-rollout flow
8. \`e9d42ab5844\` release: route build/publish notify to #release-ops by ID-vs-name
9. \`e20c85e1c13\` release: switch release-workflow runners to ubuntu_2004

All are already on \`release-25.4\`; this just brings the staging branch up to par.

Release justification: bring v25.4.11-rc into parity with release-25.4 so the release can be driven via GitHub Actions.

Epic: none
Release note: None