### PR TITLE
changefeed: create kafka topics if requested 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -241,6 +241,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/twmb/franz-go v1.18.0
 	github.com/twmb/franz-go/pkg/kadm v1.11.0
+	github.com/twmb/franz-go/pkg/kmsg v1.9.0
 	github.com/twpayne/go-geom v1.4.2
 	github.com/xdg-go/pbkdf2 v1.0.0
 	github.com/xdg-go/scram v1.1.2
@@ -470,7 +471,6 @@ require (
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/twitchtv/twirp v8.1.0+incompatible // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v1.9.0 // indirect
 	github.com/twpayne/go-kml v1.5.2 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/urfave/cli/v2 v2.3.0 // indirect

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -194,6 +194,7 @@ go_library(
         "@com_github_twmb_franz_go//pkg/kgo",
         "@com_github_twmb_franz_go//pkg/kversion",
         "@com_github_twmb_franz_go_pkg_kadm//:kadm",
+        "@com_github_twmb_franz_go_pkg_kmsg//:kmsg",
         "@com_google_cloud_go_pubsub//apiv1",
         "@com_google_cloud_go_pubsub//apiv1/pubsubpb",
         "@org_golang_google_api//impersonate",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1951,6 +1951,13 @@ func (b *changefeedResumer) resumeWithRetries(
 						}
 					}
 				}
+				var kafkaKnobs kafkaSinkV2Knobs
+				if knobs != nil {
+					kafkaKnobs = knobs.KafkaSinkV2Knobs
+				}
+				if err := maybeCreateKafkaTopics(ctx, execCfg, details, targets, schemaTS, kafkaKnobs); err != nil {
+					return errors.Wrap(err, "failed to create kafka topics")
+				}
 				var err error
 				prevResult, err = startDistChangefeed(ctx, jobExec, jobID, schemaTS, details, description,
 					initialHighWater, progress, resolvedSpans, prevResult, startedCh, onTracingEvent, targets)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/mocks"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/resolvedspan"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed/schematestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl" // locality-related table mutations
@@ -106,9 +107,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/dustin/go-humanize"
+	"github.com/golang/mock/gomock"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
 )
 
 var testServerRegion = "us-east-1"
@@ -13847,6 +13852,88 @@ func TestSinkClosedOnEventConsumerError(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestChangefeedCreateKafkaTopicsExplicit verifies that the resumer of a
+// changefeed created with `create_kafka_topics='explicit'` invokes the kafka
+// admin client's CreateTopics for each watched topic before emitting rows.
+func TestChangefeedCreateKafkaTopicsExplicit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	kafkaClient := mocks.NewMockKafkaClientV2(ctrl)
+	adminClient := mocks.NewMockKafkaAdminClientV2(ctrl)
+	kafkaClient.EXPECT().Close().AnyTimes()
+
+	const expectedTopic = "pre-foo"
+	var topicsCreated atomic.Bool
+	topicCreatedCh := make(chan struct{})
+	adminClient.EXPECT().ListTopics(gomock.Any(), expectedTopic).DoAndReturn(
+		func(ctx context.Context, topics ...string) (kadm.TopicDetails, error) {
+			require.Equal(t, []string{expectedTopic}, topics)
+			detail := kadm.TopicDetail{
+				Topic: expectedTopic,
+				Partitions: map[int32]kadm.PartitionDetail{
+					0: {Topic: expectedTopic, Partition: 0, Leader: 0, Replicas: []int32{0}, ISR: []int32{0}},
+				},
+			}
+			if !topicsCreated.Load() {
+				detail.Err = kerr.UnknownTopicOrPartition
+				detail.Partitions = nil
+			}
+			return kadm.TopicDetails{expectedTopic: detail}, nil
+		},
+	).AnyTimes()
+	adminClient.EXPECT().ValidateCreateTopics(gomock.Any(), int32(-1), int16(-1), nil, expectedTopic).Return(kadm.CreateTopicResponses{
+		expectedTopic: {Topic: expectedTopic},
+	}, nil)
+	adminClient.EXPECT().CreateTopics(gomock.Any(), int32(-1), int16(-1), nil, expectedTopic).DoAndReturn(
+		func(ctx context.Context, partitions int32, replicationFactor int16, configs map[string]*string, topics ...string) (kadm.CreateTopicResponses, error) {
+			require.Equal(t, []string{expectedTopic}, topics)
+			if topicsCreated.CompareAndSwap(false, true) {
+				close(topicCreatedCh)
+			}
+			return kadm.CreateTopicResponses{
+				expectedTopic: {Topic: expectedTopic, NumPartitions: 1, ReplicationFactor: 1},
+			}, nil
+		},
+	)
+
+	s, cleanup := makeServer(t, feedTestNoTenants, withKnobsFn(func(knobs *base.TestingKnobs) {
+		if knobs.DistSQL == nil {
+			knobs.DistSQL = &execinfra.TestingKnobs{}
+		}
+		if knobs.DistSQL.(*execinfra.TestingKnobs).Changefeed == nil {
+			knobs.DistSQL.(*execinfra.TestingKnobs).Changefeed = &TestingKnobs{}
+		}
+		cfKnobs := knobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs)
+		cfKnobs.KafkaSinkV2Knobs = kafkaSinkV2Knobs{
+			OverrideClient: func(opts []kgo.Opt) (KafkaClientV2, KafkaAdminClientV2) {
+				return kafkaClient, adminClient
+			},
+			SkipCreateTopicVersionCheck: true,
+		}
+	}))
+	defer cleanup()
+
+	execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+	KafkaV2Enabled.Override(ctx, &execCfg.Settings.SV, true)
+	sqlDB := sqlutils.MakeSQLRunner(s.DB)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+
+	var jobID int
+	sqlDB.QueryRow(t,
+		`CREATE CHANGEFEED FOR foo INTO 'kafka://localhost:9092?topic_prefix=pre-' WITH initial_scan = 'no', create_kafka_topics = 'explicit'`,
+	).Scan(&jobID)
+	defer sqlDB.Exec(t, `CANCEL JOB $1`, jobID)
+
+	select {
+	case <-topicCreatedCh:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for changefeed resumer to create kafka topics")
+	}
 }
 
 // closeTrackingSink wraps a Sink and counts Dial and Close calls.

--- a/pkg/ccl/changefeedccl/mocks/kafka_admin_v2_generated.go
+++ b/pkg/ccl/changefeedccl/mocks/kafka_admin_v2_generated.go
@@ -35,6 +35,41 @@ func (m *MockKafkaAdminClientV2) EXPECT() *MockKafkaAdminClientV2MockRecorder {
 	return m.recorder
 }
 
+// ApiVersions mocks base method.
+func (m *MockKafkaAdminClientV2) ApiVersions(arg0 context.Context) (kadm.BrokersApiVersions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApiVersions", arg0)
+	ret0, _ := ret[0].(kadm.BrokersApiVersions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApiVersions indicates an expected call of ApiVersions.
+func (mr *MockKafkaAdminClientV2MockRecorder) ApiVersions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApiVersions", reflect.TypeOf((*MockKafkaAdminClientV2)(nil).ApiVersions), arg0)
+}
+
+// CreateTopics mocks base method.
+func (m *MockKafkaAdminClientV2) CreateTopics(arg0 context.Context, arg1 int32, arg2 int16, arg3 map[string]*string, arg4 ...string) (kadm.CreateTopicResponses, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2, arg3}
+	for _, a := range arg4 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTopics", varargs...)
+	ret0, _ := ret[0].(kadm.CreateTopicResponses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTopics indicates an expected call of CreateTopics.
+func (mr *MockKafkaAdminClientV2MockRecorder) CreateTopics(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTopics", reflect.TypeOf((*MockKafkaAdminClientV2)(nil).CreateTopics), varargs...)
+}
+
 // ListTopics mocks base method.
 func (m *MockKafkaAdminClientV2) ListTopics(arg0 context.Context, arg1 ...string) (kadm.TopicDetails, error) {
 	m.ctrl.T.Helper()
@@ -53,4 +88,24 @@ func (mr *MockKafkaAdminClientV2MockRecorder) ListTopics(arg0 interface{}, arg1 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTopics", reflect.TypeOf((*MockKafkaAdminClientV2)(nil).ListTopics), varargs...)
+}
+
+// ValidateCreateTopics mocks base method.
+func (m *MockKafkaAdminClientV2) ValidateCreateTopics(arg0 context.Context, arg1 int32, arg2 int16, arg3 map[string]*string, arg4 ...string) (kadm.CreateTopicResponses, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2, arg3}
+	for _, a := range arg4 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ValidateCreateTopics", varargs...)
+	ret0, _ := ret[0].(kadm.CreateTopicResponses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateCreateTopics indicates an expected call of ValidateCreateTopics.
+func (mr *MockKafkaAdminClientV2MockRecorder) ValidateCreateTopics(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCreateTopics", reflect.TypeOf((*MockKafkaAdminClientV2)(nil).ValidateCreateTopics), varargs...)
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -267,9 +267,17 @@ func getSink(
 					return nil, err
 				}
 				if KafkaV2Enabled.Get(&serverCfg.Settings.SV) {
+					var kafkaKnobs kafkaSinkV2Knobs
+					if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok {
+						kafkaKnobs = knobs.KafkaSinkV2Knobs
+					}
+					createTopics, err := opts.GetCreateKafkaTopics()
+					if err != nil {
+						return nil, err
+					}
 					return makeKafkaSinkV2(ctx, &changefeedbase.SinkURL{URL: u}, targets, sinkOpts,
 						numSinkIOWorkers(serverCfg), newCPUPacerFactory(ctx, serverCfg), timeutil.DefaultTimeSource{},
-						serverCfg.Settings, metricsBuilder, kafkaSinkV2Knobs{})
+						serverCfg.Settings, metricsBuilder, kafkaKnobs, createTopics)
 				} else {
 					return makeKafkaSink(ctx, &changefeedbase.SinkURL{URL: u}, targets, sinkOpts, serverCfg.Settings, metricsBuilder)
 				}

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -416,7 +416,8 @@ func TestAzureKafkaDefaults(t *testing.T) {
 
 	assertExpectedKgoOpts := func(exp expectation, opts []kgo.Opt) {
 		sinkClient, err := newKafkaSinkClientV2(ctx, opts, sinkBatchConfig{},
-			"", cluster.MakeTestingClusterSettings(), kafkaSinkV2Knobs{}, nilMetricsRecorderBuilder, nil, nil, "" /* partitionAlg */)
+			"", cluster.MakeTestingClusterSettings(), kafkaSinkV2Knobs{}, nilMetricsRecorderBuilder, nil,
+			nil, "" /* partitionAlg */, changefeedbase.CreateKafkaTopicsBrokerAuto)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, sinkClient.Close()) }()
 		client := sinkClient.client.(*kgo.Client)

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -13,12 +13,16 @@ import (
 	"hash/fnv"
 	"io"
 	"net"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -26,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/klauspost/compress/zstd"
@@ -33,6 +38,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/twmb/franz-go/pkg/kversion"
 )
 
@@ -71,6 +77,7 @@ func newKafkaSinkClientV2(
 	topicsForConnectionCheck []string,
 	constHeaders map[string][]byte,
 	partitionAlg string,
+	createTopics changefeedbase.CreateKafkaTopics,
 ) (*kafkaSinkClientV2, error) {
 	bootstrapBrokers := strings.Split(bootstrapAddrsStr, `,`)
 
@@ -88,8 +95,6 @@ func newKafkaSinkClientV2(
 		kgo.ProducerBatchMaxBytes(int32(changefeedbase.KafkaMaxRequestSize.Get(&settings.SV))),
 		kgo.BrokerMaxWriteBytes(1 << 30), // 1GiB
 
-		kgo.AllowAutoTopicCreation(),
-
 		kgo.RecordRetries(5),
 		// This applies only to non-produce requests, ie the ListTopics call.
 		kgo.RequestRetries(5),
@@ -99,6 +104,9 @@ func newKafkaSinkClientV2(
 		kgo.ProducerOnDataLossDetected(func(topic string, part int32) {
 			log.Changefeed.Errorf(ctx, `kafka sink detected data loss for topic %s partition %d`, redact.SafeString(topic), redact.SafeInt(part))
 		}),
+	}
+	if createTopics == changefeedbase.CreateKafkaTopicsBrokerAuto {
+		baseOpts = append(baseOpts, kgo.AllowAutoTopicCreation())
 	}
 
 	recordResize := func(numRecords int64) {}
@@ -117,6 +125,9 @@ func newKafkaSinkClientV2(
 
 	if knobs.OverrideClient != nil {
 		client, adminClient = knobs.OverrideClient(clientOpts)
+		if client == nil || adminClient == nil {
+			return nil, errors.New("override client returned nil kafka client or admin client")
+		}
 	} else {
 		client, err = kgo.NewClient(clientOpts...)
 		if err != nil {
@@ -323,7 +334,8 @@ type KafkaAdminClientV2 interface {
 }
 
 type kafkaSinkV2Knobs struct {
-	OverrideClient func(opts []kgo.Opt) (KafkaClientV2, KafkaAdminClientV2)
+	OverrideClient              func(opts []kgo.Opt) (KafkaClientV2, KafkaAdminClientV2)
+	SkipCreateTopicVersionCheck bool
 }
 
 var _ SinkClient = (*kafkaSinkClientV2)(nil)
@@ -385,6 +397,7 @@ func makeKafkaSinkV2(
 	settings *cluster.Settings,
 	mb metricsRecorderBuilder,
 	knobs kafkaSinkV2Knobs,
+	createTopics changefeedbase.CreateKafkaTopics,
 ) (Sink, error) {
 	jsonConfig := sinkOpts.JSONConfig
 	batchCfg, retryOpts, err := getSinkConfigFromJson(jsonConfig, sinkJSONConfig{
@@ -425,13 +438,241 @@ func makeKafkaSinkV2(
 	}
 
 	topicsForConnectionCheck := topicNamer.DisplayNamesSlice()
-	client, err := newKafkaSinkClientV2(ctx, clientOpts, batchCfg, u.Host, settings, knobs, mb, topicsForConnectionCheck, sinkOpts.Headers, sinkOpts.PartitionAlg)
+	client, err := newKafkaSinkClientV2(
+		ctx, clientOpts, batchCfg, u.Host, settings, knobs, mb, topicsForConnectionCheck,
+		sinkOpts.Headers, sinkOpts.PartitionAlg, createTopics,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	return makeBatchingSink(ctx, sinkTypeKafka, client, time.Duration(batchCfg.Frequency), retryOpts,
 		parallelism, topicNamer, pacerFactory, timeSource, mb(true), settings), nil
+}
+
+// maybeCreateKafkaTopics creates any missing kafka topics for the changefeed
+// when create_kafka_topics=explicit. No-op for other modes or non-kafka sinks;
+// errors if the v2 kafka sink is disabled (only path that implements this).
+func maybeCreateKafkaTopics(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	details jobspb.ChangefeedDetails,
+	targets changefeedbase.Targets,
+	schemaTS hlc.Timestamp,
+	knobs kafkaSinkV2Knobs,
+) error {
+	ctx, span := tracing.ChildSpan(ctx, "changefeed.create_kafka_topics")
+	defer span.Finish()
+
+	opts := changefeedbase.MakeStatementOptions(details.Opts)
+	createTopics, err := opts.GetCreateKafkaTopics()
+	if err != nil {
+		return err
+	}
+	if createTopics != changefeedbase.CreateKafkaTopicsExplicit {
+		return nil
+	}
+
+	resolvedSinkURI, err := resolveDest(ctx, execCfg, details.SinkURI)
+	if err != nil {
+		return err
+	}
+	parsedSinkURL, err := url.Parse(resolvedSinkURI)
+	if err != nil {
+		return err
+	}
+	if !isKafkaSink(parsedSinkURL) {
+		return nil
+	}
+	if !KafkaV2Enabled.Get(&execCfg.Settings.SV) {
+		return errors.Newf("%s=explicit requires the v2 kafka sink; enable it with the %q cluster setting",
+			changefeedbase.OptCreateKafkaTopics, KafkaV2Enabled.Name())
+	}
+	sinkURL := &changefeedbase.SinkURL{URL: parsedSinkURL}
+
+	topics, err := kafkaTopicNamesForTargets(ctx, execCfg, targets, sinkURL, schemaTS)
+	if err != nil {
+		return err
+	}
+	if len(topics) == 0 {
+		return nil
+	}
+
+	sinkOpts, err := opts.GetKafkaSinkOptions()
+	if err != nil {
+		return err
+	}
+	client, adminClient, err := newKafkaAdminClientV2(ctx, sinkURL, sinkOpts, knobs)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	return createMissingKafkaTopics(ctx, adminClient, topics, knobs)
+}
+
+// kafkaTopicNamesForTargets returns the deduplicated, sanitized topic names
+// this changefeed will emit to.
+func kafkaTopicNamesForTargets(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	targets changefeedbase.Targets,
+	sinkURL *changefeedbase.SinkURL,
+	schemaTS hlc.Timestamp,
+) ([]string, error) {
+	prefix := sinkURL.ConsumeParam(changefeedbase.SinkParamTopicPrefix)
+	singleName := sinkURL.ConsumeParam(changefeedbase.SinkParamTopicName)
+	return ResolveTopicNames(
+		targets,
+		func() ([]catalog.TableDescriptor, error) {
+			return fetchTableDescriptors(ctx, execCfg, targets, schemaTS)
+		},
+		WithPrefix(prefix),
+		WithSingleName(singleName),
+		WithSanitizeFn(changefeedbase.SQLNameToKafkaName),
+	)
+}
+
+func newKafkaAdminClientV2(
+	ctx context.Context,
+	u *changefeedbase.SinkURL,
+	sinkOpts changefeedbase.KafkaSinkOptions,
+	knobs kafkaSinkV2Knobs,
+) (KafkaClientV2, KafkaAdminClientV2, error) {
+	bootstrapBrokers := strings.Split(u.Host, `,`)
+	clientOpts, err := buildKgoConfig(ctx, u, sinkOpts.JSONConfig, nil /* netMetrics */)
+	if err != nil {
+		return nil, nil, err
+	}
+	baseOpts := []kgo.Opt{
+
+		kgo.DisableIdempotentWrite(),
+		kgo.SeedBrokers(bootstrapBrokers...),
+		kgo.ProducerBatchMaxBytes(256 << 20),
+		kgo.BrokerMaxWriteBytes(1 << 30),
+		kgo.RecordRetries(5),
+		kgo.WithLogger(kgoLogAdapter{ctx: ctx}),
+		kgo.RequestRetries(5),
+	}
+	clientOpts = append(baseOpts, clientOpts...)
+
+	if knobs.OverrideClient != nil {
+		client, adminClient := knobs.OverrideClient(clientOpts)
+		if client == nil || adminClient == nil {
+			return nil, nil, errors.New("override client returned nil kafka client or admin client")
+		}
+		return client, adminClient, nil
+	}
+
+	client, err := kgo.NewClient(clientOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return client, kadm.NewClient(client), nil
+}
+
+// createMissingKafkaTopics creates topics not already on the broker, using
+// broker-side defaults for partitions/replication.
+func createMissingKafkaTopics(
+	ctx context.Context, adminClient KafkaAdminClientV2, topics []string, knobs kafkaSinkV2Knobs,
+) error {
+	missing, err := missingKafkaTopics(ctx, adminClient, topics)
+	if err != nil {
+		return err
+	}
+	if len(missing) == 0 {
+		log.Changefeed.VInfof(ctx, 2, "all kafka topics already exist")
+		return nil
+	}
+	if err := ensureCreateTopicsDefaultsSupported(ctx, adminClient, knobs); err != nil {
+		return err
+	}
+
+	validateResp, err := adminClient.ValidateCreateTopics(ctx, -1, -1, nil, missing...)
+	if err != nil {
+		return err
+	}
+	for _, topic := range missing {
+		if resp, ok := validateResp[topic]; ok && resp.Err != nil && !errors.Is(resp.Err, kerr.TopicAlreadyExists) {
+			return errors.Wrapf(resp.Err, "failed to validate kafka topic creation for topic %s", topic)
+		}
+	}
+
+	log.Changefeed.Infof(ctx, "creating missing kafka topics: %v", missing)
+	createResp, err := adminClient.CreateTopics(ctx, -1, -1, nil, missing...)
+	if err != nil {
+		return err
+	}
+	for _, topic := range missing {
+		resp, ok := createResp[topic]
+		if !ok {
+			continue
+		}
+		if resp.Err != nil && !errors.Is(resp.Err, kerr.TopicAlreadyExists) {
+			return errors.Wrapf(resp.Err, "failed to create kafka topic %s", topic)
+		}
+		log.Changefeed.Infof(ctx, "created kafka topic %s with num_partitions=%d replication_factor=%d",
+			topic, resp.NumPartitions, resp.ReplicationFactor)
+	}
+	return nil
+}
+
+// missingKafkaTopics returns the subset of topics not present on the broker.
+func missingKafkaTopics(
+	ctx context.Context, adminClient KafkaAdminClientV2, topics []string,
+) ([]string, error) {
+	topicDetails, err := adminClient.ListTopics(ctx, topics...)
+	if err != nil {
+		return nil, err
+	}
+
+	missing := make([]string, 0, len(topics))
+	for _, topic := range topics {
+		details, ok := topicDetails[topic]
+		if ok && details.Err == nil {
+			continue
+		}
+		if ok && !errors.Is(details.Err, kerr.UnknownTopicOrPartition) {
+			return nil, errors.Wrapf(details.Err, "failed to list kafka topic %s", topic)
+		}
+		missing = append(missing, topic)
+	}
+	return missing, nil
+}
+
+// ensureCreateTopicsDefaultsSupported errors if any broker is too old. That
+// behavior requires CreateTopics v4 (Kafka 2.4+).
+func ensureCreateTopicsDefaultsSupported(
+	ctx context.Context, adminClient KafkaAdminClientV2, knobs kafkaSinkV2Knobs,
+) error {
+	if knobs.SkipCreateTopicVersionCheck {
+		return nil
+	}
+
+	v24 := kversion.V2_4_0()
+	createTopicsVersion, ok := v24.LookupMaxKeyVersion(kmsg.CreateTopics.Int16())
+	if !ok {
+		return errors.AssertionFailedf("v2.4.0 does not support create topics but it should")
+	}
+
+	versions, err := adminClient.ApiVersions(ctx)
+	if err != nil {
+		return err
+	}
+	for brokerID, version := range versions {
+		if version.Err != nil {
+			return errors.Wrapf(version.Err, "failed to get kafka api versions for broker %d", brokerID)
+		}
+		maxVersion, ok := version.KeyMaxVersion(kmsg.CreateTopics.Int16())
+		if !ok {
+			return errors.Errorf("kafka broker %d does not support CreateTopics", brokerID)
+		}
+		if maxVersion < createTopicsVersion {
+			return errors.Errorf("kafka broker %d does not support CreateTopics defaults; broker max version %d is lower than required version %d",
+				brokerID, maxVersion, createTopicsVersion)
+		}
+	}
+	return nil
 }
 
 func buildKgoConfig(

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -317,6 +317,9 @@ type KafkaClientV2 interface {
 // to flush resolved messages.
 type KafkaAdminClientV2 interface {
 	ListTopics(ctx context.Context, topics ...string) (kadm.TopicDetails, error)
+	ApiVersions(ctx context.Context) (kadm.BrokersApiVersions, error)
+	ValidateCreateTopics(ctx context.Context, partitions int32, replicationFactor int16, configs map[string]*string, topics ...string) (kadm.CreateTopicResponses, error)
+	CreateTopics(ctx context.Context, partitions int32, replicationFactor int16, configs map[string]*string, topics ...string) (kadm.CreateTopicResponses, error)
 }
 
 type kafkaSinkV2Knobs struct {

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -16,10 +17,14 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/mocks"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -409,6 +414,300 @@ func TestKafkaSinkClientV2_Opts(t *testing.T) {
 	}
 }
 
+func TestKafkaTopicNamesForTargets(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, cleanup := makeServer(t)
+	defer cleanup()
+
+	sqlDB := sqlutils.MakeSQLRunner(s.DB)
+	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING, FAMILY f1 (a, b), FAMILY f2 (c))`)
+
+	execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+	tableDesc := cdctest.GetHydratedTableDescriptor(t, execCfg, "d", "foo")
+	makeTargets := func(targets ...changefeedbase.Target) changefeedbase.Targets {
+		res := changefeedbase.Targets{}
+		for _, target := range targets {
+			res.Add(target)
+		}
+		return res
+	}
+
+	baseTarget := changefeedbase.Target{
+		DescID:            tableDesc.GetID(),
+		StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
+	}
+
+	for _, tc := range []struct {
+		name     string
+		sinkURI  string
+		targets  changefeedbase.Targets
+		expected []string
+	}{
+		{
+			name:    "primary family only",
+			sinkURI: "kafka://localhost:9092?topic_prefix=pre-",
+			targets: makeTargets(changefeedbase.Target{
+				Type:              jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY,
+				DescID:            baseTarget.DescID,
+				StatementTimeName: baseTarget.StatementTimeName,
+			}),
+			expected: []string{"pre-foo"},
+		},
+		{
+			name:    "column family",
+			sinkURI: "kafka://localhost:9092?topic_prefix=pre-",
+			targets: makeTargets(changefeedbase.Target{
+				Type:              jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY,
+				DescID:            baseTarget.DescID,
+				FamilyName:        "f2",
+				StatementTimeName: baseTarget.StatementTimeName,
+			}),
+			expected: []string{"pre-foo.f2"},
+		},
+		{
+			name:    "each family",
+			sinkURI: "kafka://localhost:9092?topic_prefix=pre-",
+			targets: makeTargets(changefeedbase.Target{
+				Type:              jobspb.ChangefeedTargetSpecification_EACH_FAMILY,
+				DescID:            baseTarget.DescID,
+				StatementTimeName: baseTarget.StatementTimeName,
+			}),
+			expected: []string{"pre-foo.f1", "pre-foo.f2"},
+		},
+		{
+			name:    "single topic override",
+			sinkURI: "kafka://localhost:9092?topic_prefix=pre-&topic_name=all",
+			targets: makeTargets(changefeedbase.Target{
+				Type:              jobspb.ChangefeedTargetSpecification_EACH_FAMILY,
+				DescID:            baseTarget.DescID,
+				StatementTimeName: baseTarget.StatementTimeName,
+			}),
+			expected: []string{"pre-all"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parsedURL, err := url.Parse(tc.sinkURI)
+			require.NoError(t, err)
+
+			topics, err := kafkaTopicNamesForTargets(
+				ctx, &execCfg, tc.targets, &changefeedbase.SinkURL{URL: parsedURL}, s.Server.Clock().Now(),
+			)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expected, topics)
+		})
+	}
+}
+
+// TestMaybeCreateKafkaTopicsPreconditions exercises the early-exit and
+// validation paths of maybeCreateKafkaTopics: it should no-op for non-explicit
+// option values and non-Kafka sinks, and surface a clear error when the v2
+// kafka sink is not enabled.
+func TestMaybeCreateKafkaTopicsPreconditions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, cleanup := makeServer(t)
+	defer cleanup()
+	execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+
+	failOnClient := kafkaSinkV2Knobs{
+		OverrideClient: func(opts []kgo.Opt) (KafkaClientV2, KafkaAdminClientV2) {
+			t.Fatal("unexpected kafka client creation")
+			return nil, nil
+		},
+	}
+
+	explicit := map[string]string{
+		changefeedbase.OptCreateKafkaTopics: string(changefeedbase.CreateKafkaTopicsExplicit),
+	}
+	brokerAuto := map[string]string{
+		changefeedbase.OptCreateKafkaTopics: string(changefeedbase.CreateKafkaTopicsBrokerAuto),
+	}
+	off := map[string]string{
+		changefeedbase.OptCreateKafkaTopics: string(changefeedbase.CreateKafkaTopicsOff),
+	}
+
+	cases := []struct {
+		name           string
+		sinkURI        string
+		opts           map[string]string
+		kafkaV2Enabled bool
+		expectedErr    string
+	}{
+		{
+			name:           "default option is no-op",
+			sinkURI:        "kafka://localhost:9092",
+			kafkaV2Enabled: true,
+		},
+		{
+			name:           "broker_auto option is no-op",
+			sinkURI:        "kafka://localhost:9092",
+			opts:           brokerAuto,
+			kafkaV2Enabled: true,
+		},
+		{
+			name:           "off option is no-op",
+			sinkURI:        "kafka://localhost:9092",
+			opts:           off,
+			kafkaV2Enabled: true,
+		},
+		{
+			name:           "non-kafka sink is no-op",
+			sinkURI:        "null://",
+			opts:           explicit,
+			kafkaV2Enabled: true,
+		},
+		{
+			name:           "kafka v2 disabled is an error",
+			sinkURI:        "kafka://localhost:9092",
+			opts:           explicit,
+			kafkaV2Enabled: false,
+			expectedErr:    "requires the v2 kafka sink",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			KafkaV2Enabled.Override(ctx, &execCfg.Settings.SV, tc.kafkaV2Enabled)
+			err := maybeCreateKafkaTopics(ctx, &execCfg, jobspb.ChangefeedDetails{
+				SinkURI: tc.sinkURI,
+				Opts:    tc.opts,
+			}, changefeedbase.Targets{}, hlc.Timestamp{}, failOnClient)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateMissingKafkaTopics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	knobs := kafkaSinkV2Knobs{SkipCreateTopicVersionCheck: true}
+	existingTopic := func(topic string) kadm.TopicDetail {
+		return kadm.TopicDetail{
+			Topic: topic,
+			Partitions: map[int32]kadm.PartitionDetail{
+				0: {Topic: topic, Partition: 0, Leader: 0, Replicas: []int32{0}, ISR: []int32{0}},
+			},
+		}
+	}
+	unknownTopic := func(topic string) kadm.TopicDetail {
+		return kadm.TopicDetail{Topic: topic, Err: kerr.UnknownTopicOrPartition}
+	}
+
+	t.Run("all topics already exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		adminClient := mocks.NewMockKafkaAdminClientV2(ctrl)
+		adminClient.EXPECT().ListTopics(gomock.Any(), "a", "b").Return(kadm.TopicDetails{
+			"a": existingTopic("a"),
+			"b": existingTopic("b"),
+		}, nil)
+
+		require.NoError(t, createMissingKafkaTopics(ctx, adminClient, []string{"a", "b"}, knobs))
+	})
+
+	t.Run("creates only missing topics", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		adminClient := mocks.NewMockKafkaAdminClientV2(ctrl)
+		adminClient.EXPECT().ListTopics(gomock.Any(), "a", "b", "c").Return(kadm.TopicDetails{
+			"a": existingTopic("a"),
+			"b": unknownTopic("b"),
+		}, nil)
+		adminClient.EXPECT().ValidateCreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "b", "c").Return(kadm.CreateTopicResponses{
+			"b": {Topic: "b"},
+			"c": {Topic: "c"},
+		}, nil)
+		adminClient.EXPECT().CreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "b", "c").Return(kadm.CreateTopicResponses{
+			"b": {Topic: "b", NumPartitions: 3, ReplicationFactor: 1},
+			"c": {Topic: "c", NumPartitions: 3, ReplicationFactor: 1},
+		}, nil)
+
+		require.NoError(t, createMissingKafkaTopics(ctx, adminClient, []string{"a", "b", "c"}, knobs))
+	})
+
+	t.Run("error propagation", func(t *testing.T) {
+		cases := []struct {
+			name        string
+			setupMock   func(*mocks.MockKafkaAdminClientV2)
+			expectedErr string
+		}{
+			{
+				name: "list topics top-level error",
+				setupMock: func(m *mocks.MockKafkaAdminClientV2) {
+					m.EXPECT().ListTopics(gomock.Any(), "a").Return(nil, errors.New("list failed"))
+				},
+				expectedErr: "list failed",
+			},
+			{
+				name: "list topics per-topic error",
+				setupMock: func(m *mocks.MockKafkaAdminClientV2) {
+					m.EXPECT().ListTopics(gomock.Any(), "a").Return(kadm.TopicDetails{
+						"a": {Topic: "a", Err: errors.New("topic list failed")},
+					}, nil)
+				},
+				expectedErr: "topic list failed",
+			},
+			{
+				name: "validate per-topic error",
+				setupMock: func(m *mocks.MockKafkaAdminClientV2) {
+					m.EXPECT().ListTopics(gomock.Any(), "a").Return(kadm.TopicDetails{"a": unknownTopic("a")}, nil)
+					m.EXPECT().ValidateCreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "a").Return(kadm.CreateTopicResponses{
+						"a": {Topic: "a", Err: errors.New("topic validate failed")},
+					}, nil)
+				},
+				expectedErr: "topic validate failed",
+			},
+			{
+				name: "create per-topic error",
+				setupMock: func(m *mocks.MockKafkaAdminClientV2) {
+					m.EXPECT().ListTopics(gomock.Any(), "a").Return(kadm.TopicDetails{"a": unknownTopic("a")}, nil)
+					m.EXPECT().ValidateCreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "a").Return(kadm.CreateTopicResponses{
+						"a": {Topic: "a"},
+					}, nil)
+					m.EXPECT().CreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "a").Return(kadm.CreateTopicResponses{
+						"a": {Topic: "a", Err: errors.New("topic create failed")},
+					}, nil)
+				},
+				expectedErr: "topic create failed",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				adminClient := mocks.NewMockKafkaAdminClientV2(ctrl)
+				tc.setupMock(adminClient)
+				require.ErrorContains(t, createMissingKafkaTopics(ctx, adminClient, []string{"a"}, knobs), tc.expectedErr)
+			})
+		}
+	})
+
+	t.Run("topic already exists race", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		adminClient := mocks.NewMockKafkaAdminClientV2(ctrl)
+		adminClient.EXPECT().ListTopics(gomock.Any(), "a").Return(kadm.TopicDetails{
+			"a": unknownTopic("a"),
+		}, nil)
+		adminClient.EXPECT().ValidateCreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "a").Return(kadm.CreateTopicResponses{
+			"a": {Topic: "a"},
+		}, nil)
+		adminClient.EXPECT().CreateTopics(gomock.Any(), int32(-1), int16(-1), nil, "a").Return(kadm.CreateTopicResponses{
+			"a": {Topic: "a", Err: kerr.TopicAlreadyExists},
+		}, nil)
+
+		require.NoError(t, createMissingKafkaTopics(ctx, adminClient, []string{"a"}, knobs))
+	})
+}
+
 func shallowMerge(a, b map[string]any) map[string]any {
 	res := make(map[string]any, len(a))
 	for k, v := range a {
@@ -661,6 +960,7 @@ type kafkaSinkV2Fx struct {
 	batchConfig         sinkBatchConfig
 	realClient          bool
 	additionalKOpts     []kgo.Opt
+	createTopics        changefeedbase.CreateKafkaTopics
 	createClientErrorCb func(error)
 	uri                 string
 
@@ -733,13 +1033,14 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 	settings := cluster.MakeTestingClusterSettings()
 
 	fx := &kafkaSinkV2Fx{
-		t:           t,
-		settings:    settings,
-		ctx:         ctx,
-		kc:          kc,
-		ac:          ac,
-		mockCtrl:    ctrl,
-		targetNames: []string{"t"},
+		t:            t,
+		settings:     settings,
+		ctx:          ctx,
+		kc:           kc,
+		ac:           ac,
+		mockCtrl:     ctrl,
+		targetNames:  []string{"t"},
+		createTopics: changefeedbase.CreateKafkaTopicsBrokerAuto,
 	}
 
 	for _, opt := range opts {
@@ -762,7 +1063,7 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 	var err error
 	fx.sink, err = newKafkaSinkClientV2(ctx, fx.additionalKOpts,
 		fx.batchConfig, uri, settings, knobs, nilMetricsRecorderBuilder,
-		nil, nil, "" /* partitionAlg */)
+		nil, nil, "" /* partitionAlg */, fx.createTopics)
 	if err != nil && fx.createClientErrorCb != nil {
 		fx.createClientErrorCb(err)
 		return fx
@@ -783,7 +1084,9 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 	}
 	u.RawQuery = q.Encode()
 
-	bs, err := makeKafkaSinkV2(ctx, &changefeedbase.SinkURL{URL: u}, targets, changefeedbase.KafkaSinkOptions{JSONConfig: fx.sinkJSONConfig}, 1, nilPacerFactory, timeutil.DefaultTimeSource{}, settings, nilMetricsRecorderBuilder, knobs)
+	bs, err := makeKafkaSinkV2(ctx, &changefeedbase.SinkURL{URL: u}, targets, changefeedbase.KafkaSinkOptions{
+		JSONConfig: fx.sinkJSONConfig,
+	}, 1, nilPacerFactory, timeutil.DefaultTimeSource{}, settings, nilMetricsRecorderBuilder, knobs, fx.createTopics)
 	if err != nil && fx.createClientErrorCb != nil {
 		fx.createClientErrorCb(err)
 		return fx

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -141,6 +141,9 @@ type TestingKnobs struct {
 	// changefeeds, it is nil. A non-nil return error is propagated to
 	// the change frontier.
 	AfterPersistFrontier func(eval.CoreChangefeedState) error
+
+	// KafkaSinkV2Knobs are testing knobs for the v2 Kafka client.
+	KafkaSinkV2Knobs kafkaSinkV2Knobs
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/ccl/changefeedccl/topic.go
+++ b/pkg/ccl/changefeedccl/topic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/errors"
 )
@@ -110,18 +111,24 @@ func WithSanitizeFn(fn func(string) string) TopicNameOption {
 	return optSanitize(fn)
 }
 
-// MakeTopicNamer creates a TopicNamer.
-// specs are used to populate DisplayNames and the values iterated over in Each.
-// Add options using WithJoinByte, WithPrefix, WithSingleName, and/or WithSanitizeFn.
-func MakeTopicNamer(targets changefeedbase.Targets, opts ...TopicNameOption) (*TopicNamer, error) {
+// newTopicNamer creates and populates a TopicNamer with the given options
+func newTopicNamer(opts ...TopicNameOption) *TopicNamer {
 	tn := &TopicNamer{
-		join:         '.',
-		DisplayNames: make(map[changefeedbase.Target]string, targets.Size),
-		FullNames:    make(map[TopicIdentifier]string),
+		join: '.',
 	}
 	for _, opt := range opts {
 		opt.set(tn)
 	}
+	return tn
+}
+
+// MakeTopicNamer creates a TopicNamer.
+// specs are used to populate DisplayNames and the values iterated over in Each.
+// Add options using WithJoinByte, WithPrefix, WithSingleName, and/or WithSanitizeFn.
+func MakeTopicNamer(targets changefeedbase.Targets, opts ...TopicNameOption) (*TopicNamer, error) {
+	tn := newTopicNamer(opts...)
+	tn.DisplayNames = make(map[changefeedbase.Target]string, targets.Size)
+	tn.FullNames = make(map[TopicIdentifier]string)
 	err := targets.EachTarget(func(t changefeedbase.Target) error {
 		name, err := tn.makeDisplayName(t)
 		if err != nil {
@@ -130,9 +137,80 @@ func MakeTopicNamer(targets changefeedbase.Targets, opts ...TopicNameOption) (*T
 		tn.DisplayNames[t] = name
 		return nil
 	})
-
 	return tn, err
+}
 
+// ResolveTopicNames returns the deduplicated list of fully-resolved topic
+// names a changefeed with the given targets and naming options would emit to.
+// This helper expands such targets into one name per column family.
+func ResolveTopicNames(
+	targets changefeedbase.Targets,
+	fetchDescriptors func() ([]catalog.TableDescriptor, error),
+	opts ...TopicNameOption,
+) ([]string, error) {
+	tn := newTopicNamer(opts...)
+	tn.join = '.'
+
+	if tn.singleName != "" {
+		return []string{tn.nameFromComponents("")}, nil
+	}
+
+	seen := make(map[string]struct{})
+	topics := make([]string, 0, targets.Size)
+	addTopic := func(topic string) {
+		if _, ok := seen[topic]; ok {
+			return
+		}
+		seen[topic] = struct{}{}
+		topics = append(topics, topic)
+	}
+
+	// resolve every target whose name is fully known from the
+	// spec, and queue EACH_FAMILY targets for descriptor-based expansion.
+	var familyTargets []changefeedbase.Target
+	if err := targets.EachTarget(func(t changefeedbase.Target) error {
+		switch t.Type {
+		case jobspb.ChangefeedTargetSpecification_PRIMARY_FAMILY_ONLY:
+			addTopic(tn.nameFromComponents(t.StatementTimeName))
+		case jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY:
+			addTopic(tn.nameFromComponents(t.StatementTimeName, t.FamilyName))
+		case jobspb.ChangefeedTargetSpecification_EACH_FAMILY:
+			familyTargets = append(familyTargets, t)
+		default:
+			return errors.AssertionFailedf("unrecognized target type %s", t.Type)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if len(familyTargets) == 0 {
+		return topics, nil
+	}
+
+	if fetchDescriptors == nil {
+		return nil, errors.AssertionFailedf(
+			"EACH_FAMILY targets present but no descriptor fetcher was supplied")
+	}
+	tableDescs, err := fetchDescriptors()
+	if err != nil {
+		return nil, err
+	}
+	descIdxByID := make(map[descpb.ID]int, len(tableDescs))
+	for i, d := range tableDescs {
+		descIdxByID[d.GetID()] = i
+	}
+	for _, t := range familyTargets {
+		idx, ok := descIdxByID[t.DescID]
+		if !ok {
+			return nil, errors.AssertionFailedf(
+				"missing table descriptor %d while expanding topics", t.DescID)
+		}
+		for _, family := range tableDescs[idx].GetFamilies() {
+			addTopic(tn.nameFromComponents(t.StatementTimeName, family.Name))
+		}
+	}
+	return topics, nil
 }
 
 const familyPlaceholder = "{family}"


### PR DESCRIPTION
This change allows creating kafka topics when
requested, previously users had to rely on kafka cluster
for auto topic creation, now with `create_kafka_topics='explicit'`
the changefeed creates topics via the kafka admin API.
`create_kafka_topics='broker_auto'` (default), results in auto topic
creation enabled on kafka cluster and `create_kafka_topics='off'`
disables both options.

Fixes: https://github.com/cockroachdb/cockroach/issues/155157

Release note (general change): The `CREATE CHANGFEED` statement now
allows `create_kafka_topics` with options `explicit`, `off` and
`broker_auto`(default). The `broker_auto` is default behavior which
relies on kafka cluster to create kafka topics, when set to `explicit`,
the changefeed creates the topics, and `off` disables both.