### PR TITLE
optbuilder: handle NULL REGCLASS when tracking schema dependencies

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -198,7 +198,6 @@ SELECT count(descriptor) FROM system.descriptor WHERE id = $dropped_fn_id;
 ----
 0
 
-
 subtest end
 
 subtest regression_94146
@@ -453,7 +452,6 @@ SELECT f_103869('sq_103869')
 ----
 2
 
-
 subtest end
 
 # Regression test for #104927. Correctly resolve table references in UDFs as
@@ -488,7 +486,6 @@ query T
 SELECT f104927()
 ----
 [{"i": 1, "s": "foo"}]
-
 
 subtest end
 
@@ -543,7 +540,6 @@ $$
 
 subtest end
 
-
 # Regression tests for #105259 and #107654. Do not type-check subqueries in UDFs
 # outside optbuilder. Doing so can cause internal errors.
 subtest regression_105259
@@ -566,7 +562,6 @@ CREATE FUNCTION f() RETURNS VOID LANGUAGE SQL AS $$
 $$
 
 subtest end
-
 
 # Regression test for #108297. UDFs with VOID return types should succeed when
 # the last statement returns columns of any type.
@@ -864,5 +859,54 @@ DROP FUNCTION sc_62227.next_id;
 DROP FUNCTION sc_62227.next_id_sql;
 DROP SEQUENCE sc_62227.myseq;
 DROP SCHEMA sc_62227;
+
+subtest end
+
+subtest regression_170852
+
+# Regression test for #170852. Building a routine whose body contains a
+# NULL-valued REGCLASS expression (e.g. NULL::REGCLASS, or an uninitialized
+# OUT parameter of type REGCLASS) should not fail with an internal error.
+# maybeTrackRegclassDependenciesForViews evaluates constant REGCLASS
+# expressions and previously asserted the result was a *tree.DOid, but a NULL
+# REGCLASS evaluates to tree.DNull.
+statement ok
+CREATE FUNCTION f_170852_null() RETURNS INT LANGUAGE plpgsql AS $$
+DECLARE
+  v INT;
+BEGIN
+  SELECT nextval(NULL::REGCLASS) INTO v;
+  RETURN v;
+END;
+$$;
+
+# An uninitialized OUT parameter of type REGCLASS also evaluates to NULL when
+# the routine body is built.
+statement ok
+CREATE FUNCTION f_170852_out(OUT p0 REGCLASS, IN p1 BOOL) RETURNS REGCLASS
+LANGUAGE plpgsql AS $$
+BEGIN
+  p0 := p0;
+END;
+$$;
+
+# The same NULL handling applies to SQL UDFs.
+statement ok
+CREATE FUNCTION f_170852_sql() RETURNS REGCLASS LANGUAGE sql AS $$
+  SELECT NULL::REGCLASS;
+$$;
+
+# Empty function body should work too.
+statement ok
+CREATE FUNCTION f_170852_empty_body(OUT p0 REGCLASS, IN p1 BOOL) RETURNS REGCLASS
+LANGUAGE plpgsql AS $$
+BEGIN
+END;
+$$;
+
+statement ok
+DROP FUNCTION f_170852_null;
+DROP FUNCTION f_170852_out;
+DROP FUNCTION f_170852_sql;
 
 subtest end

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -588,7 +588,13 @@ func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
 	if err != nil {
 		panic(err)
 	}
-	// eval.Expr on a REGCLASS expression returns a *tree.DOid.
+	// A NULL REGCLASS references no object, so there is no dependency to track.
+	// This happens, for example, with a NULL::REGCLASS literal or an
+	// uninitialized OUT parameter of type REGCLASS in a routine body.
+	if regclass == tree.DNull {
+		return
+	}
+	// eval.Expr on a non-NULL REGCLASS expression returns a *tree.DOid.
 	// Use the OID directly for resolution rather than DOid.String(), which
 	// returns only the object name and drops the schema prefix (e.g. returns
 	// "myseq" instead of "sc.myseq"), causing unqualified lookups to fail


### PR DESCRIPTION
When building a routine or view, `maybeTrackRegclassDependenciesForViews` evaluates any constant REGCLASS expression to record the referenced data source as a schema dependency. It asserted that `eval.Expr` on a REGCLASS-typed expression always returns a `*tree.DOid`. However, a NULL REGCLASS expression evaluates to `tree.DNull`, which tripped the assertion with an internal error:

```
expected *tree.DOid from eval.Expr on REGCLASS expression, got tree.dNull
```

This happens, for example, with a `NULL::REGCLASS` literal or an uninitialized OUT parameter of type REGCLASS in a routine body. The assertion was introduced in #167679, which refactored this function.

A NULL REGCLASS references no object, so there is no dependency to track. This PR returns early in that case, before the `*tree.DOid` assertion, and adds a regression test to `udf_regressions`.

Fixes: #170852 

Release note (bug fix): Fixed a bug where creating a user-defined function or view whose body contained a NULL REGCLASS expression (e.g. `NULL::REGCLASS`, or an uninitialized OUT parameter of type REGCLASS) could fail with an internal error. 