### PR TITLE
release-26.1: rttanalysis: update benchmark expectations to address test flakes

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -35,11 +35,11 @@ exp,benchmark
 14,"Discard/DISCARD_ALL,_1_tables_in_1_db"
 19,"Discard/DISCARD_ALL,_2_tables_in_2_dbs"
 0,"Discard/DISCARD_ALL,_no_tables"
-15,DropDatabase/drop_database_0_tables
+15-17,DropDatabase/drop_database_0_tables
 16,DropDatabase/drop_database_1_table
 16,DropDatabase/drop_database_2_tables
 16,DropDatabase/drop_database_3_tables
-19-21,DropRole/drop_1_role
+19-22,DropRole/drop_1_role
 28-30,DropRole/drop_2_roles
 37-39,DropRole/drop_3_roles
 13,DropSequence/drop_1_sequence


### PR DESCRIPTION
Backport 1/1 commits from #168286.

/cc @cockroachdb/release

Fixes: #170784.

---

Update the expected RTT values for DropRole and DropDatabase to address test flakes.

Fixes: #167694
Fixes: #167266
Epic: none

Release note: None

Release justification: Test-only change.
