### PR TITLE
release-26.1.5-rc: cherry-pick remaining release-workflow fixes

### DIFF
--- a/pkg/cmd/release/release_notes_api.go
+++ b/pkg/cmd/release/release_notes_api.go
@@ -73,7 +73,10 @@ func postReleaseNotes(url, apiKey string, p releaseNotesPayload) (releaseNotesRe
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-API-Key", apiKey)
-	client := httputil.NewClientWithTimeout(30 * time.Second)
+	// The endpoint is a Cloud Function that synthesizes a release-notes
+	// draft; cold starts plus the docs work itself can easily exceed
+	// 30s, so allow a couple of minutes before giving up.
+	client := httputil.NewClientWithTimeout(2 * time.Minute)
 	resp, err := client.Do(req)
 	if err != nil {
 		return releaseNotesResponse{}, errors.Wrap(err, "posting to release-notes API")

--- a/pkg/cmd/release/sentry/main.go
+++ b/pkg/cmd/release/sentry/main.go
@@ -225,10 +225,16 @@ func main() {
 	}
 	artifactName := fmt.Sprintf("cockroach-%s.%s.tgz", version, platform)
 	log.Printf("Downloading artifact: %s", artifactName)
-	gsutilCmd := exec.Command("gsutil", "cp",
+	// Use `gcloud storage cp` rather than `gsutil cp`: under Workload
+	// Identity Federation, gsutil does not honor the credentials file
+	// google-github-actions/auth writes and silently falls back to the
+	// runner VM's metadata service account.
+	downloadCmd := exec.Command("gcloud", "storage", "cp",
 		fmt.Sprintf("gs://cockroach-release-artifacts-staged-prod/%s", artifactName),
 		"./")
-	if err := gsutilCmd.Run(); err != nil {
+	downloadCmd.Stdout = os.Stdout
+	downloadCmd.Stderr = os.Stderr
+	if err := downloadCmd.Run(); err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("Downloaded artifact: %s", artifactName)


### PR DESCRIPTION
Follow-up to #171027. Two release-workflow commits between the staging
branch cut and \`release-26.1\` were missed in that PR because I scoped
the "missing commits" search too narrowly. Re-running the search across
\`pkg/cmd/release/\` surfaces these:

1. \`8649c7be923\` release: bump release-notes API client timeout to 2 minutes (#170670)
2. \`5b45be2238f\` release/sentry: use 'gcloud storage cp' to download artifact (#170727)

The sentry one is what's currently failing the v26.1.5 build's
"Generate Sentry panic" step
(https://github.com/cockroachdb/cockroach/actions/runs/26531710689/job/78151955478):
under Workload Identity Federation \`gsutil\` doesn't honor the
credentials file and the artifact download silently exits 1.

The timeout bump is preventive — the release-notes API call has been
seen to take longer than the existing 30s ceiling.

Both are already on \`release-26.1\`.

Release justification: unblock the v26.1.5 release.

Epic: none
Release note: None