### PR TITLE
server: fix TestStatusAPICombinedStatementsWithFullScans flake

### DIFF
--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -691,10 +691,15 @@ func TestStatusAPICombinedStatementsWithFullScans(t *testing.T) {
 	}
 	skip.UnderRace(t, "test is too slow to run under race")
 
+	settings := cluster.MakeTestingClusterSettings()
+	persistedsqlstats.SQLStatsFlushEnabled.Override(
+		context.Background(), &settings.SV, false,
+	)
 	statsKnobs := sqlstats.CreateTestingKnobs()
 	statsKnobs.SynchronousSQLStats = true
 	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			Settings: settings,
 			Knobs: base.TestingKnobs{
 				SQLStatsKnobs: statsKnobs,
 				SpanConfig: &spanconfig.TestingKnobs{


### PR DESCRIPTION
Disable background SQL stats flushing in
TestStatusAPICombinedStatementsWithFullScans to prevent a race where the combined statements endpoint selects the persisted table (which only contains phase-1 data) and never falls through to the combined view where newly executed in-memory statements would be visible.

This matches the pattern used by other tests in the file that interact with the combined statements endpoint (e.g.
TestCombinedStatementUsesCorrectSourceTable).

Fixes #170845

Epic: none
Release note: None