### PR TITLE
roachtest: metamorphically exercise tenant backups with `exclude_data_from_backup` tables in backup/schedule-chaining

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_chaining.go
+++ b/pkg/cmd/roachtest/tests/backup_chaining.go
@@ -7,13 +7,21 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,6 +34,10 @@ const (
 	// in backups during these tests. It is set to an extremely low value in order to cause heavy stress
 	// in situations where we are attempting to protect or backup spans that we should not be touching.
 	scheduleChainingNotIncludedGCTTL = 10 * time.Second
+
+	// scheduleChainingTenantName is the name of the shared-process virtual
+	// cluster used when isTenant is true.
+	scheduleChainingTenantName = "apptenant"
 )
 
 func registerBackupScheduleChaining(r registry.Registry) {
@@ -60,13 +72,23 @@ func registerBackupScheduleChaining(r registry.Registry) {
 			Suites:            spec.suites,
 			Skip:              spec.skip,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				registry := GetFixtureRegistry(ctx, t, c.Cloud())
+				testRNG, seed := randutil.NewLockedPseudoRand()
+				t.L().Printf("random seed: %d", seed)
+				// isTenant := testRNG.Intn(2) == 0
+				isTenant := true
 
-				handle, err := registry.Create(ctx, fmt.Sprintf(
-					"%s-schedule-chaining", spec.fixture.Name,
-				), t.L())
+				fixtureName := fmt.Sprintf("%s-schedule-chaining", spec.fixture.Name)
+				if isTenant {
+					fixtureName += "-tenant"
+				}
+				registry := GetFixtureRegistry(ctx, t, c.Cloud())
+				handle, err := registry.Create(ctx, fixtureName, t.L())
 				require.NoError(t, err)
 
+				if isTenant {
+					spec.fixture.Schedule.CompactionThreshold = 0
+					spec.fixture.Schedule.CompactionWindow = 0
+				}
 				bd := backupDriver{
 					t:        t,
 					c:        c,
@@ -76,16 +98,44 @@ func registerBackupScheduleChaining(r registry.Registry) {
 				}
 				bd.prepareCluster(ctx)
 
+				systemConn := bd.c.Conn(
+					ctx, t.L(), 1, /* node */
+					option.VirtualClusterName(install.SystemInterfaceName),
+				)
+				defer systemConn.Close()
+
+				var sqlConn *gosql.DB
+				if isTenant {
+					bd.tenantName = scheduleChainingTenantName
+					c.StartServiceForVirtualCluster(
+						ctx, t.L(),
+						option.StartSharedVirtualClusterOpts(scheduleChainingTenantName),
+						install.MakeClusterSettings(),
+					)
+					sqlConn = bd.c.Conn(
+						ctx, t.L(), 1, /* node */
+						option.VirtualClusterName(scheduleChainingTenantName),
+					)
+					defer sqlConn.Close()
+					require.NoError(t, roachtestutil.WaitForSQLReady(ctx, sqlConn))
+					// BACKUP/RESTORE VIRTUAL CLUSTER only accepts an integer tenant ID,
+					// so resolve the name to an ID for the driver to use.
+					require.NoError(t, systemConn.QueryRowContext(
+						ctx, "SELECT id FROM system.tenants WHERE name = $1",
+						scheduleChainingTenantName,
+					).Scan(&bd.tenantID))
+				} else {
+					sqlConn = systemConn
+				}
+
 				// Shorten the GC TTL to be less than the frequency of the backup schedule.
-				conn := bd.c.Conn(ctx, t.L(), 1 /* node */)
-				defer conn.Close()
-				_, err = conn.Exec(
+				_, err = sqlConn.Exec(
 					"ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = $1",
 					int(scheduleChainingDefaultGCTTL.Seconds()),
 				)
 				require.NoError(t, err)
 				// Shorten the GC TTL of the system database, which should not be included in the backup.
-				_, err = conn.Exec(
+				_, err = sqlConn.Exec(
 					"ALTER DATABASE system CONFIGURE ZONE USING gc.ttlseconds = $1",
 					int(scheduleChainingNotIncludedGCTTL.Seconds()),
 				)
@@ -94,6 +144,13 @@ func registerBackupScheduleChaining(r registry.Registry) {
 				bd.initWorkload(ctx)
 				stopWorkload, err := bd.runWorkload(ctx)
 				require.NoError(t, err)
+				if isTenant {
+					stopExcludedWorkload := t.GoWithCancel(func(ctx context.Context, l *logger.Logger) error {
+						runExcludedTablesWorkload(t, ctx, sqlConn, testRNG)
+						return nil
+					}, task.Name("excluded-tables-workload"))
+					defer stopExcludedWorkload()
+				}
 
 				bd.scheduleBackups(ctx)
 				require.NoError(t, bd.monitorBackups(ctx))
@@ -111,5 +168,42 @@ func registerBackupScheduleChaining(r registry.Registry) {
 				require.NoError(t, handle.SetReadyAt(ctx))
 			},
 		})
+	}
+}
+
+func runExcludedTablesWorkload(t test.Test, ctx context.Context, db *gosql.DB, rng *rand.Rand) {
+	var numCreatedTables int
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			// Create or drop a table.
+			if rng.Intn(2) == 0 {
+				_, err := db.Exec(fmt.Sprintf(
+					"CREATE TABLE IF NOT EXISTS maybe_excluded_table_%d (id INT PRIMARY KEY)",
+					numCreatedTables,
+				))
+				require.NoError(t, err)
+				numCreatedTables += 1
+			} else {
+				if numCreatedTables == 0 {
+					continue
+				}
+				toDrop := rng.Intn(numCreatedTables)
+				_, err := db.Exec(fmt.Sprintf(
+					"DROP TABLE IF EXISTS maybe_excluded_table_%d",
+					toDrop,
+				))
+				require.NoError(t, err)
+			}
+
+			// Set or remove excluded flag.
+			_, err := db.Exec(fmt.Sprintf(
+				"ALTER TABLE IF EXISTS maybe_excluded_table_%d SET (exclude_data_from_backup = %t)",
+				rng.Intn(numCreatedTables), rng.Intn(2) == 0,
+			))
+			require.NoError(t, err)
+		}
 	}
 }

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -208,17 +208,24 @@ type BackupSchedule struct {
 }
 
 // CreateScheduleStatement returns a SQL statement that creates a scheduled
-// backup of database dbName into uri at the schedule's full and incremental
-// cron frequencies.
-func (schedule *BackupSchedule) CreateScheduleStatement(dbName string, uri url.URL) string {
+// backup into uri at the schedule's full and incremental cron frequencies.
+// If tenantID is non-zero, the schedule backs up that virtual cluster;
+// otherwise it backs up the database dbName.
+func (schedule *BackupSchedule) CreateScheduleStatement(
+	dbName string, tenantID uint64, uri url.URL,
+) string {
+	target := fmt.Sprintf("DATABASE %s", dbName)
+	if tenantID != 0 {
+		target = fmt.Sprintf("VIRTUAL CLUSTER %d", tenantID)
+	}
 	return fmt.Sprintf(
 		`CREATE SCHEDULE IF NOT EXISTS "%s"
-     FOR BACKUP DATABASE %s
+     FOR BACKUP %s
      INTO '%s'
      RECURRING '%s'
      FULL BACKUP '%s'
      WITH SCHEDULE OPTIONS first_run = 'now';`,
-		scheduleLabel, dbName, uri.String(), schedule.IncrementalFrequency, schedule.FullFrequency)
+		scheduleLabel, target, uri.String(), schedule.IncrementalFrequency, schedule.FullFrequency)
 }
 
 type backupDriver struct {
@@ -227,6 +234,14 @@ type backupDriver struct {
 	c        cluster.Cluster
 	fixture  blobfixture.FixtureMetadata
 	registry *blobfixture.Registry
+	// tenantName and tenantID identify a virtual cluster the driver should run
+	// its workload against and scope its backup/restore statements to. When
+	// tenantName is empty (and tenantID is zero), the driver targets the
+	// fixture's database instead. Both fields are needed because workload pgurl
+	// plumbing takes a name while the BACKUP/RESTORE VIRTUAL CLUSTER grammar
+	// takes an integer ID.
+	tenantName string
+	tenantID   uint64
 }
 
 func (bd *backupDriver) prepareCluster(ctx context.Context) {
@@ -252,7 +267,9 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 func (bd *backupDriver) initWorkload(ctx context.Context) {
 	bd.t.L().Printf("importing tpcc with %d warehouses", bd.sp.fixture.ImportWarehouses)
 
-	urls, err := bd.c.InternalPGUrl(ctx, bd.t.L(), bd.c.Node(1), roachprod.PGURLOptions{})
+	urls, err := bd.c.InternalPGUrl(ctx, bd.t.L(), bd.c.Node(1), roachprod.PGURLOptions{
+		VirtualClusterName: bd.tenantName,
+	})
 	require.NoError(bd.t, err)
 
 	cmd := roachtestutil.NewCommand("./cockroach workload fixtures import tpcc").
@@ -270,8 +287,12 @@ func (bd *backupDriver) runWorkload(ctx context.Context) (func(), error) {
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
 	m := bd.c.NewDeprecatedMonitor(workloadCtx)
 	m.Go(func(ctx context.Context) error {
+		pgurlArg := fmt.Sprintf("{pgurl%s}", bd.c.CRDBNodes())
+		if bd.tenantName != "" {
+			pgurlArg = fmt.Sprintf("{pgurl%s:%s}", bd.c.CRDBNodes(), bd.tenantName)
+		}
 		cmd := roachtestutil.NewCommand("./cockroach workload run tpcc").
-			Arg("{pgurl%s}", bd.c.CRDBNodes()).
+			Arg("%s", pgurlArg).
 			Option("tolerate-errors=true").
 			// Increase the ramp time to prevent the initial connection spike from
 			// the workload starting from overloading the cluster. Connection set up
@@ -334,7 +355,7 @@ func (bd *backupDriver) scheduleBackups(ctx context.Context) {
 		require.NoError(bd.t, err)
 	}
 	createScheduleStatement := bd.sp.fixture.Schedule.CreateScheduleStatement(
-		bd.sp.fixture.DatabaseName(), bd.registry.URI(bd.fixture.DataPath),
+		bd.sp.fixture.DatabaseName(), bd.tenantID, bd.registry.URI(bd.fixture.DataPath),
 	)
 	_, err := conn.Exec(createScheduleStatement)
 	require.NoError(bd.t, err)
@@ -522,17 +543,26 @@ func (bd *backupDriver) checkRestorability(ctx context.Context) error {
 	defer conn.Close()
 
 	uri := bd.registry.URI(bd.fixture.DataPath)
-	var restoreJobID jobspb.JobID
-	err := conn.QueryRowContext(
-		ctx,
-		fmt.Sprintf(
+	var restoreStmt string
+	if bd.tenantID != 0 {
+		restoreStmt = fmt.Sprintf(
+			`RESTORE VIRTUAL CLUSTER %d FROM LATEST IN '%s'
+			WITH detached, virtual_cluster_name='%s_restored', schema_only, experimental deferred copy`,
+			bd.tenantID,
+			uri.String(),
+			bd.tenantName,
+		)
+	} else {
+		restoreStmt = fmt.Sprintf(
 			`RESTORE DATABASE %s FROM LATEST IN '%s'
 			WITH detached, new_db_name='%s_restored', schema_only, experimental deferred copy`,
 			bd.sp.fixture.DatabaseName(),
 			uri.String(),
 			bd.sp.fixture.DatabaseName(),
-		),
-	).Scan(&restoreJobID)
+		)
+	}
+	var restoreJobID jobspb.JobID
+	err := conn.QueryRowContext(ctx, restoreStmt).Scan(&restoreJobID)
 	if err != nil {
 		return errors.Wrapf(err, "error starting restore job")
 	}


### PR DESCRIPTION
This patch adjusts the backup/schedule-chaining roachtest, along with some refactoring of `backupDriver`, to metamorphically run a backup schedule of a tenant, rather than a database. When running against a tenant, the test now additionally runs a workload, local to the roachtest, which creates and drops tables with and without the `exclude_data_from_backup` flag.

Epic: None

Release note: None