### PR TITLE
sql/row: deflake TestCheckRowSizeRateLimitsAndTruncates

### DIFF
--- a/pkg/sql/row/helper_test.go
+++ b/pkg/sql/row/helper_test.go
@@ -154,12 +154,14 @@ func TestCheckRowSizeRateLimitsAndTruncates(t *testing.T) {
 	t.Run("primary key truncation via SQL INSERT", func(t *testing.T) {
 		logSpy.Reset()
 		skippedLargeRows.Store(0)
-		// Re-init the global limiter so the SQL INSERT below sees an open
-		// window regardless of what the previous subtest did.
-		largeRowLogEvery = log.Every(testInterval)
+		// Disable rate-limiting entirely for this subtest. The limiter is
+		// process-global, so a background internal SQL operation writing a
+		// row over the lowered 1 KiB threshold could otherwise consume the
+		// window before our INSERT runs, suppressing the event we assert on.
+		// This subtest only exercises truncation, not rate-limiting.
+		defer TestingDisableLargeRowRateLimit()()
 
-		// 1 KiB log threshold scoped to this connection so the row below
-		// (8 KiB primary key) crosses it.
+		// 1 KiB log threshold so the row below (8 KiB primary key) crosses it.
 		db.Exec(t, "SET CLUSTER SETTING sql.guardrails.max_row_size_log = '1KiB'")
 		defer db.Exec(t, "SET CLUSTER SETTING sql.guardrails.max_row_size_log = DEFAULT")
 


### PR DESCRIPTION
The "primary key truncation via SQL INSERT" subtest set
`sql.guardrails.max_row_size_log` to 1 KiB via a cluster setting and then
re-initialized the process-global `largeRowLogEvery` rate limiter, expecting its
INSERT to be the first to consume the fresh rate-limit window. Because the
setting is global, any background internal SQL operation writing a row over the
lowered 1 KiB threshold could call `CheckRowSize` first, consuming the window and
emitting a `LargeRowInternal` event (which the test's log spy ignores). The
test's INSERT then found the window closed, got suppressed, and the spy captured
zero `large_row` events, failing the `Len` assertion.

This subtest only exercises primary-key truncation, not rate-limiting, so disable
the limiter entirely with `TestingDisableLargeRowRateLimit` instead of racing for
the window. This matches how `TestPerfLogging` handles the same process-global
limiter.

Resolves: #171003

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)