### PR TITLE
roachtest/perturbation: reduce IO pressure and pre-balance for restart

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -992,6 +992,14 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 
 	// Collect the baseline after the workload has stabilized.
 	baselineInterval := intervalSince(v.validationDuration / 2)
+
+	// Let any in-flight rebalancing settle before perturbing. The fill phase
+	// can leave per-store range counts noticeably skewed: when the perturbed
+	// node returns and the cluster tries to re-balance to its underfull
+	// stores, the snapshot storm concentrates on one store and can push it
+	// into a Pebble write stall.
+	v.waitForRebalanceToStop(ctx, t)
+
 	// Now start the perturbation.
 	t.Status("T3: inducing perturbation")
 	perturbationDuration := v.perturbation.startPerturbation(ctx, t, v)

--- a/pkg/cmd/roachtest/tests/perturbation/restart_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/restart_node.go
@@ -34,6 +34,12 @@ func (r restart) setup() variations {
 	// flush/compaction pipeline can fall behind into a Pebble write stall.
 	v.ratioOfMax = 0.3
 
+	// Scatter the workload table at init so initial replica placement isn't
+	// skewed across the per-node stores. A pre-existing per-store imbalance
+	// concentrates the recovery snapshot storm on whichever store appears
+	// underfull, which is what causes the stall described above.
+	v.scatter = true
+
 	// TODO(baptist): Remove this setting once #120073 is fixed.
 	v.clusterSettings["kv.lease.reject_on_leader_unknown.enabled"] = "true"
 

--- a/pkg/cmd/roachtest/tests/perturbation/restart_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/restart_node.go
@@ -27,6 +27,13 @@ func (r restart) setup() variations {
 	r.cleanRestart = true
 	v := setup(r, defaultThresholds())
 
+	// Run with extra IO headroom relative to the cluster-wide default. When the
+	// target node returns it must absorb raft catch-up, rebalancing snapshots,
+	// and re-acquired lease traffic concurrently; at the default 0.5 the
+	// recovered store sits at the edge of its sustainable write rate and the
+	// flush/compaction pipeline can fall behind into a Pebble write stall.
+	v.ratioOfMax = 0.3
+
 	// TODO(baptist): Remove this setting once #120073 is fixed.
 	v.clusterSettings["kv.lease.reject_on_leader_unknown.enabled"] = "true"
 


### PR DESCRIPTION
Recent runs of `perturbation/full/restart` have failed with extreme recovery-phase throughput dips after the 1.25x throughput floor landed in #169659. Analysis on #170849 traced the worst run (21x dip) to a Pebble commit pipeline stall of the recovering node's two stores: the rebalancer concentrated initial-snapshot ingest on whichever store appeared most underfull while the workload kept full foreground pressure on the cluster.

This PR addresses the test-side amplifiers. It does not change any production code; the allocator-side gaps in IO-overload signaling (gossiped score ignores WAL-failover and flush-backlog, no per-node consolidation) are left for a separate KV conversation.

  - Lower restart's `ratioOfMax` from 0.5 to 0.3 so the cluster runs with ~40% IO headroom; recovery work fits within sustainable disk capacity.
  - Wait for in-flight rebalancing to settle in the shared framework after the baseline interval (no-op for most tests; closes the per-store skew that drives the snapshot concentration on restart), and scatter the workload table at init for restart so initial replica placement isn't already skewed when the perturbation begins.

Fixes: https://github.com/cockroachdb/cockroach/issues/170849