### PR TITLE
release-26.2: allocator/mmaprototype: convert raft-cpu-exceeds-total panic to log

### DIFF
--- a/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/cluster_state_rebalance_stores.go
@@ -968,10 +968,15 @@ func (re *rebalanceEnv) rebalanceLeasesFromLocalStoreID(
 		// Only adding leaseholder CPU.
 		addedLoad[CPURate] = rstate.load.Load[CPURate] - rstate.load.RaftCPU
 		if addedLoad[CPURate] < 0 {
-			// TODO(sumeer): remove this panic once we are not in an
-			// experimental phase.
-			addedLoad[CPURate] = 0
-			panic("raft cpu higher than total cpu")
+			// Per the RangeLoad.RaftCPU invariant, this is unreachable: both
+			// fields are derived from a single atomic LoadStats snapshot in
+			// MakePhysicalRangeLoad. Log loudly and skip the range rather
+			// than panic if a future change breaks the invariant.
+			log.KvDistribution.Errorf(ctx,
+				"invariant violation: raft cpu %s exceeds total cpu %s for r%d",
+				time.Duration(rstate.load.RaftCPU), time.Duration(rstate.load.Load[CPURate]), rangeID)
+			re.passObs.leaseShed(ctx, rangeTransient)
+			continue
 		}
 		if !re.canShedAndAddLoad(ctx, ss, targetSS, rangeID, addedLoad, &means, true, CPURate, ml) {
 			re.passObs.leaseShed(ctx, noCandidateToAcceptLoad)

--- a/pkg/kv/kvserver/allocator/mmaprototype/load.go
+++ b/pkg/kv/kvserver/allocator/mmaprototype/load.go
@@ -222,14 +222,16 @@ func (lv SecondaryLoadVector) SafeFormat(w redact.SafePrinter, _ rune) {
 
 type RangeLoad struct {
 	Load LoadVector
-	// Nanos per second. RaftCPU <= Load[cpu]. Handling this as a special case,
-	// rather than trying to (over) generalize, since currently this is the only
-	// resource broken down into two components.
+	// Nanos per second. Handling this as a special case, rather than trying to
+	// (over) generalize, since currently this is the only resource broken down
+	// into two components.
 	//
 	// Load[cpu]-RaftCPU is work being done on this store for evaluating
 	// proposals and can vary across replicas. Pessimistically, one can assume
 	// that if this replica is the leaseholder and we move the lease to a
 	// different existing replica, it will see an addition of Load[cpu]-RaftCPU.
+	//
+	// INVARIANT: RaftCPU <= Load[CPU].
 	RaftCPU LoadValue
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #168239 on behalf of @tbg.

----

The lease shedding path computes leaseholder CPU as `Load[CPURate] -
RaftCPU` and panics if the result is negative. The TODO comment said to
remove the panic once we are out of the experimental phase.

In the current data flow the subtraction can never be negative:
`MakePhysicalRangeLoad` derives both fields from one atomic `LoadStats`
snapshot as `raft*amp` and `(request+raft)*amp`, so the difference is
`request*amp >= 0` by construction, and `MakePhysicalRangeLoad` is the
only non-test producer of `RangeLoad.RaftCPU`. The invariant is now
documented on the `RangeLoad.RaftCPU` field.

Replace the panic with an `Errorf` plus skipping the range (and bumping
the `rangeTransient` shed counter) so a future change that breaks the
invariant is loud but non-fatal.

Part of: #167723
Epic: none
Release note: None

----

Release justification: fix for a crash in (default-off) mma.