### PR TITLE
kvserver: support separated engine checkpointing

### DIFF
--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -725,13 +725,12 @@ func (r *Replica) computeChecksumPostApply(
 		}
 		// NB: the names here will match on all nodes, which is nice for debugging.
 		tag := fmt.Sprintf("r%d_at_%d", r.RangeID, as.RaftAppliedIndex)
-		_ = r.store.TODOBothEngines() // need two sets of spans, one for each engine
 		spans := r.store.checkpointSpans(&desc)
 		log.KvExec.Warningf(ctx, "creating checkpoint %s with spans %+v", tag, spans)
-		if dir, err := r.store.checkpoint(tag, spans); err != nil {
+		if dirs, err := r.store.checkpoint(tag, spans); err != nil {
 			log.KvExec.Warningf(ctx, "unable to create checkpoint %s: %+v", tag, err)
 		} else {
-			log.KvExec.Warningf(ctx, "created checkpoint %s", dir)
+			log.KvExec.Warningf(ctx, "created checkpoint(s) %v", dirs)
 		}
 	}
 

--- a/pkg/kv/kvserver/spanset/engine.go
+++ b/pkg/kv/kvserver/spanset/engine.go
@@ -92,11 +92,9 @@ func (s *spanSetEngine) Download(ctx context.Context, span roachpb.Span, copy bo
 
 // CreateCheckpoint implements the storage.EngineWithoutRW interface.
 func (s *spanSetEngine) CreateCheckpoint(dir string, spans []roachpb.Span) error {
-	for _, span := range spans {
-		if err := s.spans.CheckAllowed(SpanReadOnly, TrickySpan{Key: span.Key, EndKey: span.EndKey}); err != nil {
-			return err
-		}
-	}
+	// NB: intentionally not checking allowed spans. The caller declares
+	// coarsely-grained spans for checkpointing, so fine-grained span checking
+	// here would be more trouble than it's worth.
 	return s.e.CreateCheckpoint(dir, spans)
 }
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3727,12 +3727,35 @@ func (s *Store) checkpointSpans(desc *roachpb.RangeDescriptor) []roachpb.Span {
 	return spans
 }
 
-// checkpoint creates a Pebble checkpoint in the auxiliary directory with the
-// provided tag used in the filepath. Returns the path to the created checkpoint
-// directory. The checkpoint includes only files that intersect with either of
-// the provided key spans. If spans is empty, it includes the entire store.
-func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
-	return createCheckpoint(s.TODOBothEngines(), tag, spans)
+// checkpoint creates Pebble checkpoint(s) in the auxiliary directory of each of
+// the Store's engines, with the provided tag used in the filepath. Returns the
+// paths to the created checkpoint directories.
+//
+// The state machine (or single) engine checkpoint includes only files that
+// intersect with either of the provided key spans. If spans is empty, it
+// includes the entire engine. With separated engines, the LogEngine is
+// checkpointed entirely.
+func (s *Store) checkpoint(tag string, spans []roachpb.Span) ([]string, error) {
+	// Checkpoint the state machine first, since this is where the potential
+	// inconsistency of the replicated range data resides. The checkpoint also
+	// includes the LogEngine state if the engine is not separated.
+	statePath, err := createCheckpoint(s.StateEngine(), tag, spans)
+	if err != nil {
+		return nil, err
+	}
+	if !s.EnginesSeparated() {
+		return []string{statePath}, nil
+	}
+	// When engines are separated, checkpoint the entire LogEngine rather than try
+	// to filter it to a subset of spans. The LogEngine is expected to be orders
+	// of magnitude smaller than the StateEngine, so there is no risk leaking a
+	// substantial amount of disk space. Having the entire LogEngine is convenient
+	// for debugging. For example, it contains all raft logs and the WAG.
+	logPath, err := createCheckpoint(s.LogEngine(), tag, nil)
+	if err != nil {
+		return nil, err
+	}
+	return []string{statePath, logPath}, nil
 }
 
 // createCheckpoint creates a Pebble checkpoint in the auxiliary directory with

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3809,13 +3809,18 @@ func (s *Store) computeMetricsLocked(ctx context.Context) (m storage.Metrics, er
 	}
 	s.metrics.updateEnvStats(*envStats)
 
-	{
+	countCheckpoints := func(eng storage.Engine) int {
 		dirs, err := eng.Env().List(checkpointsDir(eng))
 		if err != nil { // skip NotFound or any other error
-			dirs = nil
+			return 0
 		}
-		s.metrics.RdbCheckpoints.Update(int64(len(dirs)))
+		return len(dirs)
 	}
+	numCheckpoints := countCheckpoints(s.StateEngine())
+	if s.EnginesSeparated() {
+		numCheckpoints += countCheckpoints(s.LogEngine())
+	}
+	s.metrics.RdbCheckpoints.Update(int64(numCheckpoints))
 
 	return m, nil
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3653,8 +3653,10 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	return nil
 }
 
-func (s *Store) checkpointsDir() string {
-	return filepath.Join(s.TODOBothEngines().GetAuxiliaryDir(), "checkpoints")
+// checkpointsDir returns the directory within the given engine that contains
+// engine checkpoints as its subdirectories.
+func checkpointsDir(eng storage.Engine) string {
+	return filepath.Join(eng.GetAuxiliaryDir(), "checkpoints")
 }
 
 // checkpointSpans returns key spans containing the given range. The spans may
@@ -3730,8 +3732,15 @@ func (s *Store) checkpointSpans(desc *roachpb.RangeDescriptor) []roachpb.Span {
 // directory. The checkpoint includes only files that intersect with either of
 // the provided key spans. If spans is empty, it includes the entire store.
 func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
-	checkpointBase := s.checkpointsDir()
-	eng := s.TODOBothEngines()
+	return createCheckpoint(s.TODOBothEngines(), tag, spans)
+}
+
+// createCheckpoint creates a Pebble checkpoint in the auxiliary directory with
+// the provided tag used in the filepath. Returns the path to the created
+// directory. The checkpoint includes only files that intersect with either of
+// the provided key spans. If spans is empty, it includes the entire engine.
+func createCheckpoint(eng storage.Engine, tag string, spans []roachpb.Span) (string, error) {
+	checkpointBase := checkpointsDir(eng)
 	_ = eng.Env().MkdirAll(checkpointBase, os.ModePerm)
 	// Create the checkpoint in a "pending" directory first. If we fail midway, it
 	// should be clear that the directory contains an incomplete checkpoint.
@@ -3778,7 +3787,7 @@ func (s *Store) computeMetricsLocked(ctx context.Context) (m storage.Metrics, er
 	s.metrics.updateEnvStats(*envStats)
 
 	{
-		dirs, err := eng.Env().List(s.checkpointsDir())
+		dirs, err := eng.Env().List(checkpointsDir(eng))
 		if err != nil { // skip NotFound or any other error
 			dirs = nil
 		}


### PR DESCRIPTION
With separated engines, checkpoint the entire `LogEngine`, both for simplicity, and for the benefit of having more debug information. This is affordable because the `LogEngine` is orders of magnitude smaller than the `StateEngine`.

Epic: CRDB-55220