### PR TITLE
release: announce blessed publish on Jira and Slack

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -473,6 +473,72 @@ jobs:
           build/github/release-publish-rafa-prs.sh
 
   # --------------------------------------------------------------------------
+  # Stage 3: Announce the blessed release on Jira + #db-release-status
+  # --------------------------------------------------------------------------
+  # Runs only on real prod publishes (IS_PRODUCTION_REPO=true && !dry_run)
+  # and only when every customer-facing publish job above succeeded. The
+  # binary adds a Jira comment to the matching CRDB Release ticket (found
+  # by cfBuildSHA = publish SHA) and posts a self-contained Slack message
+  # to #db-release-status containing the comment permalink and body —
+  # link unfurling is disabled, so the message must stand on its own.
+  # Reviewer-approval gate is on approve-publish upstream; this job
+  # inherits the gate transitively via publish-staged.
+  notify-publish:
+    name: Notify #db-release-status
+    needs:
+      - publish-staged
+      - publish-redhat
+      - create-rafa-prs
+    if: >-
+      ${{ !cancelled() &&
+        needs.publish-staged.result == 'success' &&
+        needs.publish-redhat.result == 'success' &&
+        needs.create-rafa-prs.result == 'success' &&
+        !inputs.dry_run && vars.IS_PRODUCTION_REPO == 'true' &&
+        (github.ref == 'refs/heads/master' ||
+         (startsWith(github.ref, 'refs/heads/release-') && endsWith(github.ref, '-rc')) ||
+         startsWith(github.ref, 'refs/heads/staging-v'))
+      }}
+    runs-on: [self-hosted, ubuntu_2404]
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      # Checkout at the publish SHA so pkg/build/version.txt holds the
+      # version we just published (not the master tip).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ env.RELEASE_WIF_PROVIDER }}
+          service_account: ${{ env.RELEASE_GCP_SERVICE_ACCOUNT }}
+
+      # Fetch via the official Google action so each secret is
+      # auto-registered with ::add-mask:: and never flows through `echo`.
+      - name: Fetch notify-publish secrets
+        id: secrets
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            jira_api_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-jira-api-token
+            slack_bot_token:${{ env.RELEASE_GCP_PROJECT }}/gha-releases-release-slack-bot-token
+
+      - name: Notify Jira and Slack
+        env:
+          JIRA_API_TOKEN: ${{ steps.secrets.outputs.jira_api_token }}
+          # JIRA_EMAIL is the bot's account; not a secret, kept inline
+          # to match release-pick-sha.yml.
+          JIRA_EMAIL: release-eng-bot@cockroachlabs.com
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.slack_bot_token }}
+          BUILD_VCS_NUMBER: ${{ inputs.sha || github.sha }}
+          IS_PRODUCTION_REPO: ${{ vars.IS_PRODUCTION_REPO }}
+        run: build/github/release-notify-publish.sh
+
+  # --------------------------------------------------------------------------
   # Notification (always runs)
   # --------------------------------------------------------------------------
   notify:
@@ -491,6 +557,7 @@ jobs:
       - publish-staged
       - publish-redhat
       - create-rafa-prs
+      - notify-publish
     # No `environment:` here. The release-ops environment requires a human
     # reviewer for every job that uses it; that's the right gate for
     # publish-cloud-only / publish-staged / publish-redhat / create-rafa-prs

--- a/build/github/release-notify-publish-impl.sh
+++ b/build/github/release-notify-publish-impl.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Inner half of the notify-publish wrapper. Runs INSIDE the bazel docker
+# container that run_bazel sets up: builds the release binary against
+# the workspace mounted at /go/src/github.com/cockroachdb/cockroach and
+# invokes its `notify-publish` subcommand with --sha=$BUILD_VCS_NUMBER.
+#
+# Secrets (JIRA_API_TOKEN, JIRA_EMAIL, SLACK_BOT_TOKEN) are forwarded by
+# the wrapper via docker -e passthrough; the binary reads them from its
+# own env. pkg/build/version.txt is read at the workspace path the
+# workflow's checkout step left it at — the publish SHA's version.
+
+set -euo pipefail
+
+bazel build --config=crosslinux //pkg/cmd/release
+
+$(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
+  notify-publish --sha "$BUILD_VCS_NUMBER"

--- a/build/github/release-notify-publish.sh
+++ b/build/github/release-notify-publish.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# GitHub Actions wrapper for posting the "binaries have been blessed"
+# notification on Jira and #db-release-status after a successful release
+# publish. Runs the release binary inside the bazel docker container (via
+# run_bazel) so the workflow doesn't depend on the host runner having a
+# compatible bazel / Go toolchain.
+#
+# Expects to be called by a step that has fetched the release secrets via
+# google-github-actions/get-secretmanager-secrets and bound them to the
+# env vars below. The :? defaults fail fast if the calling workflow
+# drops one.
+#
+# NOTE: This script intentionally does NOT use set -x. It handles
+# secrets that must never appear in build logs.
+
+set -euo pipefail
+
+: "${JIRA_API_TOKEN:?must be set by the workflow}"
+: "${JIRA_EMAIL:?must be set by the workflow}"
+: "${SLACK_BOT_TOKEN:?must be set by the workflow}"
+: "${BUILD_VCS_NUMBER:?must be set by the workflow (the publish SHA)}"
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$dir/build/teamcity-support.sh"        # for $root
+source "$dir/build/teamcity-bazel-support.sh"  # for run_bazel
+
+# Forward the secrets and the publish SHA into the container.
+# IS_PRODUCTION_REPO is read by the binary's isProductionRepo() helper to
+# pick the Slack channel; without it the binary defaults to #db-release-test.
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e JIRA_API_TOKEN -e JIRA_EMAIL -e SLACK_BOT_TOKEN -e BUILD_VCS_NUMBER -e IS_PRODUCTION_REPO" \
+  run_bazel build/github/release-notify-publish-impl.sh

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "jira_adf.go",
         "jira_client.go",
         "main.go",
+        "notify_publish.go",
         "pick_sha.go",
         "release_notes_api.go",
         "sender.go",
@@ -50,6 +51,7 @@ go_test(
     srcs = [
         "cut_staging_branches_test.go",
         "git_test.go",
+        "notify_publish_test.go",
         "pick_sha_test.go",
         "update_releases_test.go",
         "update_workflow_test.go",

--- a/pkg/cmd/release/cut_staging_branches.go
+++ b/pkg/cmd/release/cut_staging_branches.go
@@ -352,7 +352,7 @@ func (r *cutRunner) processCandidate(ctx context.Context, c jiraIssue) error {
 		return errors.Wrap(err, "posting Slack message")
 	}
 	if !r.dryRun {
-		if err := r.jira.AddComment(issueKey, buildJiraComment(details, link)); err != nil {
+		if _, err := r.jira.AddComment(issueKey, buildJiraComment(details, link)); err != nil {
 			return errors.Wrap(err, "adding Jira comment")
 		}
 	} else {

--- a/pkg/cmd/release/jira_client.go
+++ b/pkg/cmd/release/jira_client.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -18,7 +19,22 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const jiraBaseURL = "https://cockroachlabs.atlassian.net"
+const (
+	// jiraBaseURL is the Cloud REST API host.
+	jiraBaseURL = "https://cockroachlabs.atlassian.net"
+	// jiraBrowseBaseURL is the public Jira base URL for human-facing issue
+	// links embedded in Slack notifications and Jira comments.
+	jiraBrowseBaseURL = "https://cockroachlabs.atlassian.net/browse"
+)
+
+// jiraCommentPermalink returns the public URL for a specific comment on a
+// Jira issue, in the form Jira uses when a user clicks "Copy link" on a
+// comment: /browse/<KEY>?focusedCommentId=<id>. The query string is URL-
+// encoded so unusual comment IDs (whitespace, &, =) don't corrupt the link.
+func jiraCommentPermalink(key, commentID string) string {
+	v := url.Values{"focusedCommentId": {commentID}}
+	return fmt.Sprintf("%s/%s?%s", jiraBrowseBaseURL, key, v.Encode())
+}
 
 // jiraClient calls a small subset of the Jira Cloud REST v3 API: JQL search,
 // issue fetch, field update, transition, and comment. It uses HTTP basic auth
@@ -214,10 +230,21 @@ func (c *jiraClient) Transition(key string, transitionID string) error {
 // AddComment posts a comment whose body is the supplied Atlassian Document
 // Format doc (built via the adf* helpers in jira_adf.go). Callers own the
 // formatting; this method only handles the API envelope and POST.
-func (c *jiraClient) AddComment(key string, doc map[string]interface{}) error {
+//
+// Returns the newly created comment's ID — Jira's response includes it on
+// the created object, and callers that want to build a focusedCommentId
+// permalink (e.g. notify-publish) need it. Callers that don't care can
+// discard the return value.
+func (c *jiraClient) AddComment(key string, doc map[string]interface{}) (string, error) {
 	body := map[string]interface{}{"body": doc}
 	path := "/rest/api/3/issue/" + url.PathEscape(key) + "/comment"
-	return c.do("POST", path, body, nil)
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := c.do("POST", path, body, &resp); err != nil {
+		return "", err
+	}
+	return resp.ID, nil
 }
 
 // do issues an authenticated request and decodes the JSON response into out

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -57,6 +57,7 @@ func main() {
 
 func init() {
 	rootCmd.AddCommand(cutStagingBranchesCmd)
+	rootCmd.AddCommand(notifyPublishCmd)
 	rootCmd.AddCommand(pickSHACmd)
 	rootCmd.AddCommand(updateReleasesTestFilesCmd)
 	rootCmd.AddCommand(updateVersionsCmd)

--- a/pkg/cmd/release/notify_publish.go
+++ b/pkg/cmd/release/notify_publish.go
@@ -1,0 +1,356 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+)
+
+// notifyPublishJQL selects the CRDB Release ticket the publish SHA
+// belongs to. cfBuildSHA (customfield_10590) is set by pick-sha when it
+// dispatches build-and-sign, so by the time a publish completes there is
+// exactly one ticket tagged with the SHA we're publishing.
+//
+// Built with fmt.Sprintf at call time; the placeholder is the SHA, which
+// the operator supplies via --sha.
+const notifyPublishJQLFormat = `issueType="CRDB Release" and cf[10590]="%s"`
+
+// blessedBullets is the canonical body shared by both the Jira comment
+// and the Slack message. Both renderers consume this slice so the two
+// surfaces cannot drift; editing the bullet text here updates both. If
+// the text needs to vary per release in the future, plumb it through a
+// flag rather than splitting the constant.
+var blessedBullets = []string{
+	"Working on Homebrew versions.",
+	"Ready for docs for download/SH.",
+	"Ready for SRE to enable on CockroachCloud.",
+}
+
+// publishedBullets is the body of the second Slack post — the
+// IBM-OEM-facing "binaries have been published" announcement. Kept
+// separate from blessedBullets because the audience is different
+// (IBM-OEM team, not the wider release-team) and the verb differs
+// ("published" vs "blessed").
+var publishedBullets = []string{
+	"Ready for Security scans and SBOM",
+	"Ready for Initial Images and VCoO artifacts",
+}
+
+// ibmOEMChannel is the prod Slack channel for the
+// "binaries have been published" announcement consumed by the IBM-OEM
+// release team. Non-prod runs route to nonProdChannel instead so
+// rehearsal traffic doesn't reach the IBM team.
+const ibmOEMChannel = "#proj-ibm-oem-releases"
+
+// defaultVersionFilePath is the in-repo path the publish workflow
+// checks out at the publish SHA; the file holds the version being
+// shipped. Override via --version-file for local rehearsals.
+const defaultVersionFilePath = "pkg/build/version.txt"
+
+var notifyPublishFlags = struct {
+	sha         string
+	dryRun      bool
+	channel     string
+	ibmChannel  string
+	jiraIssue   string
+	versionFile string
+}{}
+
+var notifyPublishCmd = &cobra.Command{
+	Use:   "notify-publish",
+	Short: "Announce a finished release publish on Jira and #db-release-status",
+	Long: `Adds a "binaries have been blessed" comment to the CRDB Release Jira
+ticket whose Build SHA matches --sha, then posts a self-contained Slack
+message to #db-release-status containing the same body and a permalink
+back to the new Jira comment.
+
+The Jira ticket is located via JQL on customfield_10590 (Build SHA),
+which pick-sha sets when it dispatches build-and-sign. Pass --jira-issue
+to bypass the JQL lookup when zero or multiple tickets match.
+
+Dry-run logs the JQL, comment body, and Slack message body without
+writing to Jira or Slack — useful for local rehearsal with read-only
+Jira creds.`,
+	RunE: runNotifyPublish,
+}
+
+func init() {
+	notifyPublishCmd.Flags().StringVar(&notifyPublishFlags.sha, "sha", "",
+		"git SHA being published; used to look up the matching Jira ticket and "+
+			"required so the same JQL is reproducible offline (no env-var fallback)")
+	notifyPublishCmd.Flags().BoolVar(&notifyPublishFlags.dryRun, "dry-run", false,
+		"log the JQL, Jira comment body, and Slack message body without writing")
+	notifyPublishCmd.Flags().StringVar(&notifyPublishFlags.channel, "slack-channel", "",
+		"Slack channel for the 'blessed' announcement (default: "+releaseChannel+
+			" when "+envIsProductionRepo+"=true, "+nonProdChannel+" otherwise)")
+	notifyPublishCmd.Flags().StringVar(&notifyPublishFlags.ibmChannel, "ibm-slack-channel", "",
+		"Slack channel for the IBM-OEM 'published' announcement (default: "+ibmOEMChannel+
+			" when "+envIsProductionRepo+"=true, "+nonProdChannel+" otherwise)")
+	notifyPublishCmd.Flags().StringVar(&notifyPublishFlags.jiraIssue, "jira-issue", "",
+		"skip JQL lookup and post the comment on this ticket key directly "+
+			"(recovery escape hatch for the zero/multiple-match cases)")
+	notifyPublishCmd.Flags().StringVar(&notifyPublishFlags.versionFile, "version-file", defaultVersionFilePath,
+		"path to the version.txt file, read relative to the working dir")
+}
+
+func runNotifyPublish(_ *cobra.Command, _ []string) error {
+	if notifyPublishFlags.sha == "" {
+		return errors.New("--sha is required")
+	}
+	jiraToken := os.Getenv(envJiraToken)
+	if jiraToken == "" {
+		return errors.Newf("%s is not set", envJiraToken)
+	}
+	jiraEmail := os.Getenv(envJiraEmail)
+	if jiraEmail == "" {
+		return errors.Newf("%s is not set", envJiraEmail)
+	}
+	slackToken := os.Getenv(envSlackBotToken)
+	if slackToken == "" {
+		return errors.Newf("%s is not set", envSlackBotToken)
+	}
+
+	version, err := readVersionFile(notifyPublishFlags.versionFile)
+	if err != nil {
+		return errors.Wrapf(err, "reading version from %s", notifyPublishFlags.versionFile)
+	}
+
+	channel := notifyPublishFlags.channel
+	if channel == "" {
+		channel = nonProdChannel
+		if isProductionRepo() {
+			channel = releaseChannel
+		}
+	}
+	ibmChannel := notifyPublishFlags.ibmChannel
+	if ibmChannel == "" {
+		ibmChannel = nonProdChannel
+		if isProductionRepo() {
+			ibmChannel = ibmOEMChannel
+		}
+	}
+
+	r := &notifyPublishRunner{
+		jira:       newJiraClient(jiraEmail, jiraToken),
+		slack:      newSlackClient(slackToken),
+		sha:        notifyPublishFlags.sha,
+		version:    version,
+		channel:    channel,
+		ibmChannel: ibmChannel,
+		jiraIssue:  notifyPublishFlags.jiraIssue,
+		dryRun:     notifyPublishFlags.dryRun,
+	}
+	return r.run()
+}
+
+// notifyPublishRunner holds the wired-up dependencies and per-invocation
+// knobs for one publish-notification run. Kept narrow so unit tests can
+// substitute a fake jira/slack pair.
+type notifyPublishRunner struct {
+	jira  jiraSearchCommenter
+	slack slackPoster
+
+	sha        string
+	version    string // e.g. "v24.3.33"
+	channel    string // "blessed" announcement target
+	ibmChannel string // IBM-OEM "published" announcement target
+	jiraIssue  string // when set, skips the JQL lookup
+	dryRun     bool
+}
+
+// jiraSearchCommenter is the narrow Jira surface the runner needs.
+// Implemented by *jiraClient in production and by fakes in tests.
+type jiraSearchCommenter interface {
+	SearchJQL(jql string, fields []string) ([]jiraIssue, error)
+	AddComment(key string, doc map[string]interface{}) (string, error)
+}
+
+// slackPoster is the narrow Slack surface the runner needs. Implemented
+// by *slackClient in production.
+type slackPoster interface {
+	PostMessage(channel, text string) (string, error)
+}
+
+func (r *notifyPublishRunner) run() error {
+	key, err := r.resolveTicketKey()
+	if err != nil {
+		return err
+	}
+
+	commentDoc := buildBlessedJiraComment(r.version)
+	var commentID string
+	if r.dryRun {
+		log.Printf("[DRY RUN] would post Jira comment on %s; body: %s",
+			key, mustJSON(commentDoc))
+		commentID = "DRYRUN"
+	} else {
+		commentID, err = r.jira.AddComment(key, commentDoc)
+		if err != nil {
+			return errors.Wrapf(err, "adding blessed comment to %s", key)
+		}
+		if commentID == "" {
+			return errors.AssertionFailedf("Jira returned empty comment ID for %s", key)
+		}
+	}
+
+	slackBody := buildBlessedSlackMessage(r.version, key, commentID)
+	ibmBody := buildPublishedSlackMessage(r.version)
+	if r.dryRun {
+		log.Printf("[DRY RUN] would post to %s; body:\n%s", r.channel, slackBody)
+		log.Printf("[DRY RUN] would post to %s; body:\n%s", r.ibmChannel, ibmBody)
+		return nil
+	}
+	if _, err := r.slack.PostMessage(r.channel, slackBody); err != nil {
+		// The Jira comment is already live — operator can repost to
+		// Slack manually using the permalink in the run log below.
+		log.Printf("posted Jira comment %s on %s; Slack post failed, body was:\n%s",
+			commentID, key, slackBody)
+		return errors.Wrap(err, "posting blessed message to Slack")
+	}
+	log.Printf("ticket %s: posted blessed comment %s and Slack announcement to %s",
+		key, commentID, r.channel)
+	// The IBM-OEM post is Slack-only and intentionally has no Jira side.
+	// A failure here leaves the blessed message already posted: log the
+	// prepared body so the operator can copy-paste into the IBM channel
+	// manually before re-running anything.
+	if _, err := r.slack.PostMessage(r.ibmChannel, ibmBody); err != nil {
+		log.Printf("blessed announcement posted to %s; IBM-OEM post to %s failed, body was:\n%s",
+			r.channel, r.ibmChannel, ibmBody)
+		return errors.Wrapf(err, "posting IBM-OEM published message to %s", r.ibmChannel)
+	}
+	log.Printf("posted IBM-OEM announcement to %s", r.ibmChannel)
+	return nil
+}
+
+// resolveTicketKey returns the Jira ticket key to post on. When the
+// operator passed --jira-issue we trust it without an extra round-trip;
+// otherwise we run the JQL and require exactly one match. Multiple
+// matches and zero matches both surface as errors that name the SHA and
+// remind the operator about --jira-issue so recovery is one flag away.
+func (r *notifyPublishRunner) resolveTicketKey() (string, error) {
+	if r.jiraIssue != "" {
+		return r.jiraIssue, nil
+	}
+	jql := fmt.Sprintf(notifyPublishJQLFormat, r.sha)
+	if r.dryRun {
+		log.Printf("[DRY RUN] JQL: %s", jql)
+	}
+	issues, err := r.jira.SearchJQL(jql, []string{"summary"})
+	if err != nil {
+		return "", errors.Wrap(err, "looking up release ticket by cfBuildSHA")
+	}
+	switch len(issues) {
+	case 0:
+		return "", errors.Newf(
+			"no CRDB Release ticket found with cfBuildSHA=%s; pass --jira-issue to override",
+			r.sha)
+	case 1:
+		return issues[0].Key, nil
+	default:
+		keys := make([]string, len(issues))
+		for i, is := range issues {
+			keys[i] = is.Key
+		}
+		return "", errors.Newf(
+			"multiple CRDB Release tickets match cfBuildSHA=%s: %v; pass --jira-issue to disambiguate",
+			r.sha, keys)
+	}
+}
+
+// readVersionFile returns the version string from pkg/build/version.txt:
+// the first non-empty, non-comment line, with a leading "v" prepended if
+// it isn't already there so callers can render the version uniformly as
+// "v<X.Y.Z>".
+func readVersionFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, "v") {
+			line = "v" + line
+		}
+		return line, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.Newf("no version line found in %s", path)
+}
+
+// buildBlessedJiraComment renders the "binaries have been blessed"
+// announcement as an ADF document. The version is bolded and rendered
+// as inline code (matching the manual Jira comments this replaces);
+// each bullet is one item in blessedBullets.
+func buildBlessedJiraComment(version string) map[string]interface{} {
+	bullets := make([][]interface{}, len(blessedBullets))
+	for i, b := range blessedBullets {
+		bullets[i] = []interface{}{adfText(b)}
+	}
+	return adfDoc(
+		adfPara(
+			adfMarked(version, adfCode()),
+			adfMarked(" binaries have been blessed:", adfStrong()),
+		),
+		adfBullet(bullets...),
+	)
+}
+
+// buildBlessedSlackMessage renders the announcement as Slack mrkdwn.
+// Layout matches the manual posts this replaces: a Jira-comment
+// permalink on the first line (rendered with the ticket key as the
+// link text), then the body and bullets. The message is self-contained
+// — PostMessage disables Slack's link unfurling, so the body must not
+// depend on the Jira link expanding.
+func buildBlessedSlackMessage(version, jiraKey, commentID string) string {
+	link := jiraCommentPermalink(jiraKey, commentID)
+	var b strings.Builder
+	fmt.Fprintf(&b, "<%s|%s>\n", link, jiraKey)
+	fmt.Fprintf(&b, "`%s` binaries have been blessed:", version)
+	for _, bullet := range blessedBullets {
+		fmt.Fprintf(&b, "\n• %s", bullet)
+	}
+	return b.String()
+}
+
+// buildPublishedSlackMessage renders the IBM-OEM-facing "binaries have
+// been published" announcement as Slack mrkdwn. Intentionally has no
+// Jira link — the IBM-OEM audience doesn't track our Jira tickets, and
+// the screenshot of the manual post this replaces is body-only.
+func buildPublishedSlackMessage(version string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "`%s` binaries have been published:", version)
+	for _, bullet := range publishedBullets {
+		fmt.Fprintf(&b, "\n• %s", bullet)
+	}
+	return b.String()
+}
+
+// mustJSON formats v as compact JSON for dry-run logging. Only used on
+// values we constructed in-process (ADF docs), so the marshal cannot
+// realistically fail; on the off chance it does we surface the error
+// inline rather than aborting the dry-run.
+func mustJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("<json.Marshal failed: %v>", err)
+	}
+	return string(b)
+}

--- a/pkg/cmd/release/notify_publish_test.go
+++ b/pkg/cmd/release/notify_publish_test.go
@@ -1,0 +1,407 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJiraCommentPermalink(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		commentID string
+		expected  string
+	}{
+		{
+			name:      "typical",
+			key:       "REL-4910",
+			commentID: "363988",
+			expected:  "https://cockroachlabs.atlassian.net/browse/REL-4910?focusedCommentId=363988",
+		},
+		{
+			name:      "comment id with special chars is encoded",
+			key:       "REL-1",
+			commentID: "abc def&x=1",
+			expected:  "https://cockroachlabs.atlassian.net/browse/REL-1?focusedCommentId=abc+def%26x%3D1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, jiraCommentPermalink(tc.key, tc.commentID))
+		})
+	}
+}
+
+func TestBuildBlessedSlackMessage(t *testing.T) {
+	got := buildBlessedSlackMessage("v24.3.33", "REL-4910", "363988")
+	want := "<https://cockroachlabs.atlassian.net/browse/REL-4910?focusedCommentId=363988|REL-4910>\n" +
+		"`v24.3.33` binaries have been blessed:\n" +
+		"• Working on Homebrew versions.\n" +
+		"• Ready for docs for download/SH.\n" +
+		"• Ready for SRE to enable on CockroachCloud."
+	require.Equal(t, want, got)
+}
+
+func TestBuildPublishedSlackMessage(t *testing.T) {
+	got := buildPublishedSlackMessage("v26.2.0")
+	want := "`v26.2.0` binaries have been published:\n" +
+		"• Ready for Security scans and SBOM\n" +
+		"• Ready for Initial Images and VCoO artifacts"
+	require.Equal(t, want, got)
+}
+
+// TestBuildBlessedJiraComment asserts the ADF JSON we send to Jira.
+// JSONEq lets the test ignore key ordering while still pinning every
+// node — so a future change to the comment shape requires updating the
+// expected JSON, not silently drifting.
+func TestBuildBlessedJiraComment(t *testing.T) {
+	doc := buildBlessedJiraComment("v24.3.33")
+	got, err := json.Marshal(doc)
+	require.NoError(t, err)
+	want := `{
+		"type": "doc",
+		"version": 1,
+		"content": [
+			{
+				"type": "paragraph",
+				"content": [
+					{"type":"text","text":"v24.3.33","marks":[{"type":"code"}]},
+					{"type":"text","text":" binaries have been blessed:","marks":[{"type":"strong"}]}
+				]
+			},
+			{
+				"type": "bulletList",
+				"content": [
+					{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Working on Homebrew versions."}]}]},
+					{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Ready for docs for download/SH."}]}]},
+					{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Ready for SRE to enable on CockroachCloud."}]}]}
+				]
+			}
+		]
+	}`
+	require.JSONEq(t, want, string(got))
+}
+
+func TestReadVersionFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		expected    string
+		expectedErr string
+	}{
+		{
+			name:     "simple line with v prefix",
+			content:  "v24.3.33\n",
+			expected: "v24.3.33",
+		},
+		{
+			name:     "prepends v when missing",
+			content:  "24.3.33\n",
+			expected: "v24.3.33",
+		},
+		{
+			name:     "skips comments and blank lines",
+			content:  "# header\n\n# another\nv26.3.0-alpha.00000000\n",
+			expected: "v26.3.0-alpha.00000000",
+		},
+		{
+			name:     "trims surrounding whitespace",
+			content:  "   v25.4.3   \n",
+			expected: "v25.4.3",
+		},
+		{
+			name:        "empty file is an error",
+			content:     "",
+			expectedErr: "no version line",
+		},
+		{
+			name:        "only-comments file is an error",
+			content:     "# nothing here\n# really\n",
+			expectedErr: "no version line",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "version.txt")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0644))
+			got, err := readVersionFile(path)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+
+	t.Run("missing file surfaces the os error", func(t *testing.T) {
+		_, err := readVersionFile(filepath.Join(t.TempDir(), "does-not-exist.txt"))
+		require.Error(t, err)
+	})
+}
+
+// fakeJira is a minimal jiraSearchCommenter for resolveTicketKey and run
+// tests. It records the JQL it was asked to run, returns canned issues,
+// and tracks AddComment calls. Behavior is per-test (set fields, then
+// invoke the runner); no goroutines so concurrent access isn't a concern.
+type fakeJira struct {
+	searchResult []jiraIssue
+	searchErr    error
+	lastJQL      string
+
+	addCommentID  string
+	addCommentErr error
+	addCommentKey string
+	addCommentDoc map[string]interface{}
+}
+
+func (f *fakeJira) SearchJQL(jql string, _ []string) ([]jiraIssue, error) {
+	f.lastJQL = jql
+	return f.searchResult, f.searchErr
+}
+
+func (f *fakeJira) AddComment(key string, doc map[string]interface{}) (string, error) {
+	f.addCommentKey = key
+	f.addCommentDoc = doc
+	return f.addCommentID, f.addCommentErr
+}
+
+// fakeSlack records every PostMessage call. The runner makes more than
+// one call per run (blessed + IBM-OEM), so a single-slot recorder would
+// hide ordering bugs. postErrs returns one error per call (nil = success);
+// out-of-range index returns nil so callers only need to populate the
+// failing slot.
+type fakeSlack struct {
+	postErrs []error
+	posts    []slackPost
+}
+
+type slackPost struct{ channel, body string }
+
+func (f *fakeSlack) PostMessage(channel, text string) (string, error) {
+	f.posts = append(f.posts, slackPost{channel: channel, body: text})
+	if len(f.posts) <= len(f.postErrs) {
+		if err := f.postErrs[len(f.posts)-1]; err != nil {
+			return "", err
+		}
+	}
+	return "https://example.slack/permalink", nil
+}
+
+func TestResolveTicketKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		jiraIssue    string // operator override
+		searchResult []jiraIssue
+		searchErr    error
+		expectedKey  string
+		expectedJQL  string // empty = no JQL expected
+		expectedErr  string
+	}{
+		{
+			name:         "single match returns the key",
+			searchResult: []jiraIssue{{Key: "REL-4910"}},
+			expectedKey:  "REL-4910",
+			expectedJQL:  `issueType="CRDB Release" and cf[10590]="deadbeef"`,
+		},
+		{
+			name:        "zero matches errors with --jira-issue hint",
+			expectedJQL: `issueType="CRDB Release" and cf[10590]="deadbeef"`,
+			expectedErr: "no CRDB Release ticket found with cfBuildSHA=deadbeef; pass --jira-issue",
+		},
+		{
+			name: "multiple matches errors and lists keys",
+			searchResult: []jiraIssue{
+				{Key: "REL-1"},
+				{Key: "REL-2"},
+			},
+			expectedJQL: `issueType="CRDB Release" and cf[10590]="deadbeef"`,
+			expectedErr: "multiple CRDB Release tickets match cfBuildSHA=deadbeef: [REL-1 REL-2]; pass --jira-issue",
+		},
+		{
+			name:        "API error wraps the cause",
+			searchErr:   errors.New("boom"),
+			expectedJQL: `issueType="CRDB Release" and cf[10590]="deadbeef"`,
+			expectedErr: "looking up release ticket by cfBuildSHA: boom",
+		},
+		{
+			name:        "--jira-issue override skips the JQL entirely",
+			jiraIssue:   "REL-9999",
+			expectedKey: "REL-9999",
+			// expectedJQL stays empty: SearchJQL must not be called.
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jira := &fakeJira{
+				searchResult: tc.searchResult,
+				searchErr:    tc.searchErr,
+			}
+			r := &notifyPublishRunner{
+				jira:      jira,
+				sha:       "deadbeef",
+				jiraIssue: tc.jiraIssue,
+			}
+			got, err := r.resolveTicketKey()
+			require.Equal(t, tc.expectedJQL, jira.lastJQL)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedKey, got)
+		})
+	}
+}
+
+// TestNotifyPublishRunnerRun exercises the end-to-end happy path:
+// resolveTicketKey -> AddComment -> blessed Slack post -> IBM-OEM Slack
+// post. Asserts the two Slack posts happen in the right order, on the
+// right channels, with the right bodies (blessed contains the
+// commentID-permalink; published does not link to Jira).
+func TestNotifyPublishRunnerRun(t *testing.T) {
+	jira := &fakeJira{
+		searchResult: []jiraIssue{{Key: "REL-4910"}},
+		addCommentID: "363988",
+	}
+	slack := &fakeSlack{}
+	r := &notifyPublishRunner{
+		jira:       jira,
+		slack:      slack,
+		sha:        "deadbeef",
+		version:    "v24.3.33",
+		channel:    "#db-release-status",
+		ibmChannel: "#proj-ibm-oem-releases",
+	}
+	require.NoError(t, r.run())
+
+	require.Equal(t, "REL-4910", jira.addCommentKey)
+	require.NotNil(t, jira.addCommentDoc, "AddComment must receive an ADF doc")
+
+	require.Len(t, slack.posts, 2, "expected blessed + IBM-OEM posts")
+
+	require.Equal(t, "#db-release-status", slack.posts[0].channel)
+	require.Contains(t, slack.posts[0].body,
+		"<https://cockroachlabs.atlassian.net/browse/REL-4910?focusedCommentId=363988|REL-4910>")
+	require.Contains(t, slack.posts[0].body, "`v24.3.33` binaries have been blessed:")
+
+	require.Equal(t, "#proj-ibm-oem-releases", slack.posts[1].channel)
+	require.Contains(t, slack.posts[1].body, "`v24.3.33` binaries have been published:")
+	require.NotContains(t, slack.posts[1].body, "atlassian.net",
+		"IBM-OEM message must not include a Jira link")
+}
+
+func TestNotifyPublishRunnerRun_AssertsOnEmptyCommentID(t *testing.T) {
+	jira := &fakeJira{
+		searchResult: []jiraIssue{{Key: "REL-4910"}},
+		addCommentID: "", // simulate Jira API contract drift
+	}
+	r := &notifyPublishRunner{
+		jira:       jira,
+		slack:      &fakeSlack{},
+		sha:        "deadbeef",
+		version:    "v24.3.33",
+		channel:    "#db-release-status",
+		ibmChannel: "#proj-ibm-oem-releases",
+	}
+	err := r.run()
+	require.ErrorContains(t, err, "Jira returned empty comment ID")
+}
+
+// TestNotifyPublishRunnerRun_IBMPostFailureSurfaces guards the asymmetric
+// recovery story: when the blessed message has already been posted but
+// the IBM-OEM post fails, the job must fail loudly so the operator sees
+// it in the existing #release-ops notify summary. The blessed Slack
+// message is still considered delivered; only the IBM post needs to be
+// reposted manually.
+func TestNotifyPublishRunnerRun_IBMPostFailureSurfaces(t *testing.T) {
+	jira := &fakeJira{
+		searchResult: []jiraIssue{{Key: "REL-4910"}},
+		addCommentID: "363988",
+	}
+	slack := &fakeSlack{
+		// First call (blessed) succeeds, second call (IBM) fails.
+		postErrs: []error{nil, errors.New("slack 500")},
+	}
+	r := &notifyPublishRunner{
+		jira:       jira,
+		slack:      slack,
+		sha:        "deadbeef",
+		version:    "v24.3.33",
+		channel:    "#db-release-status",
+		ibmChannel: "#proj-ibm-oem-releases",
+	}
+	err := r.run()
+	require.ErrorContains(t, err, "posting IBM-OEM published message to #proj-ibm-oem-releases")
+	require.Len(t, slack.posts, 2,
+		"both Slack posts must be attempted before failing")
+}
+
+func TestNotifyPublishRunnerRun_DryRunDoesNotCallJiraOrSlack(t *testing.T) {
+	jira := &fakeJira{
+		searchResult:  []jiraIssue{{Key: "REL-4910"}},
+		addCommentErr: errors.New("AddComment must not be called in dry-run"),
+	}
+	slack := &fakeSlack{
+		postErrs: []error{
+			errors.New("blessed PostMessage must not be called in dry-run"),
+			errors.New("IBM PostMessage must not be called in dry-run"),
+		},
+	}
+	r := &notifyPublishRunner{
+		jira:       jira,
+		slack:      slack,
+		sha:        "deadbeef",
+		version:    "v24.3.33",
+		channel:    "#db-release-status",
+		ibmChannel: "#proj-ibm-oem-releases",
+		dryRun:     true,
+	}
+	require.NoError(t, r.run())
+	require.Empty(t, jira.addCommentKey, "AddComment must not be called in dry-run")
+	require.Empty(t, slack.posts, "PostMessage must not be called in dry-run")
+}
+
+// TestAddCommentReturnsID exercises the modified jiraClient.AddComment
+// against a stubbed Jira REST endpoint that mirrors the
+// /rest/api/3/issue/{key}/comment response shape. Catches Jira-API
+// contract regressions (renamed/removed .id field) without hitting real
+// Jira.
+func TestAddCommentReturnsID(t *testing.T) {
+	const wantID = "1234567"
+	const wantKey = "REL-42"
+
+	var seenPath, seenMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":%q,"self":"https://cockroachlabs.atlassian.net/rest/api/3/issue/%s/comment/%s"}`,
+			wantID, wantKey, wantID)
+	}))
+	defer srv.Close()
+
+	c := newJiraClient("test@example.com", "test-token")
+	c.baseURL = srv.URL
+
+	gotID, err := c.AddComment(wantKey, map[string]interface{}{"hello": "world"})
+	require.NoError(t, err)
+	require.Equal(t, wantID, gotID)
+	require.Equal(t, http.MethodPost, seenMethod)
+	require.True(t, strings.HasSuffix(seenPath, "/rest/api/3/issue/REL-42/comment"),
+		"unexpected request path %s", seenPath)
+}

--- a/pkg/cmd/release/pick_sha.go
+++ b/pkg/cmd/release/pick_sha.go
@@ -346,7 +346,7 @@ func (r *pickSHARunner) processCandidate(ctx context.Context, c jiraIssue) error
 		return errors.Wrap(err, "posting Slack message")
 	}
 	if !r.dryRun {
-		if err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link, releaseNotesPRURL)); err != nil {
+		if _, err := r.jira.AddComment(c.Key, buildPickSHAJiraComment(details, link, releaseNotesPRURL)); err != nil {
 			return errors.Wrap(err, "adding Jira comment")
 		}
 	} else {
@@ -444,10 +444,6 @@ func (r *pickSHARunner) warnReleaseNotes(key string, payload releaseNotesPayload
 		log.Printf("failed to post release-notes warning to %s: %v", r.opsChannel, postErr)
 	}
 }
-
-// jiraBrowseBaseURL is the public Jira base URL for issue links rendered
-// into Slack notifications. The cockroachlabs.atlassian.net host is fixed.
-const jiraBrowseBaseURL = "https://cockroachlabs.atlassian.net/browse"
 
 // docsInfraSlackLink is a pre-rendered Slack mrkdwn link to the
 // #docs-infrastructure-team channel — the team that owns the


### PR DESCRIPTION
Add a `notify-publish` step to the Release - Publish GHA workflow that posts two announcements after a successful prod publish:

  1. A "binaries have been blessed" comment on the matching CRDB Release Jira ticket (located by JQL on cfBuildSHA = publish SHA), and a self-contained Slack message to #db-release-status containing the same body plus a focusedCommentId permalink back to the new comment. Link unfurling is disabled, so the Slack message stands on its own.

  2. A "binaries have been published" Slack message to #proj-ibm-oem-releases for the IBM-OEM team. Slack-only — no Jira side, matching the manual post this replaces.

Both bodies are hardcoded in pkg/cmd/release/notify_publish.go; the Jira and Slack renderers share the same bullet slice so the two surfaces can't drift. The runner posts blessed first, then IBM-OEM; a Slack failure on either side logs the prepared body so the operator can recover by hand.

Gating: the new GHA job runs only on prod
(IS_PRODUCTION_REPO=true plus dry_run unset) and only when publish-staged, publish-redhat, and create-rafa-prs all succeeded. It joins the existing notify jobs needs list so its failure rolls into the #release-ops summary. Rehearsals run the binary by hand with --slack-channel= #db-release-test, --ibm-slack-channel=#db-release-test, --jira-issue, and/or --dry-run.

Side-effects of adding the subcommand:

  - jiraClient.AddComment now returns (id, error); the two existing callers (pick_sha, cut_staging_branches) ignore the new return.
  - jiraBrowseBaseURL moves from pick_sha.go to jira_client.go (next to jiraBaseURL); the new jiraCommentPermalink helper lives with it.

Epic: none

Release note: None