### PR TITLE
logictest: deflake row_level_ttl execute_schedule subtest

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1777,6 +1777,15 @@ subtest end
 
 subtest execute_schedule
 
+# Disable the job scheduler daemon for this subtest. Otherwise, the daemon can
+# scan system.scheduled_jobs in the background, find a schedule that EXECUTE
+# SCHEDULE just made eligible (next_run <= now()), run it, and reschedule
+# next_run to the future (tomorrow, for @daily). That would race with the
+# assertions below that check next_run remains in the past, causing flakes.
+# See https://github.com/cockroachdb/cockroach/issues/170997.
+statement ok
+SET CLUSTER SETTING jobs.scheduler.enabled = false
+
 statement ok
 CREATE TABLE tbl_execute_schedule (
   id INT PRIMARY KEY,
@@ -1848,5 +1857,9 @@ EXECUTE SCHEDULE $schedule_id_1
 
 statement ok
 RESUME SCHEDULE $schedule_id_1
+
+# Re-enable the job scheduler daemon disabled at the start of this subtest.
+statement ok
+RESET CLUSTER SETTING jobs.scheduler.enabled
 
 subtest end


### PR DESCRIPTION
The `execute_schedule` subtest exercises `EXECUTE SCHEDULE` / `EXECUTE SCHEDULES`, which set a schedule's `next_run` to `now()` so it becomes eligible to run, and then asserts that `next_run` remains in the past.

These assertions race against the background job scheduler daemon. When the daemon's periodic scan runs, it finds the now-eligible schedule, executes it, and reschedules `next_run` to the future (tomorrow, for the `@daily` cron used here). If that happens between `EXECUTE SCHEDULE(S)` and the assertion, the `next_run <= now()` checks fail.

This is rare in practice because the daemon waits a random 2-5 minute initial scan delay before its first scan, which is normally longer than the test runs. It surfaced on a race-enabled CI run where the single test file ran for 150s+, long enough to cross into that window during this late subtest.

The fix disables the scheduler daemon (`jobs.scheduler.enabled`) for the duration of the subtest. The daemon checks this setting before each scan, so it skips processing entirely; the setting is disabled well before any schedule is made eligible, so propagation is not a concern. The setting is reset at the end of the subtest.

Resolves: #170997

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)