### PR TITLE
sql/schemachanger: implement trivial CREATE TABLE in the DSC

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -743,6 +743,34 @@ func TestBackupRollbacks_base_create_sequence_drop_sequence(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacks_base_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacks_base_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacks_base_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_create_temp_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1671,6 +1699,34 @@ func TestBackupRollbacksMixedVersion_base_create_sequence_drop_sequence(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2605,6 +2661,34 @@ func TestBackupSuccess_base_create_sequence_drop_sequence(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccess_base_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccess_base_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccess_base_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_create_temp_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3533,6 +3617,34 @@ func TestBackupSuccessMixedVersion_base_create_sequence_drop_sequence(t *testing
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1640,22 +1640,13 @@ SET use_declarative_schema_changer = $use_decl_sc
 
 subtest end
 
-subtest create_table_unsafe_always
+subtest create_view_unsafe_always
 
 let $use_decl_sc
 SHOW use_declarative_schema_changer
 
 statement ok
 SET use_declarative_schema_changer = 'unsafe_always'
-
-statement error pq: \*tree.CreateTable not implemented in the new schema changer
-EXPLAIN (DDL) CREATE TABLE test_table(log int)
-
-statement error pq: \*tree.CreateTable not implemented in the new schema changer
-CREATE TABLE test_table(log int)
-
-statement error pq: \*tree.CreateTable not implemented in the new schema changer
-CREATE TABLE test_table_as AS SELECT 1 AS log
 
 statement error pq: \*tree.CreateView not implemented in the new schema changer
 CREATE VIEW test_view AS SELECT 1 AS log
@@ -1664,3 +1655,4 @@ statement ok
 SET use_declarative_schema_changer = $use_decl_sc
 
 subtest end
+

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_table.go
@@ -7,27 +7,362 @@ package scbuildstmt
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdecomp"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
-// createTableChecks is the cheap prefilter that decides whether CREATE TABLE
-// should be handled by the declarative schema changer. The dispatcher in
-// process.go calls it before resolving any descriptors, and a return of false
-// routes the statement back to the legacy schema changer.
+// createTableChecks returns true iff CREATE TABLE should be handled by the
+// declarative schema changer. A return of false routes the statement to the
+// legacy schema changer.
 func createTableChecks(
 	n *tree.CreateTable,
 	mode sessiondatapb.NewSchemaChangerMode,
 	activeVersion clusterversion.ClusterVersion,
 ) bool {
-	return false
+	if mode != sessiondatapb.UseNewSchemaChangerUnsafeAlways {
+		return false
+	}
+	if n.Persistence != tree.PersistencePermanent {
+		return false
+	}
+	if n.AsSource != nil {
+		return false
+	}
+	if n.PartitionByTable != nil {
+		return false
+	}
+	if n.Locality != nil {
+		return false
+	}
+	if len(n.StorageParams) > 0 {
+		return false
+	}
+	if n.OnCommit != tree.CreateTableOnCommitUnset {
+		return false
+	}
+
+	primaryKeyCount := 0
+	for _, def := range n.Defs {
+		col, ok := def.(*tree.ColumnTableDef)
+		if !ok {
+			// Non-*tree.ColumnTableDef defs all fall back for now.
+			return false
+		}
+		if !isSupportedColumnTableDef(col) {
+			return false
+		}
+		if col.PrimaryKey.IsPrimaryKey {
+			primaryKeyCount++
+		}
+	}
+	if primaryKeyCount > 1 {
+		// Composite inline primary keys fall back for now.
+		return false
+	}
+	return true
+}
+
+// isSupportedColumnTableDef returns true iff the column definition is within
+// the DSC's supported surface.
+func isSupportedColumnTableDef(col *tree.ColumnTableDef) bool {
+	if col.IsSerial {
+		return false
+	}
+	if col.GeneratedIdentity.IsGeneratedAsIdentity {
+		return false
+	}
+	if col.Hidden {
+		return false
+	}
+	if col.Unique.IsUnique {
+		return false
+	}
+	if col.DefaultExpr.Expr != nil {
+		return false
+	}
+	if col.OnUpdateExpr.Expr != nil {
+		return false
+	}
+	if len(col.CheckExprs) > 0 {
+		return false
+	}
+	if col.References.Table != nil {
+		return false
+	}
+	if col.Computed.Computed {
+		return false
+	}
+	if col.Family.Name != "" || col.Family.Create {
+		return false
+	}
+	if col.PrimaryKey.Sharded {
+		return false
+	}
+	return true
 }
 
 // CreateTable implements CREATE TABLE in the declarative schema changer.
-// Unsupported statements panic NotImplementedError; the panic is recovered in
-// schema_change_plan_node.go and routed to the legacy planner.
+// Statements outside the supported surface either fall back via
+// createTableChecks or, for issues that require descriptor resolution
+// (multi-region database, non-scalar column type), panic NotImplementedError.
 func CreateTable(b BuildCtx, n *tree.CreateTable) {
-	panic(scerrors.NotImplementedErrorf(n,
-		"create table is not yet supported in the declarative schema changer"))
+	dbElts, scElts := b.ResolveTargetObject(n.Table.ToUnresolvedObjectName(), privilege.CREATE)
+	dbElement := dbElts.FilterDatabase().MustGetOneElement()
+	schemaElement := scElts.FilterSchema().MustGetOneElement()
+	dbNamespace := dbElts.FilterNamespace().MustGetOneElement()
+	scNamespace := scElts.FilterNamespace().MustGetOneElement()
+
+	if regionConfig := dbElts.FilterDatabaseRegionConfig().MustGetZeroOrOneElement(); regionConfig != nil {
+		panic(scerrors.NotImplementedErrorf(n,
+			"create table is not yet supported on multi-region clusters"))
+	}
+
+	// Normalize the table name now that we know the database and schema.
+	n.Table.SchemaName = tree.Name(scNamespace.Name)
+	n.Table.CatalogName = tree.Name(dbNamespace.Name)
+	n.Table.ExplicitCatalog = true
+	n.Table.ExplicitSchema = true
+
+	// Existence check. ResolveTypes catches collisions with type names too.
+	existing := b.ResolveRelation(n.Table.ToUnresolvedObjectName(), ResolveParams{
+		IsExistenceOptional: true,
+		RequiredPrivilege:   privilege.USAGE,
+		WithOffline:         true,
+		ResolveTypes:        true,
+	})
+	if existing != nil && !existing.IsEmpty() {
+		if n.IfNotExists {
+			return
+		}
+		panic(sqlerrors.NewRelationAlreadyExistsError(n.Table.FQString()))
+	}
+
+	// Resolve types before allocating a descriptor ID so that an unsupported
+	// type (UDT, array, etc.) falls back to legacy without burning the ID.
+	resolvedTypes := make([]*types.T, len(n.Defs))
+	for i, def := range n.Defs {
+		col := def.(*tree.ColumnTableDef)
+		typ, err := tree.ResolveType(b, col.Type, b.SemaCtx().TypeResolver)
+		if err != nil {
+			panic(err)
+		}
+		if !isSupportedScalarType(typ) {
+			panic(scerrors.NotImplementedErrorf(n,
+				redact.Sprintf("create table column type %s is not yet supported in the declarative schema changer",
+					redact.SafeString(typ.SQLString()))))
+		}
+		resolvedTypes[i] = typ
+	}
+
+	tableID := b.GenerateUniqueDescID()
+	b.IncrementSchemaChangeCreateCounter("table")
+
+	// Table-level elements.
+	tableElem := &scpb.Table{TableID: tableID}
+	b.Add(tableElem)
+	b.Add(&scpb.Namespace{
+		DatabaseID:   dbElement.DatabaseID,
+		SchemaID:     schemaElement.SchemaID,
+		DescriptorID: tableID,
+		Name:         string(n.Table.ObjectName),
+	})
+	b.Add(&scpb.SchemaChild{
+		ChildObjectID: tableID,
+		SchemaID:      schemaElement.SchemaID,
+	})
+	b.Add(&scpb.TableData{
+		TableID:    tableID,
+		DatabaseID: dbElement.DatabaseID,
+	})
+
+	// Walk the user-defined columns. Column IDs start at 1.
+	var primaryKeyColumnID catid.ColumnID
+	var storedColumnIDs []catid.ColumnID
+	nextColumnID := catid.ColumnID(1)
+	for i, def := range n.Defs {
+		col := def.(*tree.ColumnTableDef)
+		columnID := nextColumnID
+		nextColumnID++
+		addUserColumn(b, tableID, columnID, col, resolvedTypes[i])
+		if col.PrimaryKey.IsPrimaryKey {
+			primaryKeyColumnID = columnID
+		} else {
+			storedColumnIDs = append(storedColumnIDs, columnID)
+		}
+	}
+
+	// Primary index: an explicit single-column PK if the user gave one, else
+	// the implicit rowid path. The index name follows the legacy convention.
+	pkIndexName := tabledesc.PrimaryKeyIndexName(string(n.Table.ObjectName))
+	if primaryKeyColumnID != 0 {
+		addUserPrimaryKey(b, tableID, pkIndexName, primaryKeyColumnID, storedColumnIDs)
+	} else {
+		addImplicitRowIDPrimaryKey(b, tableID, pkIndexName, nextColumnID, storedColumnIDs)
+	}
+
+	// Ownership and per-user privileges.
+	ownerElem, userPrivElems := b.BuildUserPrivilegesFromDefaultPrivileges(
+		dbElement, schemaElement, tableID, privilege.Tables, b.CurrentUser())
+	b.Add(ownerElem)
+	for _, p := range userPrivElems {
+		b.Add(p)
+	}
+
+	// External SQL sessions create tables as schema_locked unless the user
+	// opted out (same gate as the legacy path).
+	if !b.SessionData().Internal && b.SessionData().CreateTableWithSchemaLocked {
+		b.Add(&scpb.TableSchemaLocked{TableID: tableID})
+	}
+
+	b.LogEventForExistingTarget(tableElem)
+}
+
+// addUserColumn emits the elements for a single user-defined column. The
+// type must already be resolved and supported.
+func addUserColumn(
+	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID, def *tree.ColumnTableDef, typ *types.T,
+) {
+	b.Add(&scpb.Column{TableID: tableID, ColumnID: columnID})
+	b.Add(&scpb.ColumnType{
+		TableID:                 tableID,
+		ColumnID:                columnID,
+		TypeT:                   newTypeT(typ),
+		ElementCreationMetadata: scdecomp.NewElementCreationMetadata(b.EvalCtx().Settings.Version.ActiveVersion(b)),
+	})
+	b.Add(&scpb.ColumnName{
+		TableID:  tableID,
+		ColumnID: columnID,
+		Name:     string(def.Name),
+	})
+	// NOT NULL is emitted when the user asked for it explicitly OR when this
+	// is the inline primary-key column (PK columns must be NOT NULL).
+	if def.Nullable.Nullability == tree.NotNull || def.PrimaryKey.IsPrimaryKey {
+		b.Add(&scpb.ColumnNotNull{TableID: tableID, ColumnID: columnID})
+	}
+}
+
+// isSupportedScalarType returns true iff typ is within the DSC's supported
+// surface.
+func isSupportedScalarType(typ *types.T) bool {
+	switch typ.Family() {
+	case types.ArrayFamily,
+		types.TupleFamily,
+		types.EnumFamily,
+		types.CollatedStringFamily,
+		types.AnyFamily,
+		types.VoidFamily,
+		types.UnknownFamily:
+		return false
+	}
+	return !typ.UserDefined()
+}
+
+// addUserPrimaryKey emits the primary-index elements for an explicit
+// single-column inline PRIMARY KEY. storedColumnIDs is the STORE list.
+func addUserPrimaryKey(
+	b BuildCtx,
+	tableID catid.DescID,
+	indexName string,
+	keyColumnID catid.ColumnID,
+	storedColumnIDs []catid.ColumnID,
+) {
+	addPrimaryIndexElements(b, tableID, indexName, []catid.ColumnID{keyColumnID}, storedColumnIDs)
+}
+
+// addImplicitRowIDPrimaryKey emits the hidden rowid column and the primary
+// index over it when the user did not specify a primary key.
+func addImplicitRowIDPrimaryKey(
+	b BuildCtx,
+	tableID catid.DescID,
+	indexName string,
+	rowIDColumnID catid.ColumnID,
+	storedColumnIDs []catid.ColumnID,
+) {
+	b.Add(&scpb.Column{
+		TableID:  tableID,
+		ColumnID: rowIDColumnID,
+	})
+	b.Add(&scpb.ColumnHidden{
+		TableID:  tableID,
+		ColumnID: rowIDColumnID,
+	})
+	b.Add(&scpb.ColumnType{
+		TableID:                 tableID,
+		ColumnID:                rowIDColumnID,
+		TypeT:                   newTypeT(types.Int),
+		ElementCreationMetadata: scdecomp.NewElementCreationMetadata(b.EvalCtx().Settings.Version.ActiveVersion(b)),
+	})
+	b.Add(&scpb.ColumnNotNull{TableID: tableID, ColumnID: rowIDColumnID})
+	b.Add(&scpb.ColumnName{
+		TableID:  tableID,
+		ColumnID: rowIDColumnID,
+		Name:     "rowid",
+	})
+	// unique_rowid() default expression; see
+	// alter_table_alter_column_set_default.go for the canonical idiom.
+	rowIDExpr, err := parser.ParseExpr("unique_rowid()")
+	if err != nil {
+		panic(errors.NewAssertionErrorWithWrappedErrf(err, "parsing unique_rowid()"))
+	}
+	b.Add(&scpb.ColumnDefaultExpression{
+		TableID:    tableID,
+		ColumnID:   rowIDColumnID,
+		Expression: *b.WrapExpression(tableID, rowIDExpr),
+	})
+	addPrimaryIndexElements(b, tableID, indexName, []catid.ColumnID{rowIDColumnID}, storedColumnIDs)
+}
+
+// addPrimaryIndexElements emits PrimaryIndex, IndexName, and IndexColumn
+// elements for the freshly-created table's primary index (always ID=1).
+func addPrimaryIndexElements(
+	b BuildCtx,
+	tableID catid.DescID,
+	indexName string,
+	keyColumnIDs []catid.ColumnID,
+	storedColumnIDs []catid.ColumnID,
+) {
+	const primaryIndexID = catid.IndexID(1)
+	b.Add(&scpb.PrimaryIndex{
+		Index: scpb.Index{
+			TableID:  tableID,
+			IndexID:  primaryIndexID,
+			IsUnique: true,
+		},
+	})
+	b.Add(&scpb.IndexName{
+		TableID: tableID,
+		IndexID: primaryIndexID,
+		Name:    indexName,
+	})
+	for ord, colID := range keyColumnIDs {
+		b.Add(&scpb.IndexColumn{
+			TableID:       tableID,
+			IndexID:       primaryIndexID,
+			ColumnID:      colID,
+			OrdinalInKind: uint32(ord),
+			Kind:          scpb.IndexColumn_KEY,
+			Direction:     catenumpb.IndexColumn_ASC,
+		})
+	}
+	for ord, colID := range storedColumnIDs {
+		b.Add(&scpb.IndexColumn{
+			TableID:       tableID,
+			IndexID:       primaryIndexID,
+			ColumnID:      colID,
+			OrdinalInKind: uint32(ord),
+			Kind:          scpb.IndexColumn_STORED,
+		})
+	}
 }

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_create
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_create
@@ -11,10 +11,6 @@ CREATE TYPE typ AS ENUM('a','b');
 ----
 
 unimplemented
-CREATE TABLE t (i INT PRIMARY KEY);
-----
-
-unimplemented
 CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL, INDEX (i), UNIQUE INDEX (j));
 ----
 
@@ -31,10 +27,6 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT, FAMILY "primary" (i, j), FAMILY
 ----
 
 unimplemented
-CREATE TABLE IF NOT EXISTS t (i INT PRIMARY KEY);
-----
-
-unimplemented
 CREATE TEMPORARY TABLE t (i INT PRIMARY KEY);
 ----
 
@@ -44,4 +36,44 @@ CREATE UNLOGGED TABLE t (i INT PRIMARY KEY);
 
 unimplemented
 CREATE TABLE t AS SELECT 1 AS i;
+----
+
+unimplemented
+CREATE TABLE t (i SERIAL PRIMARY KEY);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 1);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY, j INT ON UPDATE 1);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY, j INT AS (i + 1) STORED);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY, j INT UNIQUE);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY, j INT CHECK (j > 0));
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY USING HASH);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY, j INT[]);
+----
+
+unimplemented
+CREATE TABLE t (i INT PRIMARY KEY) PARTITION BY LIST (i) (PARTITION p1 VALUES IN (1));
 ----

--- a/pkg/sql/schemachanger/scexec/scmutationexec/table.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/table.go
@@ -9,13 +9,48 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam/tablestorageparam"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
+
+// CreateTableDescriptor materializes a new table descriptor in the ADD state.
+// Subsequent ops on the Table ABSENT -> PUBLIC path fill in the rest.
+func (i *immediateVisitor) CreateTableDescriptor(
+	_ context.Context, op scop.CreateTableDescriptor,
+) error {
+	// Mirrors CreateSequenceDescriptor. PrimaryIndex must be seeded so that
+	// AllocateIDsWithoutValidation (called during column emission) does not
+	// assign ID=1 to the zero-valued placeholder, which would leave a stale
+	// entry alongside the real mutation and fail end-of-stage validation.
+	mut := tabledesc.NewBuilder(&descpb.TableDescriptor{
+		ParentID:      catid.InvalidDescID, // set by `SchemaParent` element
+		Name:          "",                  // set by `Namespace` element
+		ID:            op.TableID,
+		Privileges:    &catpb.PrivilegeDescriptor{Version: catpb.Version23_2}, // set by `UserPrivileges` and `Owner` elements
+		Version:       1,
+		FormatVersion: descpb.InterleavedFormatVersion,
+		PrimaryIndex: descpb.IndexDescriptor{
+			ID:           1,
+			Name:         tabledesc.LegacyPrimaryKeyIndexName,
+			Version:      descpb.LatestIndexDescriptorVersion,
+			EncodingType: catenumpb.PrimaryIndexEncoding,
+			ConstraintID: 1,
+			Unique:       true,
+		},
+		NextIndexID:      2,
+		NextConstraintID: 2,
+	}).BuildCreatedMutable()
+	mut.(*tabledesc.Mutable).State = descpb.DescriptorState_ADD
+	i.CreateDescriptor(mut)
+	return nil
+}
 
 func (i *immediateVisitor) AddTableZoneConfig(
 	ctx context.Context, op scop.AddTableZoneConfig,

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1131,6 +1131,13 @@ type CreateSequenceDescriptor struct {
 	Temporary  bool
 }
 
+// CreateTableDescriptor materializes a new table descriptor in the catalog in
+// the ADD state. Subsequent ops fill in the rest and transition it to PUBLIC.
+type CreateTableDescriptor struct {
+	immediateMutationOp
+	TableID descpb.ID
+}
+
 type SetSequenceOption struct {
 	immediateMutationOp
 	SequenceID descpb.ID

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -162,6 +162,7 @@ type ImmediateMutationVisitor interface {
 	RemoveOwner(context.Context, RemoveOwner) error
 	CreateSchemaDescriptor(context.Context, CreateSchemaDescriptor) error
 	CreateSequenceDescriptor(context.Context, CreateSequenceDescriptor) error
+	CreateTableDescriptor(context.Context, CreateTableDescriptor) error
 	SetSequenceOption(context.Context, SetSequenceOption) error
 	UnsetSequenceOption(context.Context, UnsetSequenceOption) error
 	MaybeUpdateSequenceValue(context.Context, MaybeUpdateSequenceValue) error
@@ -920,6 +921,11 @@ func (op CreateSchemaDescriptor) Visit(ctx context.Context, v ImmediateMutationV
 // Visit is part of the ImmediateMutationOp interface.
 func (op CreateSequenceDescriptor) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.CreateSequenceDescriptor(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op CreateTableDescriptor) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.CreateTableDescriptor(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table.go
@@ -14,9 +14,12 @@ func init() {
 	opRegistry.register((*scpb.Table)(nil),
 		toPublic(
 			scpb.Status_ABSENT,
-			to(scpb.Status_DROPPED,
-				emit(func(this *scpb.Table) *scop.NotImplemented {
-					return notImplemented(this)
+			equiv(scpb.Status_DROPPED),
+			to(scpb.Status_DESCRIPTOR_ADDED,
+				emit(func(this *scpb.Table) *scop.CreateTableDescriptor {
+					return &scop.CreateTableDescriptor{
+						TableID: this.TableID,
+					}
 				}),
 			),
 			to(scpb.Status_PUBLIC,
@@ -29,6 +32,7 @@ func init() {
 		),
 		toAbsent(
 			scpb.Status_PUBLIC,
+			equiv(scpb.Status_DESCRIPTOR_ADDED),
 			to(scpb.Status_DROPPED,
 				revertible(false),
 				emit(func(this *scpb.Table) *scop.MarkDescriptorAsDropped {

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -743,6 +743,34 @@ func TestEndToEndSideEffects_create_sequence_drop_sequence(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_create_temp_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1671,6 +1699,34 @@ func TestExecuteWithDMLInjection_create_sequence_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2605,6 +2661,34 @@ func TestGenerateSchemaChangeCorpus_create_sequence_drop_sequence(t *testing.T) 
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_create_temp_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3533,6 +3617,34 @@ func TestPause_create_sequence_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -4467,6 +4579,34 @@ func TestPauseMixedVersion_create_sequence_drop_sequence(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_create_temp_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -5395,6 +5535,34 @@ func TestRollback_create_sequence_drop_sequence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_create_table_if_not_exists(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_create_table_multi_col(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_create_table_simple_int(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_create_table_with_pk(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.definition
@@ -1,0 +1,9 @@
+setup
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (a INT);
+----
+
+test
+CREATE TABLE IF NOT EXISTS t1 (a INT);
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.explain
@@ -1,0 +1,15 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (a INT);
+
+/* test */
+EXPLAIN (DDL) CREATE TABLE IF NOT EXISTS t1 (a INT);
+----
+Schema change plan for CREATE TABLE IF NOT EXISTS ‹db›.‹public›.‹t1› (‹a› INT8);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ └── PreCommitPhase
+      └── Stage 1 of 1 in PreCommitPhase
+           └── 1 Mutation operation
+                └── UndoAllInTxnImmediateMutationOpSideEffects

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.explain_shape
@@ -1,0 +1,10 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (a INT);
+
+/* test */
+EXPLAIN (DDL, SHAPE) CREATE TABLE IF NOT EXISTS t1 (a INT);
+----
+Schema change plan for CREATE TABLE IF NOT EXISTS ‹db›.‹public›.‹t1› (‹a› INT8);
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_if_not_exists/create_table_if_not_exists.side_effects
@@ -1,0 +1,20 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (a INT);
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
++object {104 105 t1} -> 106
+
+/* test */
+CREATE TABLE IF NOT EXISTS t1 (a INT);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CREATE TABLE
+# end StatementPhase
+# begin PreCommitPhase
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DATABASE db;
+USE db;
+----
+
+test
+CREATE TABLE t2 (a INT NOT NULL, b STRING);
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.explain
@@ -1,0 +1,172 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+
+/* test */
+EXPLAIN (DDL) CREATE TABLE t2 (a INT NOT NULL, b STRING);
+----
+Schema change plan for CREATE TABLE ‹db›.‹public›.‹t2› (‹a› INT8 NOT NULL, ‹b› STRING);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 25 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Table:{DescID: 106 (t2+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (t2+), Name: "t2", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 106 (t2+), ReferencedDescID: 105 (public)}
+ │         │    ├── ABSENT → PUBLIC TableData:{DescID: 106 (t2+), ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t2+), ColumnID: 1 (a+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t2+), Name: "a", ColumnID: 1 (a+)}
+ │         │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t2+), ColumnID: 1 (a+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t2+), ColumnID: 2 (b+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 2 (b+), TypeName: "STRING"}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t2+), Name: "b", ColumnID: 2 (b+)}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t2+), ColumnID: 3 (rowid+)}
+ │         │    ├── ABSENT → PUBLIC ColumnHidden:{DescID: 106 (t2+), ColumnID: 3 (rowid+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 3 (rowid+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t2+), ColumnID: 3 (rowid+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t2+), Name: "rowid", ColumnID: 3 (rowid+)}
+ │         │    ├── ABSENT → PUBLIC ColumnDefaultExpression:{DescID: 106 (t2+), ColumnID: 3 (rowid+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 106 (t2+), IndexID: 1 (t2_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexName:{DescID: 106 (t2+), Name: "t2_pkey", IndexID: 1 (t2_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t2+), ColumnID: 3 (rowid+), IndexID: 1 (t2_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t2+), ColumnID: 1 (a+), IndexID: 1 (t2_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t2+), ColumnID: 2 (b+), IndexID: 1 (t2_pkey+)}
+ │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (t2+)}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t2+), Name: "admin"}
+ │         │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t2+), Name: "root"}
+ │         └── 38 Mutation operations
+ │              ├── CreateTableDescriptor {"TableID":106}
+ │              ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t2"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t2","SchemaID":105}}
+ │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":106,"SchemaID":105}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":106}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"a","TableID":106}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"b","TableID":106}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":106}}
+ │              ├── MakeColumnHidden {"ColumnID":3,"TableID":106}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":3,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":106}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":3,"TableID":106}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":106}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":1,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":106}
+ │              ├── UpdateOwner {"Owner":{"DescriptorID":106,"Owner":"root"}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":106}
+ │              ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":1,"TableID":106}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":3,"TableID":106}
+ │              ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":3,"TableID":106}
+ │              ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":106}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":106}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":106}
+ │              ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":106}
+ │              ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":106}
+ │              ├── SetIndexName {"IndexID":1,"Name":"t2_pkey","TableID":106}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+ │              └── MarkDescriptorAsPublic {"DescriptorID":106}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 25 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Table:{DescID: 106 (t2+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (t2+), Name: "t2", ReferencedDescID: 104 (db), IntValue: 105}
+      │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 106 (t2+), ReferencedDescID: 105 (public)}
+      │    │    ├── PUBLIC → ABSENT TableData:{DescID: 106 (t2+), ReferencedDescID: 104 (db)}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t2+), ColumnID: 1 (a+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t2+), Name: "a", ColumnID: 1 (a+)}
+      │    │    ├── PUBLIC → ABSENT ColumnNotNull:{DescID: 106 (t2+), ColumnID: 1 (a+), IndexID: 0}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t2+), ColumnID: 2 (b+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 2 (b+), TypeName: "STRING"}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t2+), Name: "b", ColumnID: 2 (b+)}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t2+), ColumnID: 3 (rowid+)}
+      │    │    ├── PUBLIC → ABSENT ColumnHidden:{DescID: 106 (t2+), ColumnID: 3 (rowid+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 3 (rowid+), TypeName: "INT8"}
+      │    │    ├── PUBLIC → ABSENT ColumnNotNull:{DescID: 106 (t2+), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t2+), Name: "rowid", ColumnID: 3 (rowid+)}
+      │    │    ├── PUBLIC → ABSENT ColumnDefaultExpression:{DescID: 106 (t2+), ColumnID: 3 (rowid+), Expr: unique_rowid()}
+      │    │    ├── PUBLIC → ABSENT PrimaryIndex:{DescID: 106 (t2+), IndexID: 1 (t2_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexName:{DescID: 106 (t2+), Name: "t2_pkey", IndexID: 1 (t2_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t2+), ColumnID: 3 (rowid+), IndexID: 1 (t2_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t2+), ColumnID: 1 (a+), IndexID: 1 (t2_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t2+), ColumnID: 2 (b+), IndexID: 1 (t2_pkey+)}
+      │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (t2+)}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (t2+), Name: "admin"}
+      │    │    └── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (t2+), Name: "root"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 25 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Table:{DescID: 106 (t2+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (t2+), Name: "t2", ReferencedDescID: 104 (db), IntValue: 105}
+           │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 106 (t2+), ReferencedDescID: 105 (public)}
+           │    ├── ABSENT → PUBLIC TableData:{DescID: 106 (t2+), ReferencedDescID: 104 (db)}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t2+), ColumnID: 1 (a+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t2+), Name: "a", ColumnID: 1 (a+)}
+           │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t2+), ColumnID: 1 (a+), IndexID: 0}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t2+), ColumnID: 2 (b+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 2 (b+), TypeName: "STRING"}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t2+), Name: "b", ColumnID: 2 (b+)}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t2+), ColumnID: 3 (rowid+)}
+           │    ├── ABSENT → PUBLIC ColumnHidden:{DescID: 106 (t2+), ColumnID: 3 (rowid+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t2+), ColumnFamilyID: 0, ColumnID: 3 (rowid+), TypeName: "INT8"}
+           │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t2+), ColumnID: 3 (rowid+), IndexID: 0}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t2+), Name: "rowid", ColumnID: 3 (rowid+)}
+           │    ├── ABSENT → PUBLIC ColumnDefaultExpression:{DescID: 106 (t2+), ColumnID: 3 (rowid+), Expr: unique_rowid()}
+           │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 106 (t2+), IndexID: 1 (t2_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexName:{DescID: 106 (t2+), Name: "t2_pkey", IndexID: 1 (t2_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t2+), ColumnID: 3 (rowid+), IndexID: 1 (t2_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t2+), ColumnID: 1 (a+), IndexID: 1 (t2_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t2+), ColumnID: 2 (b+), IndexID: 1 (t2_pkey+)}
+           │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (t2+)}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t2+), Name: "admin"}
+           │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t2+), Name: "root"}
+           └── 39 Mutation operations
+                ├── CreateTableDescriptor {"TableID":106}
+                ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t2"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t2","SchemaID":105}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"t2","TableID":106}
+                ├── SetObjectParentID {"ObjParent":{"ChildObjectID":106,"SchemaID":105}}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":106}}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":106}}
+                ├── SetColumnName {"ColumnID":1,"Name":"a","TableID":106}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+                ├── SetColumnName {"ColumnID":2,"Name":"b","TableID":106}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":106}}
+                ├── MakeColumnHidden {"ColumnID":3,"TableID":106}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":3,"TableID":106}}
+                ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":106}
+                ├── AddColumnDefaultExpression {"Default":{"ColumnID":3,"TableID":106}}
+                ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":106}}
+                ├── AddColumnToIndex {"ColumnID":3,"IndexID":1,"TableID":106}
+                ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":106}
+                ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":106}
+                ├── UpdateOwner {"Owner":{"DescriptorID":106,"Owner":"root"}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":106}
+                ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":1,"TableID":106}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":3,"TableID":106}
+                ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":3,"TableID":106}
+                ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":106}
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":106}
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":106}
+                ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":106}
+                ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":106}
+                ├── SetIndexName {"IndexID":1,"Name":"t2_pkey","TableID":106}
+                ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+                └── MarkDescriptorAsPublic {"DescriptorID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+
+/* test */
+EXPLAIN (DDL, SHAPE) CREATE TABLE t2 (a INT NOT NULL, b STRING);
+----
+Schema change plan for CREATE TABLE ‹db›.‹public›.‹t2› (‹a› INT8 NOT NULL, ‹b› STRING);
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_multi_col/create_table_multi_col.side_effects
@@ -1,0 +1,200 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
+
+/* test */
+CREATE TABLE t2 (a INT NOT NULL, b STRING);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CREATE TABLE
+increment telemetry for sql.schema.create_table
+## StatementPhase stage 1 of 1 with 38 MutationType ops
+add object namespace entry {104 105 t2} -> 106
+upsert descriptor #106
+  -
+  +table:
+  +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: a
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - id: 2
+  +    name: b
+  +    nullable: true
+  +    type:
+  +      family: StringFamily
+  +      oid: 25
+  +  - defaultExpr: unique_rowid()
+  +    hidden: true
+  +    id: 3
+  +    name: rowid
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  createAsOfTime: {}
+  +  families:
+  +  - columnIds:
+  +    - 1
+  +    - 2
+  +    - 3
+  +    columnNames:
+  +    - a
+  +    - b
+  +    - rowid
+  +    defaultColumnId: 1
+  +    name: primary
+  +  formatVersion: 3
+  +  id: 106
+  +  modificationTime: {}
+  +  mutations: []
+  +  name: t2
+  +  nextColumnId: 4
+  +  nextConstraintId: 2
+  +  nextFamilyId: 1
+  +  nextIndexId: 2
+  +  parentId: 104
+  +  primaryIndex:
+  +    constraintId: 1
+  +    encodingType: 1
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 1
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 3
+  +    keyColumnNames:
+  +    - rowid
+  +    name: t2_pkey
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnIds:
+  +    - 1
+  +    - 2
+  +    storeColumnNames:
+  +    - a
+  +    - b
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  replacementOf:
+  +    time: {}
+  +  unexposedParentSchemaId: 105
+  +  version: "1"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 39 MutationType ops
+add object namespace entry {104 105 t2} -> 106
+upsert descriptor #106
+  -
+  +table:
+  +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: a
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - id: 2
+  +    name: b
+  +    nullable: true
+  +    type:
+  +      family: StringFamily
+  +      oid: 25
+  +  - defaultExpr: unique_rowid()
+  +    hidden: true
+  +    id: 3
+  +    name: rowid
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  createAsOfTime: {}
+  +  families:
+  +  - columnIds:
+  +    - 1
+  +    - 2
+  +    - 3
+  +    columnNames:
+  +    - a
+  +    - b
+  +    - rowid
+  +    defaultColumnId: 1
+  +    name: primary
+  +  formatVersion: 3
+  +  id: 106
+  +  modificationTime: {}
+  +  mutations: []
+  +  name: t2
+  +  nextColumnId: 4
+  +  nextConstraintId: 2
+  +  nextFamilyId: 1
+  +  nextIndexId: 2
+  +  parentId: 104
+  +  primaryIndex:
+  +    constraintId: 1
+  +    encodingType: 1
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 1
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 3
+  +    keyColumnNames:
+  +    - rowid
+  +    name: t2_pkey
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnIds:
+  +    - 1
+  +    - 2
+  +    storeColumnNames:
+  +    - a
+  +    - b
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  replacementOf:
+  +    time: {}
+  +  unexposedParentSchemaId: 105
+  +  version: "1"
+persist all catalog changes to storage
+update ttl schedule label #106
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DATABASE db;
+USE db;
+----
+
+test
+CREATE TABLE t1 (a INT);
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.explain
@@ -1,0 +1,141 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+
+/* test */
+EXPLAIN (DDL) CREATE TABLE t1 (a INT);
+----
+Schema change plan for CREATE TABLE ‹db›.‹public›.‹t1› (‹a› INT8);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 20 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Table:{DescID: 106 (t1+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (t1+), Name: "t1", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 106 (t1+), ReferencedDescID: 105 (public)}
+ │         │    ├── ABSENT → PUBLIC TableData:{DescID: 106 (t1+), ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t1+), ColumnID: 1 (a+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t1+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t1+), Name: "a", ColumnID: 1 (a+)}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t1+), ColumnID: 2 (rowid+)}
+ │         │    ├── ABSENT → PUBLIC ColumnHidden:{DescID: 106 (t1+), ColumnID: 2 (rowid+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t1+), ColumnFamilyID: 0, ColumnID: 2 (rowid+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t1+), ColumnID: 2 (rowid+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t1+), Name: "rowid", ColumnID: 2 (rowid+)}
+ │         │    ├── ABSENT → PUBLIC ColumnDefaultExpression:{DescID: 106 (t1+), ColumnID: 2 (rowid+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 106 (t1+), IndexID: 1 (t1_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexName:{DescID: 106 (t1+), Name: "t1_pkey", IndexID: 1 (t1_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t1+), ColumnID: 2 (rowid+), IndexID: 1 (t1_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t1+), ColumnID: 1 (a+), IndexID: 1 (t1_pkey+)}
+ │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (t1+)}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t1+), Name: "admin"}
+ │         │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t1+), Name: "root"}
+ │         └── 30 Mutation operations
+ │              ├── CreateTableDescriptor {"TableID":106}
+ │              ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t1"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t1","SchemaID":105}}
+ │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":106,"SchemaID":105}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":106}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"a","TableID":106}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+ │              ├── MakeColumnHidden {"ColumnID":2,"TableID":106}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":106}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":2,"TableID":106}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":106}}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":106}
+ │              ├── UpdateOwner {"Owner":{"DescriptorID":106,"Owner":"root"}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":106}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":106}
+ │              ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":106}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":106}
+ │              ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+ │              ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":106}
+ │              ├── SetIndexName {"IndexID":1,"Name":"t1_pkey","TableID":106}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+ │              └── MarkDescriptorAsPublic {"DescriptorID":106}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 20 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Table:{DescID: 106 (t1+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (t1+), Name: "t1", ReferencedDescID: 104 (db), IntValue: 105}
+      │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 106 (t1+), ReferencedDescID: 105 (public)}
+      │    │    ├── PUBLIC → ABSENT TableData:{DescID: 106 (t1+), ReferencedDescID: 104 (db)}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t1+), ColumnID: 1 (a+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t1+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t1+), Name: "a", ColumnID: 1 (a+)}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t1+), ColumnID: 2 (rowid+)}
+      │    │    ├── PUBLIC → ABSENT ColumnHidden:{DescID: 106 (t1+), ColumnID: 2 (rowid+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t1+), ColumnFamilyID: 0, ColumnID: 2 (rowid+), TypeName: "INT8"}
+      │    │    ├── PUBLIC → ABSENT ColumnNotNull:{DescID: 106 (t1+), ColumnID: 2 (rowid+), IndexID: 0}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t1+), Name: "rowid", ColumnID: 2 (rowid+)}
+      │    │    ├── PUBLIC → ABSENT ColumnDefaultExpression:{DescID: 106 (t1+), ColumnID: 2 (rowid+), Expr: unique_rowid()}
+      │    │    ├── PUBLIC → ABSENT PrimaryIndex:{DescID: 106 (t1+), IndexID: 1 (t1_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexName:{DescID: 106 (t1+), Name: "t1_pkey", IndexID: 1 (t1_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t1+), ColumnID: 2 (rowid+), IndexID: 1 (t1_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t1+), ColumnID: 1 (a+), IndexID: 1 (t1_pkey+)}
+      │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (t1+)}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (t1+), Name: "admin"}
+      │    │    └── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (t1+), Name: "root"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 20 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Table:{DescID: 106 (t1+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (t1+), Name: "t1", ReferencedDescID: 104 (db), IntValue: 105}
+           │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 106 (t1+), ReferencedDescID: 105 (public)}
+           │    ├── ABSENT → PUBLIC TableData:{DescID: 106 (t1+), ReferencedDescID: 104 (db)}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t1+), ColumnID: 1 (a+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t1+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t1+), Name: "a", ColumnID: 1 (a+)}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t1+), ColumnID: 2 (rowid+)}
+           │    ├── ABSENT → PUBLIC ColumnHidden:{DescID: 106 (t1+), ColumnID: 2 (rowid+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t1+), ColumnFamilyID: 0, ColumnID: 2 (rowid+), TypeName: "INT8"}
+           │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t1+), ColumnID: 2 (rowid+), IndexID: 0}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t1+), Name: "rowid", ColumnID: 2 (rowid+)}
+           │    ├── ABSENT → PUBLIC ColumnDefaultExpression:{DescID: 106 (t1+), ColumnID: 2 (rowid+), Expr: unique_rowid()}
+           │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 106 (t1+), IndexID: 1 (t1_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexName:{DescID: 106 (t1+), Name: "t1_pkey", IndexID: 1 (t1_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t1+), ColumnID: 2 (rowid+), IndexID: 1 (t1_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t1+), ColumnID: 1 (a+), IndexID: 1 (t1_pkey+)}
+           │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (t1+)}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t1+), Name: "admin"}
+           │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t1+), Name: "root"}
+           └── 31 Mutation operations
+                ├── CreateTableDescriptor {"TableID":106}
+                ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t1"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t1","SchemaID":105}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"t1","TableID":106}
+                ├── SetObjectParentID {"ObjParent":{"ChildObjectID":106,"SchemaID":105}}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":106}}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":106}}
+                ├── SetColumnName {"ColumnID":1,"Name":"a","TableID":106}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+                ├── MakeColumnHidden {"ColumnID":2,"TableID":106}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+                ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":106}
+                ├── AddColumnDefaultExpression {"Default":{"ColumnID":2,"TableID":106}}
+                ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":106}}
+                ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"TableID":106}
+                ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":106}
+                ├── UpdateOwner {"Owner":{"DescriptorID":106,"Owner":"root"}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":106}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+                ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":2,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":106}
+                ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":106}
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":106}
+                ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+                ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":106}
+                ├── SetIndexName {"IndexID":1,"Name":"t1_pkey","TableID":106}
+                ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+                └── MarkDescriptorAsPublic {"DescriptorID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+
+/* test */
+EXPLAIN (DDL, SHAPE) CREATE TABLE t1 (a INT);
+----
+Schema change plan for CREATE TABLE ‹db›.‹public›.‹t1› (‹a› INT8);
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_simple_int/create_table_simple_int.side_effects
@@ -1,0 +1,182 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
+
+/* test */
+CREATE TABLE t1 (a INT);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CREATE TABLE
+increment telemetry for sql.schema.create_table
+## StatementPhase stage 1 of 1 with 30 MutationType ops
+add object namespace entry {104 105 t1} -> 106
+upsert descriptor #106
+  -
+  +table:
+  +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: a
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - defaultExpr: unique_rowid()
+  +    hidden: true
+  +    id: 2
+  +    name: rowid
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  createAsOfTime: {}
+  +  families:
+  +  - columnIds:
+  +    - 1
+  +    - 2
+  +    columnNames:
+  +    - a
+  +    - rowid
+  +    defaultColumnId: 1
+  +    name: primary
+  +  formatVersion: 3
+  +  id: 106
+  +  modificationTime: {}
+  +  mutations: []
+  +  name: t1
+  +  nextColumnId: 3
+  +  nextConstraintId: 2
+  +  nextFamilyId: 1
+  +  nextIndexId: 2
+  +  parentId: 104
+  +  primaryIndex:
+  +    constraintId: 1
+  +    encodingType: 1
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 1
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 2
+  +    keyColumnNames:
+  +    - rowid
+  +    name: t1_pkey
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnIds:
+  +    - 1
+  +    storeColumnNames:
+  +    - a
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  replacementOf:
+  +    time: {}
+  +  unexposedParentSchemaId: 105
+  +  version: "1"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 31 MutationType ops
+add object namespace entry {104 105 t1} -> 106
+upsert descriptor #106
+  -
+  +table:
+  +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: a
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - defaultExpr: unique_rowid()
+  +    hidden: true
+  +    id: 2
+  +    name: rowid
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  createAsOfTime: {}
+  +  families:
+  +  - columnIds:
+  +    - 1
+  +    - 2
+  +    columnNames:
+  +    - a
+  +    - rowid
+  +    defaultColumnId: 1
+  +    name: primary
+  +  formatVersion: 3
+  +  id: 106
+  +  modificationTime: {}
+  +  mutations: []
+  +  name: t1
+  +  nextColumnId: 3
+  +  nextConstraintId: 2
+  +  nextFamilyId: 1
+  +  nextIndexId: 2
+  +  parentId: 104
+  +  primaryIndex:
+  +    constraintId: 1
+  +    encodingType: 1
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 1
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 2
+  +    keyColumnNames:
+  +    - rowid
+  +    name: t1_pkey
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnIds:
+  +    - 1
+  +    storeColumnNames:
+  +    - a
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  replacementOf:
+  +    time: {}
+  +  unexposedParentSchemaId: 105
+  +  version: "1"
+persist all catalog changes to storage
+update ttl schedule label #106
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DATABASE db;
+USE db;
+----
+
+test
+CREATE TABLE t3 (a INT PRIMARY KEY, b STRING NOT NULL);
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+
+/* test */
+EXPLAIN (DDL) CREATE TABLE t3 (a INT PRIMARY KEY, b STRING NOT NULL);
+----
+Schema change plan for CREATE TABLE ‹db›.‹public›.‹t3› (‹a› INT8 PRIMARY KEY, ‹b› STRING NOT NULL);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 19 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC Table:{DescID: 106 (t3+)}
+ │         │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (t3+), Name: "t3", ReferencedDescID: 104 (db), IntValue: 105}
+ │         │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 106 (t3+), ReferencedDescID: 105 (public)}
+ │         │    ├── ABSENT → PUBLIC TableData:{DescID: 106 (t3+), ReferencedDescID: 104 (db)}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t3+), ColumnID: 1 (a+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t3+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t3+), Name: "a", ColumnID: 1 (a+)}
+ │         │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t3+), ColumnID: 1 (a+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t3+), ColumnID: 2 (b+)}
+ │         │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t3+), ColumnFamilyID: 0, ColumnID: 2 (b+), TypeName: "STRING"}
+ │         │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t3+), Name: "b", ColumnID: 2 (b+)}
+ │         │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t3+), ColumnID: 2 (b+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 106 (t3+), IndexID: 1 (t3_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexName:{DescID: 106 (t3+), Name: "t3_pkey", IndexID: 1 (t3_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t3+), ColumnID: 1 (a+), IndexID: 1 (t3_pkey+)}
+ │         │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t3+), ColumnID: 2 (b+), IndexID: 1 (t3_pkey+)}
+ │         │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (t3+)}
+ │         │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t3+), Name: "admin"}
+ │         │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t3+), Name: "root"}
+ │         └── 30 Mutation operations
+ │              ├── CreateTableDescriptor {"TableID":106}
+ │              ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t3"}
+ │              ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t3","SchemaID":105}}
+ │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":106,"SchemaID":105}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":106}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":1,"Name":"a","TableID":106}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"b","TableID":106}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":106}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"TableID":106}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+ │              ├── UpdateOwner {"Owner":{"DescriptorID":106,"Owner":"root"}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+ │              ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":106}
+ │              ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":1,"TableID":106}
+ │              ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":2,"TableID":106}
+ │              ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":106}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":106}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":106}
+ │              ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":106}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+ │              ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":106}
+ │              ├── SetIndexName {"IndexID":1,"Name":"t3_pkey","TableID":106}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+ │              └── MarkDescriptorAsPublic {"DescriptorID":106}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 19 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT Table:{DescID: 106 (t3+)}
+      │    │    ├── PUBLIC → ABSENT Namespace:{DescID: 106 (t3+), Name: "t3", ReferencedDescID: 104 (db), IntValue: 105}
+      │    │    ├── PUBLIC → ABSENT SchemaChild:{DescID: 106 (t3+), ReferencedDescID: 105 (public)}
+      │    │    ├── PUBLIC → ABSENT TableData:{DescID: 106 (t3+), ReferencedDescID: 104 (db)}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t3+), ColumnID: 1 (a+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t3+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t3+), Name: "a", ColumnID: 1 (a+)}
+      │    │    ├── PUBLIC → ABSENT ColumnNotNull:{DescID: 106 (t3+), ColumnID: 1 (a+), IndexID: 0}
+      │    │    ├── PUBLIC → ABSENT Column:{DescID: 106 (t3+), ColumnID: 2 (b+)}
+      │    │    ├── PUBLIC → ABSENT ColumnType:{DescID: 106 (t3+), ColumnFamilyID: 0, ColumnID: 2 (b+), TypeName: "STRING"}
+      │    │    ├── PUBLIC → ABSENT ColumnName:{DescID: 106 (t3+), Name: "b", ColumnID: 2 (b+)}
+      │    │    ├── PUBLIC → ABSENT ColumnNotNull:{DescID: 106 (t3+), ColumnID: 2 (b+), IndexID: 0}
+      │    │    ├── PUBLIC → ABSENT PrimaryIndex:{DescID: 106 (t3+), IndexID: 1 (t3_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexName:{DescID: 106 (t3+), Name: "t3_pkey", IndexID: 1 (t3_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t3+), ColumnID: 1 (a+), IndexID: 1 (t3_pkey+)}
+      │    │    ├── PUBLIC → ABSENT IndexColumn:{DescID: 106 (t3+), ColumnID: 2 (b+), IndexID: 1 (t3_pkey+)}
+      │    │    ├── PUBLIC → ABSENT Owner:{DescID: 106 (t3+)}
+      │    │    ├── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (t3+), Name: "admin"}
+      │    │    └── PUBLIC → ABSENT UserPrivileges:{DescID: 106 (t3+), Name: "root"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 19 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC Table:{DescID: 106 (t3+)}
+           │    ├── ABSENT → PUBLIC Namespace:{DescID: 106 (t3+), Name: "t3", ReferencedDescID: 104 (db), IntValue: 105}
+           │    ├── ABSENT → PUBLIC SchemaChild:{DescID: 106 (t3+), ReferencedDescID: 105 (public)}
+           │    ├── ABSENT → PUBLIC TableData:{DescID: 106 (t3+), ReferencedDescID: 104 (db)}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t3+), ColumnID: 1 (a+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t3+), ColumnFamilyID: 0, ColumnID: 1 (a+), TypeName: "INT8"}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t3+), Name: "a", ColumnID: 1 (a+)}
+           │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t3+), ColumnID: 1 (a+), IndexID: 0}
+           │    ├── ABSENT → PUBLIC Column:{DescID: 106 (t3+), ColumnID: 2 (b+)}
+           │    ├── ABSENT → PUBLIC ColumnType:{DescID: 106 (t3+), ColumnFamilyID: 0, ColumnID: 2 (b+), TypeName: "STRING"}
+           │    ├── ABSENT → PUBLIC ColumnName:{DescID: 106 (t3+), Name: "b", ColumnID: 2 (b+)}
+           │    ├── ABSENT → PUBLIC ColumnNotNull:{DescID: 106 (t3+), ColumnID: 2 (b+), IndexID: 0}
+           │    ├── ABSENT → PUBLIC PrimaryIndex:{DescID: 106 (t3+), IndexID: 1 (t3_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexName:{DescID: 106 (t3+), Name: "t3_pkey", IndexID: 1 (t3_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t3+), ColumnID: 1 (a+), IndexID: 1 (t3_pkey+)}
+           │    ├── ABSENT → PUBLIC IndexColumn:{DescID: 106 (t3+), ColumnID: 2 (b+), IndexID: 1 (t3_pkey+)}
+           │    ├── ABSENT → PUBLIC Owner:{DescID: 106 (t3+)}
+           │    ├── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t3+), Name: "admin"}
+           │    └── ABSENT → PUBLIC UserPrivileges:{DescID: 106 (t3+), Name: "root"}
+           └── 31 Mutation operations
+                ├── CreateTableDescriptor {"TableID":106}
+                ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t3"}
+                ├── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t3","SchemaID":105}}
+                ├── UpdateTTLScheduleMetadata {"NewName":"t3","TableID":106}
+                ├── SetObjectParentID {"ObjParent":{"ChildObjectID":106,"SchemaID":105}}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":1,"TableID":106}}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":1,"TableID":106}}
+                ├── SetColumnName {"ColumnID":1,"Name":"a","TableID":106}
+                ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":2,"TableID":106}}
+                ├── UpsertColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
+                ├── SetColumnName {"ColumnID":2,"Name":"b","TableID":106}
+                ├── MakeAbsentIndexBackfilling {"Index":{"IndexID":1,"IsUnique":true,"TableID":106}}
+                ├── AddColumnToIndex {"ColumnID":1,"IndexID":1,"TableID":106}
+                ├── AddColumnToIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":106}
+                ├── UpdateOwner {"Owner":{"DescriptorID":106,"Owner":"root"}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"admin","WithGrantOption":2}}
+                ├── UpdateUserPrivileges {"Privileges":{"DescriptorID":106,"Privileges":2,"UserName":"root","WithGrantOption":2}}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":1,"TableID":106}
+                ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":1,"TableID":106}
+                ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":2,"TableID":106}
+                ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":2,"TableID":106}
+                ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":106}
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":106}
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":2,"TableID":106}
+                ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":106}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+                ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":106}
+                ├── SetIndexName {"IndexID":1,"Name":"t3_pkey","TableID":106}
+                ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+                └── MarkDescriptorAsPublic {"DescriptorID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+
+/* test */
+EXPLAIN (DDL, SHAPE) CREATE TABLE t3 (a INT PRIMARY KEY, b STRING NOT NULL);
+----
+Schema change plan for CREATE TABLE ‹db›.‹public›.‹t3› (‹a› INT8 PRIMARY KEY, ‹b› STRING NOT NULL);
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_table_with_pk/create_table_with_pk.side_effects
@@ -1,0 +1,174 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
+
+/* test */
+CREATE TABLE t3 (a INT PRIMARY KEY, b STRING NOT NULL);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CREATE TABLE
+increment telemetry for sql.schema.create_table
+## StatementPhase stage 1 of 1 with 30 MutationType ops
+add object namespace entry {104 105 t3} -> 106
+upsert descriptor #106
+  -
+  +table:
+  +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: a
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - id: 2
+  +    name: b
+  +    type:
+  +      family: StringFamily
+  +      oid: 25
+  +  createAsOfTime: {}
+  +  families:
+  +  - columnIds:
+  +    - 1
+  +    - 2
+  +    columnNames:
+  +    - a
+  +    - b
+  +    defaultColumnId: 1
+  +    name: primary
+  +  formatVersion: 3
+  +  id: 106
+  +  modificationTime: {}
+  +  mutations: []
+  +  name: t3
+  +  nextColumnId: 3
+  +  nextConstraintId: 2
+  +  nextFamilyId: 1
+  +  nextIndexId: 2
+  +  parentId: 104
+  +  primaryIndex:
+  +    constraintId: 1
+  +    encodingType: 1
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 1
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 1
+  +    keyColumnNames:
+  +    - a
+  +    name: t3_pkey
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnIds:
+  +    - 2
+  +    storeColumnNames:
+  +    - b
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  replacementOf:
+  +    time: {}
+  +  unexposedParentSchemaId: 105
+  +  version: "1"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 31 MutationType ops
+add object namespace entry {104 105 t3} -> 106
+upsert descriptor #106
+  -
+  +table:
+  +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: a
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - id: 2
+  +    name: b
+  +    type:
+  +      family: StringFamily
+  +      oid: 25
+  +  createAsOfTime: {}
+  +  families:
+  +  - columnIds:
+  +    - 1
+  +    - 2
+  +    columnNames:
+  +    - a
+  +    - b
+  +    defaultColumnId: 1
+  +    name: primary
+  +  formatVersion: 3
+  +  id: 106
+  +  modificationTime: {}
+  +  mutations: []
+  +  name: t3
+  +  nextColumnId: 3
+  +  nextConstraintId: 2
+  +  nextFamilyId: 1
+  +  nextIndexId: 2
+  +  parentId: 104
+  +  primaryIndex:
+  +    constraintId: 1
+  +    encodingType: 1
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 1
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 1
+  +    keyColumnNames:
+  +    - a
+  +    name: t3_pkey
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnIds:
+  +    - 2
+  +    storeColumnNames:
+  +    - b
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  privileges:
+  +    ownerProto: root
+  +    users:
+  +    - privileges: "2"
+  +      userProto: admin
+  +      withGrantOption: "2"
+  +    - privileges: "2"
+  +      userProto: root
+  +      withGrantOption: "2"
+  +    version: 3
+  +  replacementOf:
+  +    time: {}
+  +  unexposedParentSchemaId: 105
+  +  version: "1"
+persist all catalog changes to storage
+update ttl schedule label #106
+# end PreCommitPhase
+commit transaction #1


### PR DESCRIPTION
This PR teaches the declarative schema changer to build a table descriptor for a minimal subset of CREATE TABLE, as the first concrete step toward moving CREATE TABLE off the legacy schema changer. The first commit adds the `CreateTableDescriptor` op and the opgen wiring that materializes the descriptor; the second tightens the dispatcher prefilter to accept a small surface (plain columns plus an optional single-column inline PRIMARY KEY) and adds the builder that emits the corresponding elements.

Gated on `use_declarative_schema_changer = 'unsafe_always'`; the default `on` setting is unchanged and still uses the legacy path. Anything outside the accepted subset falls back to legacy.

Informs #98316

Epic: CRDB-25312

Release note: None