### PR TITLE
roachtest: blocklist django test that's not PG18 compatible

### DIFF
--- a/pkg/cmd/roachtest/tests/django_blocklist.go
+++ b/pkg/cmd/roachtest/tests/django_blocklist.go
@@ -158,6 +158,7 @@ var enabledDjangoTests = []string{
 
 // Maintain that this list is alphabetized.
 var djangoBlocklist = blocklist{
+	`introspection.tests.IntrospectionTests.test_get_constraints`:      "django 4.1.x does not expect synthesized NOT NULL rows in pg_constraint; see #170036",
 	`schema.tests.SchemaTests.test_alter_text_field_to_date_field`:     "alter type requires USING",
 	`schema.tests.SchemaTests.test_alter_text_field_to_datetime_field`: "alter type requires USING",
 	`schema.tests.SchemaTests.test_alter_text_field_to_time_field`:     "alter type requires USING",


### PR DESCRIPTION
The `django-cockroachdb` adapter needs to be updated
to support this column added in PG18. Until then, the
test can be blocked.

Epic: none
Part of: #170036

Release note: None
