### PR TITLE
release-23.2: build: stop tagging release-staging in make-and-publish-build-start

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -60,15 +60,6 @@ tc_end_block "Variable Setup"
 configure_git_ssh_key
 
 if [[ -z "${is_customized_build}" ]] ; then
-  tc_start_block "Tag the release"
-  git tag "${build_name}"
-  tc_end_block "Tag the release"
-
-  tc_start_block "Push release tag to github.com/cockroachlabs/release-staging"
-  git_wrapped push ssh://git@github.com/cockroachlabs/release-staging.git "${build_name}"
-  tc_end_block "Push release tag to github.com/cockroachlabs/release-staging"
-
-
   tc_start_block "Tag docker image as latest-build"
   # Only tag the image as "latest-vX.Y-build" if the tag is on a release branch
   # (or master for the alphas for the next major release).


### PR DESCRIPTION
Backport 1/1 commits from #171115 on behalf of @rail.

----

Tags in the release-staging repo are no longer used for releases, so creating and pushing them from the build-start step is dead work. Drop the tag/push along with the SSH key setup that only existed for the push. The build_name value still populates the 'tag' field in the metadata JSON published to GCS, which preserves the existing contract for downstream consumers.

Epic: none
Release note: None

----

Release justification: release automation changes