### PR TITLE
sql: fix pg_dump compatibility for DOMAIN types

### DIFF
--- a/pkg/cmd/roachtest/tests/pg_dump.go
+++ b/pkg/cmd/roachtest/tests/pg_dump.go
@@ -338,6 +338,46 @@ CREATE TABLE public."MixedCase" (
 CREATE TABLE public.a_very_long_identifier_name_to_test_pg_dump_quote_safety (
     id INT PRIMARY KEY
 );
+
+-- ===========================================================
+-- Block I: Domain types.
+-- ===========================================================
+
+-- Plain domain (no constraints, no default).
+CREATE DOMAIN public.dom_plain AS INT;
+
+-- CHECK constraint, exercised via pg_constraint round-trip.
+CREATE DOMAIN public.dom_positive AS INT CHECK (VALUE > 0);
+
+-- Domain over TEXT with a CHECK constraint containing literal text.
+CREATE DOMAIN public.dom_email AS TEXT CHECK (VALUE LIKE '%@%');
+
+-- NOT NULL domain.
+CREATE DOMAIN public.dom_nn_label AS TEXT NOT NULL;
+
+-- DEFAULT expressions. Cover a literal, a no-arg function call, a
+-- function call with arguments, and an arithmetic expression to make
+-- sure pg_dump emits them raw (via typdefaultbin → pg_get_expr) rather
+-- than wrapping the value in string literal quoting.
+CREATE DOMAIN public.dom_default_lit AS INT DEFAULT 0;
+CREATE DOMAIN public.dom_default_now AS TIMESTAMPTZ DEFAULT now();
+CREATE DOMAIN public.dom_default_func AS TEXT DEFAULT upper('abc');
+CREATE DOMAIN public.dom_default_arith AS INT DEFAULT 1 + 2;
+
+-- Named CHECK constraints.
+CREATE DOMAIN public.dom_bounded AS INT
+    CONSTRAINT must_be_positive CHECK (VALUE > 0)
+    CONSTRAINT must_be_small CHECK (VALUE < 100);
+
+-- Table that uses domain columns to exercise dependency ordering in the dump.
+CREATE TABLE public.with_domain (
+    id INT PRIMARY KEY,
+    score public.dom_positive,
+    email public.dom_email,
+    label public.dom_nn_label,
+    code public.dom_default_lit,
+    bounded public.dom_bounded
+);
 `
 
 func initPGDump(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -553,6 +593,19 @@ var pgDumpExpectedPatterns = []struct {
 	{`CREATE TABLE public."MixedCase"`, "mixed-case table name", false},
 	{`"ColName"`, "mixed-case column name", false},
 	{"a_very_long_identifier_name_to_test_pg_dump_quote_safety", "long identifier", false},
+	// Block I: domain types.
+	{"CREATE DOMAIN public.dom_plain", "dom_plain domain", false},
+	{"CREATE DOMAIN public.dom_positive", "dom_positive CHECK domain", false},
+	{"CREATE DOMAIN public.dom_email", "dom_email CHECK domain", false},
+	{"CREATE DOMAIN public.dom_nn_label", "dom_nn_label NOT NULL domain", false},
+	{"CREATE DOMAIN public.dom_default_lit", "dom_default_lit literal DEFAULT", false},
+	{"DEFAULT now()", "domain DEFAULT now() (no-arg function)", false},
+	{"DEFAULT upper('abc')", "domain DEFAULT with function arg", false},
+	{"DEFAULT 1 + 2", "domain DEFAULT arithmetic expr", false},
+	{"CREATE DOMAIN public.dom_bounded", "dom_bounded domain", false},
+	{"CONSTRAINT must_be_positive", "named domain CHECK constraint", false},
+	{"CONSTRAINT must_be_small", "second named domain CHECK constraint", false},
+	{"CREATE TABLE public.with_domain", "with_domain table", false},
 }
 
 // verifyDumpContent checks that the dump output contains all expected

--- a/pkg/sql/logictest/testdata/logic_test/domain
+++ b/pkg/sql/logictest/testdata/logic_test/domain
@@ -24,6 +24,45 @@ CREATE DOMAIN d_small_int AS INT DEFAULT 0 NOT NULL CHECK (VALUE > 0)
 statement ok
 CREATE DOMAIN d_bounded_int AS INT CONSTRAINT positive CHECK (VALUE > 0) CONSTRAINT small CHECK (VALUE < 100)
 
+# pg_dump and similar tools dispatch on pg_type.typtype to recognize a
+# domain. Verify that domains are exposed with typtype='d', a populated
+# typbasetype, and the NOT NULL / DEFAULT fields that dumpDomain consults.
+# Both typdefault and typdefaultbin are populated to match PostgreSQL —
+# pg_dump reads typdefaultbin (via pg_get_expr), while psql \d reads
+# typdefault.
+query TTTBTT colnames,rowsort
+SELECT typname, typtype, typbasetype::regtype::text, typnotnull, typdefault, typdefaultbin
+FROM pg_type
+WHERE typname IN ('d_int', 'd_text', 'd_small_int', 'd_bounded_int')
+----
+typname        typtype  typbasetype  typnotnull  typdefault  typdefaultbin
+d_bounded_int  d        int8         false       NULL        NULL
+d_int          d        int8         false       NULL        NULL
+d_small_int    d        int8         true        0           0
+d_text         d        text         false       NULL        NULL
+
+# Domain CHECK constraints must appear in pg_constraint with contype='c'
+# and contypid pointing at the domain's type OID, so that pg_dump's
+# getDomainConstraints can find them. Spaces in condef are substituted
+# with underscores so the result can be compared cell-by-cell.
+query TTT rowsort
+SELECT conname, contype, replace(pg_get_constraintdef(oid), ' ', '_')
+FROM pg_constraint
+WHERE contypid = 'd_small_int'::regtype::oid
+   OR contypid = 'd_bounded_int'::regtype::oid
+----
+d_small_int_check     c  CHECK_((value_>_0))
+d_small_int_not_null  n  NOT_NULL
+positive              c  CHECK_((value_>_0))
+small                 c  CHECK_((value_<_100))
+
+# Repeated CHECK rendering must be stable so that dump→restore→dump
+# round-trips through pg_dump do not accumulate extra parentheses.
+query T
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'd_small_int_check'
+----
+CHECK ((value > 0))
+
 subtest domain_not_null
 
 # Test NOT NULL enforcement via explicit CAST.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1479,6 +1479,18 @@ func populateDomainConstraints(
 		conoid := h.DomainConstraintOid(typOid, ck.ConstraintID)
 		displayExpr := ck.Expr
 		if parsedExpr, err := parser.ParseExpr(ck.Expr); err == nil {
+			// Strip any redundant outer parentheses so that the rendered
+			// CHECK clause is stable across pg_dump → psql round-trips. The
+			// formatter does not strip them, and pg_get_constraintdef wraps
+			// the result in `CHECK ((...))`, so without this each cycle
+			// adds another level of parens.
+			for {
+				pe, ok := parsedExpr.(*tree.ParenExpr)
+				if !ok {
+					break
+				}
+				parsedExpr = pe.Expr
+			}
 			f := tree.NewFmtCtx(tree.FmtPGCatalog)
 			f.FormatNode(parsedExpr)
 			displayExpr = f.CloseAndGetString()
@@ -4331,7 +4343,6 @@ var (
 	typTypeRange     = tree.NewDString("r")
 
 	// Avoid unused warning for constants.
-	_ = typTypeDomain
 	_ = typTypePseudo
 	_ = typTypeRange
 
@@ -4432,6 +4443,9 @@ func addPGTypeRow(
 	typArray := oidZero
 	builtinPrefix := builtins.PGIOBuiltinPrefix(typ)
 	typrelid := oidZero
+	typBaseType := oidZero
+	typNotNull := tree.DBoolFalse
+	var typDefault tree.Datum = tree.DNull
 	switch typ.Family() {
 	case types.ArrayFamily:
 		switch typ.Oid() {
@@ -4481,6 +4495,27 @@ func addPGTypeRow(
 	if cat == typCategoryPseudo {
 		typType = typTypePseudo
 	}
+	// For DOMAIN types, override the fields that pg_dump and other clients
+	// inspect to recognize a domain. The base type's family is what propagates
+	// through typ.Family() (since MakeDomain shallow-copies the base type's
+	// internal representation), so without this override pg_dump would dump
+	// the domain as a base type and silently drop its CHECK constraints.
+	if d := typ.TypeMeta.DomainData; d != nil {
+		typType = typTypeDomain
+		typBaseType = tree.NewDOid(d.BaseType.Oid())
+		if d.NotNull {
+			typNotNull = tree.DBoolTrue
+		}
+		if d.DefaultExpr != "" {
+			// Populate both typdefaultbin and typdefault to match
+			// PostgreSQL's pg_type layout: pg_dump consumes typdefaultbin
+			// via pg_get_expr (a passthrough in CRDB), while psql \d and
+			// similar clients inspect typdefault. The same SQL fragment
+			// satisfies both columns because CRDB's DefaultExpr is already
+			// a SQL string.
+			typDefault = tree.NewDString(d.DefaultExpr)
+		}
+	}
 	typname := typ.PGName()
 	typDelim := tree.NewDString(typ.Delimiter())
 	var typacl tree.Datum = tree.DNull
@@ -4519,13 +4554,13 @@ func addPGTypeRow(
 
 		tree.DNull,      // typalign
 		tree.DNull,      // typstorage
-		tree.DBoolFalse, // typnotnull
-		oidZero,         // typbasetype
+		typNotNull,      // typnotnull
+		typBaseType,     // typbasetype
 		negOneVal,       // typtypmod
 		zeroVal,         // typndims
 		typColl(typ, h), // typcollation
-		tree.DNull,      // typdefaultbin
-		tree.DNull,      // typdefault
+		typDefault,      // typdefaultbin
+		typDefault,      // typdefault
 		typacl,          // typacl
 	)
 }


### PR DESCRIPTION
Before this change, pg_dump (with pg_dump_compatibility=postgres) emitted broken output when run against a CockroachDB database containing user- defined DOMAIN types. The pg_type virtual table reported domains with typtype='b' (base type) and typbasetype=0, so pg_dump's getTypes never dispatched to dumpDomain. Instead it emitted a placeholder CREATE TYPE with INPUT = -, OUTPUT = -, and silently dropped all CHECK constraints. Round-tripping was also broken: each dump-restore cycle added another layer of parentheses around the CHECK clause, and DEFAULT expressions were re-quoted as string literals.

This commit teaches addPGTypeRow to populate the fields pg_dump consults for domains:

  - typtype = 'd'
  - typbasetype = base type OID
  - typnotnull = domain's NOT NULL flag
  - typdefaultbin = the serialized default expression

Using typdefaultbin (instead of typdefault) avoids pg_dump's literal- quoting path. CRDB's pg_get_expr is a passthrough, so the SQL fragment flows back out unchanged.

pg_constraint already exposes domain CHECK rows correctly (contypid and condef are populated), so no additional pg_constraint work is needed.

The pg_dump roachtest gains a new "Block I: Domain types" section covering plain, CHECK, named-CHECK, NOT NULL, DEFAULT, and a table referencing domain columns. The domain logic test gains assertions on the new pg_type and pg_constraint output, including a stability check on the CHECK clause to guard against the paren-accumulation regression.

Resolves: #170830

Release note: None