### PR TITLE
build: stop tagging release-staging in make-and-publish-build-start

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-start.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-start.sh
@@ -18,14 +18,9 @@ fi
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
 
-github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY:?GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY must be specified}"
 metadata_gcs_bucket="cockroach-release-qualification-prod"
 metadata_google_credentials="$GCS_CREDENTIALS_PROD"
 build_name="$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)"
-
-configure_git_ssh_key
-git tag "${build_name}"
-git_wrapped push ssh://git@github.com/cockroachlabs/release-staging.git "${build_name}"
 
 # Publish build metadata to a stable location.
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Tags in the release-staging repo are no longer used for releases, so creating and pushing them from the build-start step is dead work. Drop the tag/push along with the SSH key setup that only existed for the push. The build_name value still populates the 'tag' field in the metadata JSON published to GCS, which preserves the existing contract for downstream consumers.

Epic: none
Release note: None