### PR TITLE
release-26.2: sql/stats: fix TestCanaryStatsDelayDelete flake

### DIFF
--- a/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
+++ b/pkg/upgrade/upgrades/v26_2_add_table_statistics_delay_delete_column_test.go
@@ -132,9 +132,17 @@ func TestCanaryStatsDelayDelete(t *testing.T) {
 	)
 	defer tc.Stopper().Stop(ctx)
 
+	// Disable automatic stats collection to prevent it from racing with
+	// manual ANALYZE calls. The auto refresher would create __auto__ stats
+	// and delete the test's manually-created stats, breaking assertions.
+	_, err := sqlDB.Exec(
+		`SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`,
+	)
+	require.NoError(t, err)
+
 	// Verify that sql_stats_canary_window is rejected before upgrading
 	// to V26_2.
-	_, err := sqlDB.Exec(
+	_, err = sqlDB.Exec(
 		`CREATE TABLE t_canary (k INT PRIMARY KEY) WITH (sql_stats_canary_window = '15s')`,
 	)
 	require.Error(t, err)


### PR DESCRIPTION
backport 1/1 commit from https://github.com/cockroachdb/cockroach/pull/168780

Fixes: #170109
Fixes: #170050
Fixes: #170483

----

The test was flaky because it didn't disable automatic statistics collection. The auto stats refresher would fire during the test, create __auto__ stats, and delete the test's manually-created stats (which have name=''), causing the delay_delete=true assertion to fail.

Disable automatic stats collection at the start of the test to prevent the race.

Fixes: #168244
Fixes: #168029
Epic: none
Release note: None

----

Release justification: fix a flacky test.