### PR TITLE
workload: expect error on missing default for spatial types

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1439,3 +1439,36 @@ func (og *operationGenerator) tableHasUniqueConstraintMutation(
 			AND (m->'index'->>'unique')::BOOL IS TRUE
 		);`, tableName)
 }
+
+// tableHasNotNullSpatialColumnMutation reports whether the table has a mutation
+// adding a NOT NULL column of a spatial type with no DEFAULT expression.
+func (og *operationGenerator) tableHasNotNullSpatialColumnMutation(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	return og.scanBool(ctx, tx, `
+		WITH table_desc AS (
+			SELECT crdb_internal.pb_to_json(
+				'desc',
+				descriptor,
+				false
+			)->'table' as d
+			FROM system.descriptor
+			WHERE id = $1::REGCLASS
+		)
+		SELECT EXISTS (
+			SELECT * FROM (
+			SELECT jsonb_array_elements(
+				CASE WHEN d->'mutations' IS NULL
+				THEN '[]'::JSONB
+				ELSE d->'mutations'
+				END
+			) as m
+			FROM table_desc)
+			WHERE (m->>'direction')::STRING = 'ADD'
+			AND (m->'column'->'nullable')::BOOL IS NOT TRUE
+			AND (m->'column'->>'defaultExpr') IS NULL
+			AND (m->'column'->'type'->>'family') IN (
+				'Box2DFamily', 'GeometryFamily', 'GeographyFamily'
+			)
+		);`, tableName)
+}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3261,12 +3261,22 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (stmt *o
 		}
 	}
 
+	// A concurrent ADD COLUMN of a NOT NULL spatial type without a DEFAULT
+	// causes the optimizer to synthesize a default for the WRITE_ONLY mutation
+	// column which fails because tree.NewDefaultDatum has no zero value for
+	// these type families.
+	hasNotNullSpatialColumnMutation, err := og.tableHasNotNullSpatialColumnMutation(ctx, tx, tableName)
+	if err != nil {
+		return nil, err
+	}
+
 	stmt.potentialExecErrors.addAll(codesWithConditions{
 		{code: pgcode.UniqueViolation, condition: hasUniqueConstraints || hasUniqueConstraintsMutations},
 		{code: pgcode.ForeignKeyViolation, condition: true},
 		{code: pgcode.NotNullViolation, condition: true},
 		{code: pgcode.CheckViolation, condition: true},
 		{code: pgcode.InsufficientPrivilege, condition: true}, // For RLS violations
+		{code: pgcode.FeatureNotSupported, condition: hasNotNullSpatialColumnMutation},
 	})
 	og.potentialCommitErrors.addAll(codesWithConditions{
 		{code: pgcode.ForeignKeyViolation, condition: true},


### PR DESCRIPTION
The brief `WRITE_ONLY` phase on adding a column
with `NOT NULL` and no default allows for a short
period where the column is filled using
`NewDefaultDatum`. Scalars use zero values but
spatial values have a
[known](https://github.com/cockroachdb/cockroach/blob/d9137701cbf9d38d866ae24749bbe9a209ea7d58/pkg/sql/sem/tree/datum.go#L5952-L5959)
error. This change expects that (misleading) error
when the right concurrent operations are found.

Epic: none
Fixes: #170874
See also: #171131

Release note: None
