### PR TITLE
sql/schemachanger: route CREATE TABLE through the DSC dispatcher

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "create_policy.go",
         "create_schema.go",
         "create_sequence.go",
+        "create_table.go",
         "create_trigger.go",
         "database_zone_config.go",
         "dependencies.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_table.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+)
+
+// createTableChecks is the cheap prefilter that decides whether CREATE TABLE
+// should be handled by the declarative schema changer. The dispatcher in
+// process.go calls it before resolving any descriptors, and a return of false
+// routes the statement back to the legacy schema changer.
+func createTableChecks(
+	n *tree.CreateTable,
+	mode sessiondatapb.NewSchemaChangerMode,
+	activeVersion clusterversion.ClusterVersion,
+) bool {
+	return false
+}
+
+// CreateTable implements CREATE TABLE in the declarative schema changer.
+// Unsupported statements panic NotImplementedError; the panic is recovered in
+// schema_change_plan_node.go and routed to the legacy planner.
+func CreateTable(b BuildCtx, n *tree.CreateTable) {
+	panic(scerrors.NotImplementedErrorf(n,
+		"create table is not yet supported in the declarative schema changer"))
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -65,6 +65,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.CreateRoutine)(nil)):       {fn: CreateFunction, statementTags: []string{tree.CreateFunctionTag, tree.CreateProcedureTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateSchema)(nil)):        {fn: CreateSchema, statementTags: []string{tree.CreateSchemaTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateSequence)(nil)):      {fn: CreateSequence, statementTags: []string{tree.CreateSequenceTag}, on: true, checks: nil},
+	reflect.TypeOf((*tree.CreateTable)(nil)):         {fn: CreateTable, statementTags: []string{tree.CreateTableTag}, on: true, checks: createTableChecks},
 	reflect.TypeOf((*tree.CreateTrigger)(nil)):       {fn: CreateTrigger, statementTags: []string{tree.CreateTriggerTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.DropDatabase)(nil)):        {fn: DropDatabase, statementTags: []string{tree.DropDatabaseTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.DropRoutine)(nil)):         {fn: DropFunction, statementTags: []string{tree.DropFunctionTag, tree.DropProcedureTag}, on: true, checks: nil},

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_create
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_create
@@ -29,3 +29,19 @@ CREATE TABLE t (i INT PRIMARY KEY) WITH (schema_locked = t);
 unimplemented
 CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT, FAMILY "primary" (i, j), FAMILY "secondary" (k));
 ----
+
+unimplemented
+CREATE TABLE IF NOT EXISTS t (i INT PRIMARY KEY);
+----
+
+unimplemented
+CREATE TEMPORARY TABLE t (i INT PRIMARY KEY);
+----
+
+unimplemented
+CREATE UNLOGGED TABLE t (i INT PRIMARY KEY);
+----
+
+unimplemented
+CREATE TABLE t AS SELECT 1 AS i;
+----

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -100,6 +100,7 @@ const (
 	CreateTriggerTag       = "CREATE TRIGGER"
 	CreateSchemaTag        = "CREATE SCHEMA"
 	CreateSequenceTag      = "CREATE SEQUENCE"
+	CreateTableTag         = "CREATE TABLE"
 	CreateDatabaseTag      = "CREATE DATABASE"
 	CreatePolicyTag        = "CREATE POLICY"
 	CommentOnColumnTag     = "COMMENT ON COLUMN"


### PR DESCRIPTION
Previously CREATE TABLE never reached the declarative schema changer because there was no entry for it in supportedStatements. Every statement went straight to the legacy schema changer.

This change wires CREATE TABLE into the DSC dispatcher behind a createTableChecks prefilter that, for now, rejects every statement and so still routes everything to the legacy path. The builder body also panics NotImplementedError as defense-in-depth in case a future change widens the prefilter without landing real logic. A matching CreateTableTag constant is added to pkg/sql/sem/tree alongside the other DDL tags.

Informs #98316

Release note: None
Epic: CRDB-25312
