### PR TITLE
roachtest: split mixed-version issue routing by phase

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -121,6 +121,15 @@ func failuresAsErrorWithOwnership(failures []failure) *registry.ErrorWithOwnersh
 	return nil
 }
 
+func failuresAsIssueTitleOverride(failures []failure) *registry.IssueTitleOverride {
+	var issueTitleOverride registry.IssueTitleOverride
+	if failuresMatchingError(failures, &issueTitleOverride) {
+		return &issueTitleOverride
+	}
+
+	return nil
+}
+
 func failuresAsNonReportableError(failures []failure) *registry.NonReportableError {
 	var nonReportable registry.NonReportableError
 	if failuresMatchingError(failures, &nonReportable) {
@@ -216,6 +225,14 @@ func (g *githubIssues) createPostRequest(
 		infraFlake    bool
 	)
 
+	overrideIssueName := func(title string) {
+		if title == "" {
+			return
+		}
+		issueName = title
+		messagePrefix = fmt.Sprintf("test %s failed: ", testName)
+	}
+
 	// handleErrorWithOwnership updates the local variables in this
 	// function that contain the name of the issue being created,
 	// message prefix, and team that will own it.
@@ -224,8 +241,7 @@ func (g *githubIssues) createPostRequest(
 		infraFlake = err.InfraFlake
 
 		if err.TitleOverride != "" {
-			issueName = err.TitleOverride
-			messagePrefix = fmt.Sprintf("test %s failed: ", testName)
+			overrideIssueName(err.TitleOverride)
 		}
 	}
 
@@ -239,6 +255,11 @@ func (g *githubIssues) createPostRequest(
 	}
 	if errWithOwner != nil {
 		handleErrorWithOwnership(*errWithOwner)
+	}
+	if issueName == testName {
+		if titleOverride := failuresAsIssueTitleOverride(failures); titleOverride != nil {
+			overrideIssueName(titleOverride.TitleOverride)
+		}
 	}
 
 	// Issues posted from roachtest are identifiable as such, and they are also release blockers

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -97,6 +97,92 @@ func TestShouldPost(t *testing.T) {
 	}
 }
 
+func TestCreatePostRequestIssueTitleOverride(t *testing.T) {
+	reg := makeTestRegistry()
+	testSpec := &registry.TestSpec{
+		Name:    "multi-region/mixed-version",
+		Owner:   OwnerUnitTest,
+		Cluster: reg.MakeClusterSpec(1),
+	}
+
+	const titleOverride = "multi-region/mixed-version/on-startup/setup-tpcc"
+	github := &githubIssues{teamLoader: validTeamsFn}
+	baseErr := errors.New("oops")
+
+	for _, tc := range []struct {
+		name             string
+		refErr           error
+		expectedTestName string
+		expectedLabels   []string
+	}{
+		{
+			name:             "title override only",
+			refErr:           registry.ErrorWithIssueTitleOverride(baseErr, titleOverride),
+			expectedTestName: titleOverride,
+		},
+		{
+			name: "title override composes with owner",
+			refErr: registry.ErrorWithIssueTitleOverride(
+				registry.ErrorWithOwner(registry.OwnerSQLFoundations, baseErr),
+				titleOverride,
+			),
+			expectedTestName: titleOverride,
+			expectedLabels:   []string{"T-sql-foundations"},
+		},
+		{
+			name: "owner title takes precedence",
+			refErr: registry.ErrorWithIssueTitleOverride(
+				registry.ErrorWithOwner(
+					registry.OwnerSQLFoundations, baseErr,
+					registry.WithTitleOverride("schema_change_workload_failure"),
+				),
+				titleOverride,
+			),
+			expectedTestName: "schema_change_workload_failure",
+			expectedLabels:   []string{"T-sql-foundations"},
+		},
+		{
+			name: "typed transient title takes precedence",
+			refErr: registry.ErrorWithIssueTitleOverride(
+				rperrors.TransientFailure(baseErr, "typed_transient_problem"),
+				titleOverride,
+			),
+			expectedTestName: "typed_transient_problem",
+			expectedLabels:   []string{"T-testeng", "X-infra-flake"},
+		},
+		{
+			name: "string transient fallback title takes precedence",
+			refErr: registry.ErrorWithIssueTitleOverride(
+				errors.New("Received unexpected error:\nTRANSIENT_ERROR(fallback_transient_problem)"),
+				titleOverride,
+			),
+			expectedTestName: "fallback_transient_problem",
+			expectedLabels:   []string{"T-testeng", "X-infra-flake"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := github.createPostRequest(
+				testSpec.Name,
+				time.Time{},
+				time.Time{},
+				testSpec,
+				[]failure{{squashedErr: tc.refErr}},
+				tc.refErr.Error(),
+				false, /* runtimeAssertionsBuild */
+				false, /* coverageBuild */
+				nil,   /* params */
+				&githubIssueInfo{},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedTestName, req.TestName)
+			require.Equal(t, fmt.Sprintf("test %s failed: %s", testSpec.Name, tc.refErr.Error()), req.Message)
+			for _, label := range tc.expectedLabels {
+				require.Contains(t, req.Labels, label)
+			}
+		})
+	}
+}
+
 func TestGenerateHelpCommand(t *testing.T) {
 	start := time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC)
 	end := time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC)

--- a/pkg/cmd/roachtest/registry/errors.go
+++ b/pkg/cmd/roachtest/registry/errors.go
@@ -23,6 +23,13 @@ type (
 		Err        error
 	}
 
+	IssueTitleOverride struct {
+		// TitleOverride allows errors to overwrite the "{testName}
+		// failed" title used in issues without changing issue ownership.
+		TitleOverride string
+		Err           error
+	}
+
 	NonReportableError struct {
 		Err error
 	}
@@ -44,6 +51,22 @@ func (ewo ErrorWithOwnership) Unwrap() error {
 
 func (ewo ErrorWithOwnership) As(reference interface{}) bool {
 	return errors.As(ewo.Err, reference)
+}
+
+func (ito IssueTitleOverride) Error() string {
+	return ito.Err.Error()
+}
+
+func (ito IssueTitleOverride) Is(target error) bool {
+	return errors.Is(ito.Err, target)
+}
+
+func (ito IssueTitleOverride) Unwrap() error {
+	return ito.Err
+}
+
+func (ito IssueTitleOverride) As(reference interface{}) bool {
+	return errors.As(ito.Err, reference)
 }
 
 func WithTitleOverride(title string) errorOption {
@@ -83,6 +106,12 @@ func ErrorWithOwner(owner Owner, err error, opts ...errorOption) ErrorWithOwners
 	}
 
 	return result
+}
+
+// ErrorWithIssueTitleOverride associates err with a GitHub issue title override
+// without changing the issue owner.
+func ErrorWithIssueTitleOverride(err error, title string) IssueTitleOverride {
+	return IssueTitleOverride{Err: err, TitleOverride: title}
 }
 
 // NonReportable wraps the given error and makes it non-reportable --

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -36,6 +36,11 @@ import (
 )
 
 type (
+	issueTitleComponentError struct {
+		component string
+		err       error
+	}
+
 	serviceRuntime struct {
 		descriptor      *ServiceDescriptor
 		binaryVersions  *atomic.Value
@@ -51,6 +56,7 @@ type (
 		ctx           context.Context
 		cancel        context.CancelFunc
 		plan          *TestPlan
+		testName      string
 		tag           string
 		cluster       cluster.Cluster
 		systemService *serviceRuntime
@@ -70,6 +76,32 @@ type (
 		_addAnnotation func() error
 	}
 )
+
+func (e issueTitleComponentError) Error() string {
+	return e.err.Error()
+}
+
+func (e issueTitleComponentError) Is(target error) bool {
+	return errors.Is(e.err, target)
+}
+
+func (e issueTitleComponentError) Unwrap() error {
+	return e.err
+}
+
+func (e issueTitleComponentError) As(reference interface{}) bool {
+	return errors.As(e.err, reference)
+}
+
+// ErrorWithIssueTitleComponent appends component to the mixed-version issue
+// title generated when err fails a test step. Use this when a hook can
+// identify a root-cause bucket that is more specific than the hook name.
+func ErrorWithIssueTitleComponent(err error, component string) error {
+	if err == nil {
+		return nil
+	}
+	return issueTitleComponentError{err: err, component: component}
+}
 
 var (
 	// everything that is not an alphanum or a few special characters
@@ -123,6 +155,7 @@ func newTestRunner(
 		ctx:           ctx,
 		cancel:        cancel,
 		plan:          plan,
+		testName:      rt.Name(),
 		tag:           tag,
 		logger:        l,
 		systemService: systemService,
@@ -318,7 +351,59 @@ func (tr *testRunner) stepError(
 		step.ID, step.impl.Description(false),
 	)
 
-	return tr.testFailure(ctx, stepErr, l, &step.context)
+	failureErr := tr.testFailure(ctx, stepErr, l, &step.context)
+	if title := tr.failureIssueTitle(step, err); title != "" {
+		failureErr = registry.ErrorWithIssueTitleOverride(failureErr, title)
+	}
+	return failureErr
+}
+
+func (tr *testRunner) failureIssueTitle(step *singleStep, err error) string {
+	if tr.testName == "" {
+		return ""
+	}
+
+	parts := []string{tr.testName}
+	if stage := step.context.DefaultService().Stage.String(); stage != "" {
+		parts = append(parts, stage)
+	}
+	if stepTitle := stepIssueTitleComponent(step); stepTitle != "" {
+		parts = append(parts, stepTitle)
+	}
+	if failureTitle := failureIssueTitleComponent(err); failureTitle != "" {
+		parts = append(parts, failureTitle)
+	}
+	return strings.Join(parts, "/")
+}
+
+func stepIssueTitleComponent(step *singleStep) string {
+	if hookStep, ok := step.impl.(runHookStep); ok && hookStep.hook.name != "" {
+		return issueTitleComponent(hookStep.hook.name)
+	}
+	return issueTitleComponent(step.impl.Description(false))
+}
+
+func failureIssueTitleComponent(err error) string {
+	var component issueTitleComponentError
+	if errors.As(err, &component) {
+		return issueTitleComponent(component.component)
+	}
+	return ""
+}
+
+func issueTitleComponent(s string) string {
+	var b strings.Builder
+	lastWasSeparator := true
+	for _, r := range strings.ToLower(s) {
+		if ('a' <= r && r <= 'z') || ('0' <= r && r <= '9') {
+			b.WriteRune(r)
+			lastWasSeparator = false
+		} else if !lastWasSeparator {
+			b.WriteByte('-')
+			lastWasSeparator = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // testFailure generates a `testFailure` for failures that happened

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -60,6 +60,29 @@ func Test_runSingleStep(t *testing.T) {
 	require.Contains(t, err.Error(), "panic (stack trace above): runtime error: index out of range [0] with length 0")
 }
 
+func Test_failureIssueTitle(t *testing.T) {
+	tr := testTestRunner()
+	tr.testName = "multi-region/mixed-version"
+
+	initialVersion := clusterupgrade.MustParseVersion(predecessorVersion)
+	testContext := newInitialContext(initialVersion, nodes, nil)
+	testContext.System.Stage = OnStartupStage
+	step := newSingleStep(
+		testContext,
+		runHookStep{hook: versionUpgradeHook{name: "setup TPCC"}},
+		newRand(),
+	)
+
+	require.Equal(
+		t,
+		"multi-region/mixed-version/on-startup/setup-tpcc/replica-gc-threshold",
+		tr.failureIssueTitle(
+			step,
+			ErrorWithIssueTitleComponent(errors.New("oops"), "replica GC threshold"),
+		),
+	)
+}
+
 // Test_run verifies that the test runner's `run` function is able to
 // appropriately change ownership to Test Eng when no user provided
 // functions have run at the time the failure happened.
@@ -157,6 +180,7 @@ func testTestRunner() *testRunner {
 		cancel:         cancel,
 		logger:         nilLogger,
 		systemService:  newServiceRuntime(systemDescriptor),
+		testName:       "mixed-version-test",
 		background:     task.NewManager(runnerCtx, nilLogger),
 		ranUserHooks:   &ranUserHooks,
 		plan:           &TestPlan{seed: seed},

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -153,55 +153,80 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 					),
 				}
 				if dbListType == inactiveDbListType {
-					options.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					options.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) error {
+						return nil
 					}
 				} else {
-					options.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					options.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) error {
 						settings := install.MakeClusterSettings()
 						startOpts := option.DefaultStartOpts()
 						startOpts.RoachprodOpts.ScheduleBackups = false
-						c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
-						conn := c.Conn(ctx, t.L(), 1)
+						if err := c.StartE(ctx, t.L(), startOpts, settings, c.CRDBNodes()); err != nil {
+							return err
+						}
+						conn, err := c.ConnE(ctx, t.L(), 1)
+						if err != nil {
+							return err
+						}
 						defer conn.Close()
 						// Disable autocommit before DDL since we need to batch statements
 						// in a single transaction for them to complete in a reasonable amount
 						// of time. In multi-region this latency can be substantial.
-						_, err := conn.Exec("SET CLUSTER SETTING sql.defaults.autocommit_before_ddl.enabled = 'false'")
-						require.NoError(t, err)
+						_, err = conn.Exec("SET CLUSTER SETTING sql.defaults.autocommit_before_ddl.enabled = 'false'")
+						if err != nil {
+							return errors.Wrap(err, "setting sql.defaults.autocommit_before_ddl.enabled")
+						}
 						// Allow optimizations to use leased descriptors when querying
 						// pg_catalog and information_schema.
 						_, err = conn.Exec("SET CLUSTER SETTING sql.catalog.allow_leased_descriptors.enabled = 'true'")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "setting sql.catalog.allow_leased_descriptors.enabled")
+						}
 						// Enabled locked descriptor leasing for correctness.
 						_, err = conn.Exec("SET CLUSTER SETTING sql.catalog.descriptor_lease.use_locked_timestamps.enabled = 'true'")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "setting sql.catalog.descriptor_lease.use_locked_timestamps.enabled")
+						}
 						// Since we will be making a large number of databases / tables
 						// quickly,on MR the job retention can slow things down. Let's
 						// minimize how long jobs are kept, so that the creation / ingest
 						// completes in a reasonable amount of time.
 						_, err = conn.Exec("SET CLUSTER SETTING jobs.retention_time='1h'")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "setting jobs.retention_time")
+						}
 						// Use a higher number of retries, since we hit retry errors on importing
 						// a large number of tables
 						_, err = conn.Exec("SET CLUSTER SETTING kv.transaction.internal.max_auto_retries=500")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "setting kv.transaction.internal.max_auto_retries")
+						}
 						// Disable the schema object count limit to allow creating 40,000+
 						// tables. This is a guardrail that prevents unbounded growth of the
 						// descriptor table, but for this benchmark we intentionally want to
 						// test with a large number of tables.
 						_, err = conn.Exec("SET CLUSTER SETTING sql.schema.approx_max_object_count = 0")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "setting sql.schema.approx_max_object_count")
+						}
 						// Disable the automatic INSPECT job that runs after each
 						// IMPORT. With high-concurrency imports of many tables, the
 						// INSPECT jobs exhaust the memory budget.
 						_, err = conn.Exec("SET CLUSTER SETTING bulkio.import.row_count_validation.mode = 'off'")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "setting bulkio.import.row_count_validation.mode")
+						}
 						// Create a user that will be used for authentication for the REST
 						// API calls.
 						_, err = conn.Exec("CREATE USER roachadmin password 'roacher'")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "creating roachadmin user")
+						}
 						_, err = conn.Exec("GRANT ADMIN to roachadmin")
-						require.NoError(t, err)
+						if err != nil {
+							return errors.Wrap(err, "granting admin to roachadmin")
+						}
+						return nil
 					}
 				}
 				err := c.PutString(ctx, strings.Join(dbList, "\n"), populateFileName, 0755, c.WorkloadNode())
@@ -449,8 +474,9 @@ func runLargeSchemaIntrospectionBenchmark(
 		),
 		// Use all CRDB nodes for init to distribute table creation load.
 		InitNodes: c.CRDBNodes(),
-		Start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		Start: func(ctx context.Context, t test.Test, c cluster.Cluster) error {
 			// Cluster is already started, this is a no-op.
+			return nil
 		},
 	}
 	setupTPCC(ctx, t, t.L(), c, options)

--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -149,24 +149,21 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 					l.Printf("waiting for setup to finish")
 					<-backgroundTPCCSetupDone
 
-					runTPCC(ctx, t, l, c, backgroundTPCCOpts)
-					return nil
+					return runTPCCE(ctx, t, l, c, backgroundTPCCOpts)
 				},
 			)
 
 			mvt.InMixedVersion(
 				"run tpcc",
 				func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-					runTPCC(ctx, t, l, c, mixedVersionTPCCOpts)
-					return nil
+					return runTPCCE(ctx, t, l, c, mixedVersionTPCCOpts)
 				},
 			)
 
 			mvt.AfterUpgradeFinalized(
 				"run tpcc",
 				func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-					runTPCC(ctx, t, l, c, mixedVersionTPCCOpts)
-					return nil
+					return runTPCCE(ctx, t, l, c, mixedVersionTPCCOpts)
 				},
 			)
 

--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -94,7 +94,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 				ExtraSetupArgs:         partitionConfig,
 				ExtraRunArgs:           "--tolerate-errors " + partitionConfig,
 				ExpectedDeaths:         10000, // we don't want the internal monitor to fail
-				Start:                  func(_ context.Context, t test.Test, c cluster.Cluster) {},
+				Start:                  func(_ context.Context, t test.Test, c cluster.Cluster) error { return nil },
 				SetupType:              usingInit,
 				SkipPostRunCheck:       true,
 				DisablePrometheus:      true,
@@ -106,7 +106,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 				Warehouses:             len(regions) * mixedVersionWarehousesPerRegion,
 				ExtraSetupArgs:         partitionConfig,
 				ExtraRunArgs:           partitionConfig,
-				Start:                  func(_ context.Context, t test.Test, c cluster.Cluster) {},
+				Start:                  func(_ context.Context, t test.Test, c cluster.Cluster) error { return nil },
 				SetupType:              usingInit,
 				Duration:               10 * time.Minute,
 				ExpensiveChecks:        true,
@@ -120,19 +120,23 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 				"setup tpcc",
 				func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
 					if err := enableTenantSplitScatter(l, rng, h); err != nil {
-						return err
+						return mixedversion.ErrorWithIssueTitleComponent(err, "enable tenant split scatter")
 					}
 					if err := enableTenantMultiRegion(l, rng, h); err != nil {
-						return err
+						return mixedversion.ErrorWithIssueTitleComponent(err, "enable tenant multi-region")
 					}
 
-					setupTPCC(ctx, t, l, c, backgroundTPCCOpts)
+					if err := setupTPCCE(ctx, t, l, c, backgroundTPCCOpts); err != nil {
+						return mixedversion.ErrorWithIssueTitleComponent(err, "setup background TPCC")
+					}
 					// Update the `SetupType` so that the corresponding
 					// `runTPCC` calls don't attempt to import data again.
 					backgroundTPCCOpts.SetupType = usingExistingData
 					close(backgroundTPCCSetupDone)
 
-					setupTPCC(ctx, t, l, c, mixedVersionTPCCOpts)
+					if err := setupTPCCE(ctx, t, l, c, mixedVersionTPCCOpts); err != nil {
+						return mixedversion.ErrorWithIssueTitleComponent(err, "setup mixed-version TPCC")
+					}
 					mixedVersionTPCCOpts.SetupType = usingExistingData
 
 					return nil

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -228,7 +228,7 @@ type tpccOptions struct {
 	// If specified, called to stage+start cockroach. If not
 	// specified, defaults to uploading the default binary to
 	// all nodes, and starting it on all but the last node.
-	Start func(context.Context, test.Test, cluster.Cluster)
+	Start func(context.Context, test.Test, cluster.Cluster) error
 	// If specified, assigned to StartOpts.ExtraArgs when starting cockroach.
 	ExtraStartArgs                []string
 	DisableDefaultScheduledBackup bool
@@ -301,9 +301,15 @@ func tpccImportCmdWithCockroachBinary(
 func setupTPCC(
 	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, opts tpccOptions,
 ) {
+	require.NoError(t, setupTPCCE(ctx, t, l, c, opts))
+}
+
+func setupTPCCE(
+	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, opts tpccOptions,
+) error {
 	// If setup should be skipped, then nothing to o here.
 	if opts.SkipSetup {
-		return
+		return nil
 	}
 
 	if c.IsLocal() {
@@ -311,7 +317,7 @@ func setupTPCC(
 	}
 
 	if opts.Start == nil {
-		opts.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		opts.Start = func(ctx context.Context, t test.Test, c cluster.Cluster) error {
 			settings := install.MakeClusterSettings()
 			if c.IsLocal() {
 				settings.Env = append(settings.Env, "COCKROACH_SCAN_INTERVAL=200ms")
@@ -320,55 +326,67 @@ func setupTPCC(
 			startOpts := option.DefaultStartOpts()
 			startOpts.RoachprodOpts.ExtraArgs = opts.ExtraStartArgs
 			startOpts.RoachprodOpts.ScheduleBackups = !opts.DisableDefaultScheduledBackup
-			c.Start(ctx, l, startOpts, settings, c.CRDBNodes())
+			return c.StartE(ctx, l, startOpts, settings, c.CRDBNodes())
 		}
 	}
 
-	func() {
-		opts.Start(ctx, t, c)
-		db := c.Conn(ctx, l, 1)
-		defer db.Close()
+	if err := opts.Start(ctx, t, c); err != nil {
+		return errors.Wrap(err, "starting TPCC cluster")
+	}
+	db, err := c.ConnE(ctx, l, 1)
+	if err != nil {
+		return errors.Wrap(err, "connecting to TPCC cluster")
+	}
+	defer db.Close()
 
-		if t.SkipInit() {
-			return
+	if t.SkipInit() {
+		return nil
+	}
+
+	if !opts.DisableIsolationLevels {
+		if err := enableIsolationLevels(ctx, t, db); err != nil {
+			return errors.Wrap(err, "enabling isolation levels")
 		}
+	}
 
-		if !opts.DisableIsolationLevels {
-			require.NoError(t, enableIsolationLevels(ctx, t, db))
+	if err := roachtestutil.WaitFor3XReplication(ctx, l, db); err != nil {
+		return errors.Wrap(err, "waiting for 3x replication")
+	}
+
+	estimatedSetupTimeStr := ""
+	if opts.EstimatedSetupTime != 0 {
+		estimatedSetupTimeStr = fmt.Sprintf(" (<%s)", opts.EstimatedSetupTime)
+	}
+
+	switch opts.SetupType {
+	case usingExistingData:
+		// Do nothing.
+	case usingImport:
+		t.Status("loading fixture" + estimatedSetupTimeStr)
+		if err := c.RunE(ctx, option.WithNodes(c.Node(1)), tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, opts.DB, opts.getWorkloadCmd(), opts.Warehouses, opts.ExtraSetupArgs, "{pgurl:1}")); err != nil {
+			return errors.Wrap(err, "importing TPCC fixture")
 		}
-
-		require.NoError(t, roachtestutil.WaitFor3XReplication(ctx, l, db))
-
-		estimatedSetupTimeStr := ""
-		if opts.EstimatedSetupTime != 0 {
-			estimatedSetupTimeStr = fmt.Sprintf(" (<%s)", opts.EstimatedSetupTime)
+	case usingInit:
+		l.Printf("initializing tables" + estimatedSetupTimeStr)
+		extraArgs := opts.ExtraSetupArgs
+		initNodes := opts.InitNodes
+		if len(initNodes) == 0 {
+			initNodes = c.Node(1)
 		}
+		cmd := roachtestutil.NewCommand("%s workload init %s", test.DefaultCockroachPath, opts.getWorkloadCmd()).
+			MaybeFlag(opts.DB != "", "db", opts.DB).
+			Flag("warehouses", opts.Warehouses).
+			Arg("%s", extraArgs).
+			Arg("{pgurl%s}", initNodes)
 
-		switch opts.SetupType {
-		case usingExistingData:
-			// Do nothing.
-		case usingImport:
-			t.Status("loading fixture" + estimatedSetupTimeStr)
-			c.Run(ctx, option.WithNodes(c.Node(1)), tpccImportCmdWithCockroachBinary(test.DefaultCockroachPath, opts.DB, opts.getWorkloadCmd(), opts.Warehouses, opts.ExtraSetupArgs, "{pgurl:1}"))
-		case usingInit:
-			l.Printf("initializing tables" + estimatedSetupTimeStr)
-			extraArgs := opts.ExtraSetupArgs
-			initNodes := opts.InitNodes
-			if len(initNodes) == 0 {
-				initNodes = c.Node(1)
-			}
-			cmd := roachtestutil.NewCommand("%s workload init %s", test.DefaultCockroachPath, opts.getWorkloadCmd()).
-				MaybeFlag(opts.DB != "", "db", opts.DB).
-				Flag("warehouses", opts.Warehouses).
-				Arg("%s", extraArgs).
-				Arg("{pgurl%s}", initNodes)
-
-			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd.String())
-		default:
-			t.Fatal("unknown tpcc setup type")
+		if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd.String()); err != nil {
+			return errors.Wrap(err, "initializing TPCC tables")
 		}
-		l.Printf("finished tpc-c setup")
-	}()
+	default:
+		return errors.New("unknown tpcc setup type")
+	}
+	l.Printf("finished tpc-c setup")
+	return nil
 }
 
 func collectTPCCProfiles(

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -273,6 +273,14 @@ type workloadInstance struct {
 
 const workloadPProfStartPort = 33333
 
+type tpccSkipError struct {
+	reason string
+}
+
+func (e tpccSkipError) Error() string {
+	return e.reason
+}
+
 // tpccImportCmd see tpccImportCmdWithCockroachBinary, this variant is set up to
 // invoke the default tpcc subcommand
 func tpccImportCmd(db string, warehouses int, extraArgs ...string) string {
@@ -301,7 +309,9 @@ func tpccImportCmdWithCockroachBinary(
 func setupTPCC(
 	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, opts tpccOptions,
 ) {
-	require.NoError(t, setupTPCCE(ctx, t, l, c, opts))
+	if err := setupTPCCE(ctx, t, l, c, opts); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func setupTPCCE(
@@ -472,6 +482,27 @@ func collectTPCCProfiles(
 func runTPCC(
 	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, opts tpccOptions,
 ) {
+	err := runTPCCE(ctx, t, l, c, opts)
+	var skipErr tpccSkipError
+	if errors.As(err, &skipErr) {
+		t.Skip(skipErr.reason)
+		return
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runTPCCE(
+	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, opts tpccOptions,
+) error {
+	wrap := func(err error, component string) error {
+		if err == nil {
+			return nil
+		}
+		return mixedversion.ErrorWithIssueTitleComponent(err, component)
+	}
+
 	workloadInstances := opts.WorkloadInstances
 	if len(workloadInstances) == 0 {
 		workloadInstances = append(
@@ -494,20 +525,23 @@ func runTPCC(
 		// during import itself is uninteresting and pollutes actual workload
 		// data.
 		var cleanupFunc func()
-		promCfg, cleanupFunc = setupPrometheusForRoachtest(ctx, t, c, opts.PrometheusConfig, workloadInstances)
+		var err error
+		promCfg, cleanupFunc, err = setupPrometheusForRoachtestE(ctx, t, c, opts.PrometheusConfig, workloadInstances)
+		if err != nil {
+			return wrap(errors.Wrap(err, "setting up prometheus"), "prometheus")
+		}
 		defer cleanupFunc()
 	}
 	if opts.ChaosEventsProcessor != nil {
 		if promCfg == nil {
-			t.Skip("skipping test as prometheus is needed, but prometheus does not yet work locally")
-			return
+			return tpccSkipError{"skipping test as prometheus is needed, but prometheus does not yet work locally"}
 		}
 		cep, err := opts.ChaosEventsProcessor(
 			c.Nodes(int(promCfg.PrometheusNode)),
 			workloadInstances,
 		)
 		if err != nil {
-			t.Fatal(err)
+			return wrap(errors.Wrap(err, "setting up TPCC chaos event processor"), "chaos-events")
 		}
 		cep.listen(ctx, t, l)
 		ep = &cep
@@ -519,7 +553,9 @@ func runTPCC(
 			opts.Duration = time.Minute
 		}
 	}
-	setupTPCC(ctx, t, l, c, opts)
+	if err := setupTPCCE(ctx, t, l, c, opts); err != nil {
+		return wrap(errors.Wrap(err, "setting up TPCC"), "setup")
+	}
 	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.ExpectDeaths(int32(opts.ExpectedDeaths))
 	rampDur := rampDuration(c.IsLocal())
@@ -565,17 +601,33 @@ func runTPCC(
 				return nil
 			}
 
-			return err
+			if err != nil {
+				return wrap(errors.Wrap(err, "running TPCC workload"), "workload-run")
+			}
+			return nil
 		})
 	}
 	if opts.Chaos != nil {
 		chaos := opts.Chaos()
-		m.Go(chaos.Runner(c, t, m))
+		chaosRunner := chaos.Runner(c, t, m)
+		m.Go(func(ctx context.Context) error {
+			if err := chaosRunner(ctx); err != nil {
+				return wrap(errors.Wrap(err, "running TPCC chaos events"), "chaos-events")
+			}
+			return nil
+		})
 	}
 	if opts.During != nil {
-		m.Go(opts.During)
+		m.Go(func(ctx context.Context) error {
+			if err := opts.During(ctx); err != nil {
+				return wrap(errors.Wrap(err, "running TPCC during hook"), "during")
+			}
+			return nil
+		})
 	}
-	m.Wait()
+	if err := m.WaitE(); err != nil {
+		return errors.Wrap(err, "running TPCC monitor")
+	}
 
 	if opts.CollectProfiles {
 		collectTPCCProfiles(ctx, t, c, opts, pgURLs)
@@ -589,15 +641,18 @@ func runTPCC(
 			Flag("warehouses", opts.Warehouses).
 			Arg("{pgurl:1}")
 
-		c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd.String())
+		if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd.String()); err != nil {
+			return wrap(errors.Wrap(err, "checking TPCC workload"), "post-run-check")
+		}
 	}
 
 	// Check no errors from metrics.
 	if ep != nil {
 		if err := ep.err(); err != nil {
-			t.Fatal(errors.Wrap(err, "error detected during DRT"))
+			return wrap(errors.Wrap(err, "error detected during DRT"), "drt-metrics")
 		}
 	}
+	return nil
 }
 
 // mergeAndExportTPCCProfiles accepts a map of individual profiles of each
@@ -2570,11 +2625,25 @@ func setupPrometheusForRoachtest(
 	promCfg *prometheus.Config,
 	workloadInstances []workloadInstance,
 ) (*prometheus.Config, func()) {
+	cfg, cleanup, err := setupPrometheusForRoachtestE(ctx, t, c, promCfg, workloadInstances)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg, cleanup
+}
+
+func setupPrometheusForRoachtestE(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	promCfg *prometheus.Config,
+	workloadInstances []workloadInstance,
+) (*prometheus.Config, func(), error) {
 	cfg := promCfg
 	if cfg == nil {
 		// Avoid setting prometheus automatically up for local clusters.
 		if c.IsLocal() {
-			return nil, func() {}
+			return nil, func() {}, nil
 		}
 		cfg = &prometheus.Config{}
 		workloadNode := c.WorkloadNode().InstallNodes()[0]
@@ -2588,17 +2657,17 @@ func setupPrometheusForRoachtest(
 	}
 	if c.IsLocal() {
 		t.Status("ignoring prometheus setup given --local was specified")
-		return nil, func() {}
+		return nil, func() {}, nil
 	}
 
 	t.Status(fmt.Sprintf("setting up prometheus/grafana (<%s)", 2*time.Minute))
 
 	quietLogger, err := t.L().ChildLogger("start-grafana", logger.QuietStdout, logger.QuietStderr)
 	if err != nil {
-		t.Fatal(err)
+		return nil, nil, err
 	}
 	if err := c.StartGrafana(ctx, quietLogger, cfg); err != nil {
-		t.Fatal(err)
+		return nil, nil, err
 	}
 	cleanupFunc := func() {
 		if t.IsDebug() {
@@ -2608,7 +2677,7 @@ func setupPrometheusForRoachtest(
 			t.L().ErrorfCtx(ctx, "error(s) shutting down prom/grafana: %s", err)
 		}
 	}
-	return cfg, cleanupFunc
+	return cfg, cleanupFunc, nil
 }
 
 func getTpccLabels(


### PR DESCRIPTION
Mixed-version roachtests currently group unrelated failures from broad tests
under one GitHub issue title. This is especially noisy for the multi-region
mixed-version TPCC test, where setup, runtime workload, chaos, and post-run
failures can all route to the same long-lived issue.

Add a title-only error wrapper and wire the mixed-version runner to build issue
titles from the test name, upgrade stage, step or hook name, and optional
component supplied by the test. The wrapper only affects title selection;
ownership and existing infra-flake title overrides continue to take precedence.
The multi-region TPCC setup hook uses this to split setup subphases into stable
buckets.

Add error-returning TPCC setup and run helpers and use them from the
mixed-version runtime hooks. The runner keeps the existing fatal wrappers for
current callers, but mixed-version hooks can now return errors tagged by coarse
TPCC phases such as setup, prometheus, workload-run, chaos-events, during,
post-run-check, and drt-metrics.

Tests:
`./dev test ./pkg/cmd/roachtest ./pkg/cmd/roachtest/roachtestutil/mixedversion ./pkg/cmd/roachtest/tests`

Epic: none
Informs: #121455
Release note: None
