### PR TITLE
jobs: enable per-job cluster metrics registration

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -134,6 +134,8 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/protectedts/ptpb",
+        "//pkg/obs/clustermetrics",
+        "//pkg/obs/clustermetrics/cmwriter",
         "//pkg/obs/workloadid",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -17,7 +17,7 @@ import (
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
-// Metrics are for production monitoring of each job type.
+// Metrics are for per-node production monitoring of each job type.
 type Metrics struct {
 	JobMetrics    [jobspb.NumJobTypes]*JobTypeMetrics
 	JobPTSMetrics [jobspb.NumJobTypes]*JobTypePTSMetrics
@@ -55,6 +55,15 @@ type Metrics struct {
 	// without an adopt loop, e.g., through a StartableJob.
 	ResumedJobs *metric.Counter
 }
+
+// ClusterMetrics are for cluster-wide production monitoring of each job type.
+type ClusterMetrics struct {
+	// JobSpecificMetrics holds per-type cluster-metric structs indexed by jobspb.Type ordinal.
+	JobSpecificMetrics [jobspb.NumJobTypes]metric.Struct
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (ClusterMetrics) MetricStruct() {}
 
 // JobTypeMetrics is a metric.Struct containing metrics for each type of job.
 type JobTypeMetrics struct {
@@ -389,8 +398,11 @@ var (
 // MetricStruct implements the metric.Struct interface.
 func (Metrics) MetricStruct() {}
 
-// init initializes the metrics for job monitoring.
-func (m *Metrics) init(histogramWindowInterval time.Duration, lookup *cidr.Lookup) {
+// initMetrics initializes both the per-node Metrics and the
+// per-cluster ClusterMetrics for job monitoring.
+func initMetrics(
+	m *Metrics, c *ClusterMetrics, histogramWindowInterval time.Duration, lookup *cidr.Lookup,
+) {
 	if MakeRowLevelTTLMetricsHook != nil {
 		m.RowLevelTTL = MakeRowLevelTTLMetricsHook(histogramWindowInterval)
 	}
@@ -437,6 +449,9 @@ func (m *Metrics) init(histogramWindowInterval time.Duration, lookup *cidr.Looku
 		if opts, ok := getRegisterOptions(jt); ok {
 			if opts.metrics != nil {
 				m.JobSpecificMetrics[jt] = opts.metrics
+			}
+			if opts.clusterMetrics != nil {
+				c.JobSpecificMetrics[jt] = opts.clusterMetrics
 			}
 			if opts.resolvedMetric != nil {
 				m.ResolvedMetrics[jt] = opts.resolvedMetric

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -100,8 +100,11 @@ type Registry struct {
 	nodeID    *base.SQLIDContainer
 	settings  *cluster.Settings
 	execCtx   jobExecCtxMaker
-	metrics   Metrics
-	knobs     TestingKnobs
+
+	metrics        Metrics
+	clusterMetrics ClusterMetrics
+
+	knobs TestingKnobs
 
 	// adoptionChan is used to nudge the registry to resume claimed jobs and
 	// potentially attempt to claim jobs.
@@ -253,7 +256,7 @@ func MakeRegistry(
 	}
 	r.mu.adoptedJobs = make(map[jobspb.JobID]*adoptedJob)
 	r.mu.waiting = make(map[jobspb.JobID]map[*waitingSet]struct{})
-	r.metrics.init(histogramWindowInterval, lookup)
+	initMetrics(&r.metrics, &r.clusterMetrics, histogramWindowInterval, lookup)
 	return r
 }
 
@@ -269,6 +272,11 @@ func (r *Registry) SetInternalDB(db isql.DB) {
 // cycles.
 func (r *Registry) MetricsStruct() *Metrics {
 	return &r.metrics
+}
+
+// ClusterMetrics returns the per-cluster metrics for jobs that opted in via WithJobClusterMetrics.
+func (r *Registry) ClusterMetrics() *ClusterMetrics {
+	return &r.clusterMetrics
 }
 
 // CurrentlyRunningJobs returns a slice of the ids of all jobs running on this node.
@@ -1432,6 +1440,17 @@ func WithJobMetrics(m metric.Struct) RegisterOption {
 	}
 }
 
+// WithJobClusterMetrics returns a RegisterOption which configures
+// jobs of this type to use the specified cluster metrics.
+//
+// Use this alongside WithJobMetrics for jobs that have both per-node
+// and cluster-wide metric needs.
+func WithJobClusterMetrics(m metric.Struct) RegisterOption {
+	return func(opts *registerOptions) {
+		opts.clusterMetrics = m
+	}
+}
+
 // WithResolvedMetric registers a gauge metric that the poller will update to
 // reflect the minimum resolved timestamp of all the jobs of this type.
 func WithResolvedMetric(m *metric.Gauge) RegisterOption {
@@ -1454,6 +1473,10 @@ type registerOptions struct {
 
 	// metrics allow jobs to register job specific metrics.
 	metrics metric.Struct
+
+	// clusterMetrics, if set, is the per-cluster metric struct
+	// registered via WithJobClusterMetrics.
+	clusterMetrics metric.Struct
 
 	// resolvedMetric, if set, is the metric to update using the min resolved ts.
 	resolvedMetric *metric.Gauge

--- a/pkg/jobs/registry_external_test.go
+++ b/pkg/jobs/registry_external_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
+	"github.com/cockroachdb/cockroach/pkg/obs/clustermetrics"
+	"github.com/cockroachdb/cockroach/pkg/obs/clustermetrics/cmwriter"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -37,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -524,4 +527,55 @@ func TestWaitWithRetryableError(t *testing.T) {
 		// retry.
 		require.GreaterOrEqualf(t, numberOfTimesDetected.Load(), int64(2), "jobs query did not retry")
 	}
+}
+
+type testJobClusterMetrics struct {
+	Counter *clustermetrics.Counter
+}
+
+func (*testJobClusterMetrics) MetricStruct() {}
+
+// TestWithJobClusterMetrics verifies that a struct registered via
+// WithJobClusterMetrics flows through the registry and lands in
+// system.cluster_metrics on flush.
+func TestWithJobClusterMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	defer clustermetrics.TestingAllowNonInitConstruction()()
+
+	const metricName = "test.with_job_cluster_metrics.counter"
+	tcm := &testJobClusterMetrics{
+		Counter: clustermetrics.NewCounter(metric.Metadata{Name: metricName}),
+	}
+
+	defer jobs.TestingRegisterConstructor(
+		jobspb.TypeImport,
+		func(_ *jobs.Job, _ *cluster.Settings) jobs.Resumer {
+			return jobstest.FakeResumer{}
+		},
+		jobs.UsesTenantCostControl,
+		jobs.WithJobClusterMetrics(tcm),
+	)()
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+
+	s := srv.ApplicationLayer()
+	registry := s.JobRegistry().(*jobs.Registry)
+
+	require.Same(t, metric.Struct(tcm),
+		registry.ClusterMetrics().JobSpecificMetrics[jobspb.TypeImport])
+
+	tcm.Counter.Inc(42)
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	execCfg.ClusterMetricsWriter.(*cmwriter.Writer).Flush(ctx)
+
+	runner := sqlutils.MakeSQLRunner(s.SQLConn(t))
+	var value int64
+	runner.QueryRow(t,
+		`SELECT value FROM system.cluster_metrics WHERE name = $1`,
+		metricName,
+	).Scan(&value)
+	require.Equal(t, int64(42), value)
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1257,6 +1257,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	cfg.registry.AddMetricStruct(clusterMetricsWriter.Metrics())
 	execCfg.ClusterMetricsWriter = clusterMetricsWriter
 
+	// Register job cluster metrics with writer.
+	clusterMetricsWriter.AddMetricStruct(jobRegistry.ClusterMetrics())
+
 	execCfg.IndexBackfiller = sql.NewIndexBackfiller(execCfg)
 	execCfg.IndexSpanSplitter = sql.NewIndexSplitAndScatter(execCfg)
 	execCfg.IndexMerger = sql.NewIndexBackfillerMergePlanner(execCfg)


### PR DESCRIPTION
This patch does some refactoring and plumbing necessary to allow jobs to register cluster-wide metrics using the new `clustermetrics` system.

Informs: #169173

Release note: None