### PR TITLE
kvstorage: retain applied raft log prefix in RewriteRaftState

### DIFF
--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -256,13 +256,19 @@ func RemoveStaleRHSFromSplit(
 
 // RewriteRaftState rewrites the raft state of the given replica with the
 // provided state. Specifically, it rewrites HardState and RaftTruncatedState,
-// and clears the raft log. All writes are generated in the engine keys order.
+// and clears raft log entries in (clearAfter, MaxUint64]. When clearAfter is 0,
+// the entire log is cleared. All writes are generated in the engine keys order.
+//
+// With separated engines, clearAfter should be set to the applied index so that
+// only the unapplied suffix of the log is cleared. The applied prefix is left
+// for WAG garbage collection.
 func RewriteRaftState(
 	ctx context.Context,
 	raftWO RaftWO,
 	sl logstore.StateLoader,
 	hs raftpb.HardState,
 	ts kvserverpb.RaftTruncatedState,
+	clearAfter kvpb.RaftIndex,
 ) error {
 	// Update HardState.
 	if err := sl.SetHardState(ctx, raftWO, hs); err != nil {
@@ -272,11 +278,9 @@ func RewriteRaftState(
 	// keys in this span. We use ClearRangeSizeKnown with pointKeyThreshold=0 to
 	// force a single range tombstone over the whole log span, without scanning.
 	// TODO(ibrahim): We can actually know the log bounds using truncIndex and lastIndex.
-	// TODO(sep-raft-log): delegate clearing <= AppliedIndex to WAG cleanup when engines
-	// are separated.
 	if err := logstore.ClearRangeSizeKnown(
 		raftWO, sl.RangeIDPrefixBuf,
-		0 /* lo */, math.MaxUint64 /* hi */, 0, /* pointKeyThreshold */
+		clearAfter /* lo */, math.MaxUint64 /* hi */, 0, /* pointKeyThreshold */
 		false, /* maybeUseSingleDel */
 	); err != nil {
 		return errors.Wrapf(err, "unable to clear the raft log")

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -615,12 +615,13 @@ func (r *Replica) applySnapshotRaftMuLocked(
 		}
 	}
 	if err := sw.prepareSnapApply(ctx, snapWrite{
-		sl:         r.raftMu.stateLoader.StateLoader,
-		truncState: truncState,
-		hardState:  hs,
-		desc:       desc,
-		origDesc:   r.shMu.state.Desc,
-		subsume:    subsume, // NB: ordered by StartKey
+		sl:               r.raftMu.stateLoader.StateLoader,
+		truncState:       truncState,
+		hardState:        hs,
+		desc:             desc,
+		origDesc:         r.shMu.state.Desc,
+		raftAppliedIndex: r.shMu.state.RaftAppliedIndex,
+		subsume:          subsume, // NB: ordered by StartKey
 	}); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -8,6 +8,7 @@ package kvserver
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
@@ -228,6 +229,10 @@ type snapWrite struct {
 	hardState  raftpb.HardState
 	desc       *roachpb.RangeDescriptor // corresponds to the range descriptor in the snapshot
 	origDesc   *roachpb.RangeDescriptor // pre-snapshot range descriptor
+	// raftAppliedIndex is the replica's applied index before the snapshot. With
+	// separated engines, only the unapplied log suffix (after this index) is
+	// cleared; the applied prefix is left for WAG garbage collection.
+	raftAppliedIndex kvpb.RaftIndex
 	// NB: subsume must be in sorted order by DestroyReplicaInfo start key.
 	subsume []kvstorage.DestroyReplicaInfo
 }
@@ -321,14 +326,16 @@ func (s *snapWriter) prepareSnapApply(ctx context.Context, sw snapWrite) error {
 // The method knows how to handle separated and single engine, so that the
 // caller is not concerned about it.
 func (s *snapWriter) rewriteRaftState(ctx context.Context, sw *snapWrite) error {
-	// If engines are separated, write directly to the raft engine batch.
+	// If engines are separated, write directly to the raft engine batch. Only
+	// clear the unapplied suffix of the log; the applied prefix is left for WAG
+	// garbage collection.
 	if s.raftWO != nil {
-		return kvstorage.RewriteRaftState(ctx, kvstorage.RaftWO(s.raftWO), sw.sl, sw.hardState, sw.truncState)
+		return kvstorage.RewriteRaftState(ctx, kvstorage.RaftWO(s.raftWO), sw.sl, sw.hardState, sw.truncState, sw.raftAppliedIndex)
 	}
 	// Otherwise, write to an SSTable in the state machine engine, or s.batch if
 	// applying the snapshot as a batch.
 	return s.writeSST(ctx, func(ctx context.Context, w storage.Writer) error {
-		return kvstorage.RewriteRaftState(ctx, kvstorage.RaftWO(w), sw.sl, sw.hardState, sw.truncState)
+		return kvstorage.RewriteRaftState(ctx, kvstorage.RaftWO(w), sw.sl, sw.hardState, sw.truncState, 0 /* clearAfter */)
 	})
 }
 

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -145,6 +145,11 @@ func testPrepareSnapApply(t *testing.T, separateEngines bool) {
 	createRaftState(t, eng.LogEngine(), descA.RangeID)
 	createRangeData(t, eng.StateEngine(), *descB)
 	createRaftState(t, eng.LogEngine(), descB.RangeID)
+	// Create raft state for the main replica too, so that the log clearing is
+	// exercised. The applied index is set to truncIndex+1 so that in the
+	// separated engines case, entries at and below it are retained for WAG GC.
+	createRaftState(t, eng.LogEngine(), id.RangeID)
+	const raftAppliedIndex kvpb.RaftIndex = 11 // truncIndex(10) + 1
 
 	sl := kvstorage.MakeStateLoader(id.RangeID)
 	ctx := context.Background()
@@ -187,11 +192,12 @@ func testPrepareSnapApply(t *testing.T, separateEngines bool) {
 		writeSST: writeSST,
 	}
 	require.NoError(t, sw.prepareSnapApply(ctx, snapWrite{
-		sl:         sl.StateLoader,
-		truncState: kvserverpb.RaftTruncatedState{Index: 100, Term: 20},
-		hardState:  raftpb.HardState{Term: 20, Commit: 100},
-		desc:       snapDesc,
-		origDesc:   origDesc,
+		sl:               sl.StateLoader,
+		truncState:       kvserverpb.RaftTruncatedState{Index: 100, Term: 20},
+		hardState:        raftpb.HardState{Term: 20, Commit: 100},
+		desc:             snapDesc,
+		origDesc:         origDesc,
+		raftAppliedIndex: raftAppliedIndex,
 		subsume: []kvstorage.DestroyReplicaInfo{
 			{FullReplicaID: roachpb.FullReplicaID{RangeID: descA.RangeID, ReplicaID: replicaID}, Keys: descA.RSpan()},
 			{FullReplicaID: roachpb.FullReplicaID{RangeID: descB.RangeID, ReplicaID: replicaID}, Keys: descB.RSpan()},

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply/sep-eng=true
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply/sep-eng=true
@@ -15,7 +15,7 @@ Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x0
 Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109): 
 >> raft:
 Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vote:0 commit:100 lead:0 lead_epoch:0 
-Delete Range: [0,0 /Local/RangeID/123/u/RaftLog (0x0169f67b757266746c00): , 0,0 /Local/RangeID/123/u"rftm" (0x0169f67b757266746d00): )
+Delete Range: [0,0 /Local/RangeID/123/u/RaftLog/logIndex:12 (0x0169f67b757266746c000000000000000c00): , 0,0 /Local/RangeID/123/u"rftm" (0x0169f67b757266746d00): )
 Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 Delete (Sized at 38): 0,0 /Local/RangeID/101/u/RaftHardState (0x0169ed757266746800): 
 Delete (Sized at 42): 0,0 /Local/RangeID/101/u/RaftLog/logIndex:11 (0x0169ed757266746c000000000000000b00): 


### PR DESCRIPTION
With separated engines, `RewriteRaftState` now only clears the unapplied suffix of the raft log (entries after the applied index), matching the pattern already used by `destroyReplicaImpl`. The applied prefix is left for WAG garbage collection.

A new `clearAfter` parameter controls the lower bound: when 0, the entire log is cleared (single-engine behavior); when set to the applied index, only the unapplied tail is removed.

Epic: CRDB-49113