### PR TITLE
opt,optbuilder: add NumStmts/BuildStmt to RoutineBodyBuilder

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -1459,6 +1459,12 @@ type PostQueryBuilder interface {
 // Note: factory is always *norm.Factory; declared as interface{} to
 // avoid circular package dependencies.
 type RoutineBodyBuilder interface {
+	// Build constructs all body statements at once into the single provided
+	// factory, for callers that do not interleave building with execution. It
+	// produces the same per-statement RelExprs as BuildStmt over
+	// [0, NumStmts()), but with all statements sharing one factory and one set
+	// of parameter columns. (BuildStmt requires a fresh factory per call to
+	// keep parameter column IDs stable; see BuildStmt.)
 	Build(
 		ctx context.Context,
 		semaCtx *tree.SemaContext,
@@ -1466,6 +1472,34 @@ type RoutineBodyBuilder interface {
 		catalog cat.Catalog,
 		factory interface{},
 	) (body []RelExpr, bodyProps []*physical.Required, params opt.ColList, err error)
+
+	// NumStmts returns the number of body statements that will be built,
+	// including any synthetic statement appended for a VOID-returning
+	// routine. It is stable for the lifetime of the builder.
+	NumStmts() int
+
+	// BuildStmt builds the body statement at stmtIdx into a RelExpr using the
+	// provided catalog and factory. The caller may refresh the catalog
+	// between calls so that a statement can resolve names introduced by DDL
+	// executed in an earlier statement.
+	//
+	// The caller must pass a fresh, empty factory on each call. Parameter
+	// columns are then synthesized with identical column IDs across calls, so
+	// one argument-to-parameter mapping serves every statement.
+	//
+	// TODO(janexing): think about the mutation detection with interleaving
+	// model. Unlike the lump-sum Build path, where all statements share one
+	// statementTree and a later body statement sees mutations registered by
+	// earlier ones, BuildStmt re-inits the tree per call, so cross-statement
+	// conflict detection within a body no longer happens here.
+	BuildStmt(
+		ctx context.Context,
+		semaCtx *tree.SemaContext,
+		evalCtx *eval.Context,
+		catalog cat.Catalog,
+		factory interface{},
+		stmtIdx int,
+	) (stmt RelExpr, props *physical.Required, params opt.ColList, err error)
 }
 
 // GroupingOrderType is the grouping column order type for group by and distinct

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -122,6 +122,7 @@ go_test(
     srcs = [
         "builder_test.go",
         "name_resolution_test.go",
+        "routine_test.go",
         "scalar_test.go",
         "statement_tree_test.go",
         "union_test.go",
@@ -134,6 +135,7 @@ go_test(
         "//pkg/sql/catalog/colinfo/colinfotestutils",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
+        "//pkg/sql/opt/norm",
         "//pkg/sql/opt/testutils",
         "//pkg/sql/opt/testutils/opttester",
         "//pkg/sql/opt/testutils/testcat",
@@ -146,5 +148,6 @@ go_test(
         "//pkg/testutils/datapathutils",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -548,26 +548,20 @@ func (b *Builder) buildRoutine(
 	return routine
 }
 
-// buildSQLRoutineBodyStmts builds the body statements of a SQL routine into
-// RelExprs. It is used on both the eager path (plan-time) and the deferred path
-// (execution-time), distinguished by funcExpr:
+// buildSQLRoutineBodyStmts builds all body statements of a SQL routine into
+// RelExprs at plan time (the eager path), called from buildRoutine.
 //
-//   - Eager path (funcExpr != nil): called at plan time from
-//     buildRoutine. The return type may still need finalization (e.g. resolving
-//     AnyTuple for RETURNS RECORD routines), so finalizeRoutineReturnType is
-//     called. funcExpr and inScope are required for this
-//     finalization.
+// It appends the synthetic VOID-return statement when needed, then builds each
+// statement via buildOneBodyStmt. funcExpr (always non-nil here) and inScope
+// are required because the final statement's return type may still need
+// finalization at plan time, e.g. resolving AnyTuple for RETURNS RECORD
+// routines; see buildOneBodyStmt for how funcExpr selects between finalization
+// and validation. rTyp is the return type (funcExpr.ResolvedType()), used for
+// the VOID-return check.
 //
-//   - Deferred path (funcExpr == nil): called at execution time from
-//     sqlRoutineBodyBuilder.Build. The return type (rTyp) was already resolved
-//     and persisted at plan time — AnyTuple and ReturnsRecordType are always
-//     resolved before reaching this path. Only validateReturnType is needed to
-//     confirm that the rebuilt body columns are still compatible.
-//
-// rTyp is the routine's return type on both paths: on the eager path it is
-// funcExpr.ResolvedType(); on the deferred path it is the type captured
-// at plan time. It is always used for the VOID-return check (appending
-// VALUES (NULL)).
+// The deferred (execution-time) path does not go through this function; it
+// builds statements directly via buildOneBodyStmt from
+// sqlRoutineBodyBuilder.Build and BuildStmt.
 func (b *Builder) buildSQLRoutineBodyStmts(
 	stmtASTs []tree.Statement,
 	bodyScope *scope,
@@ -577,62 +571,109 @@ func (b *Builder) buildSQLRoutineBodyStmts(
 	isSetReturning bool,
 	insideDataSource bool,
 ) (body []memo.RelExpr, bodyProps []*physical.Required, bodyTags []string) {
-	// Add a VALUES (NULL) statement if the return type of the function is
-	// VOID. We cannot simply project NULL from the last statement because
-	// all columns would be pruned and the contents of last statement would
-	// not be executed.
-	// TODO(mgartner): This will add some planning overhead for every
-	// invocation of the function. Is there a more efficient way to do this?
-	var appendedNullForVoidReturn bool
-	if rTyp.Family() == types.VoidFamily {
-		stmtASTs = append(append([]tree.Statement(nil), stmtASTs...), &tree.Select{
-			Select: &tree.ValuesClause{
-				Rows: []tree.Exprs{{tree.DNull}},
-			},
-		})
-		appendedNullForVoidReturn = true
-	}
-
+	stmtASTs, appendedNullForVoidReturn := maybeAppendVoidReturnStmt(stmtASTs, rTyp)
+	lastIdx := len(stmtASTs) - 1
 	body = make([]memo.RelExpr, len(stmtASTs))
 	bodyProps = make([]*physical.Required, len(stmtASTs))
 	bodyTags = make([]string, len(stmtASTs))
 	for i, ast := range stmtASTs {
-		// TODO(michae2): We should be checking the statement hints cache here to
-		// find any external statement hints that could apply to this statement.
-		stmtScope := b.buildStmtAtRootWithScope(ast, nil /* desiredTypes */, bodyScope)
-
-		// The last statement produces the output of the routine.
-		if i == len(stmtASTs)-1 {
-			if funcExpr != nil {
-				// Eager path: finalize the return type. This handles AnyTuple
-				// resolution for RETURNS RECORD routines, column-definition-list
-				// validation for data-source usage, and type annotation on the
-				// FuncExpr. See finalizeRoutineReturnType for details.
-				rTyp = b.finalizeRoutineReturnType(
-					funcExpr, stmtScope, inScope, insideDataSource,
-				)
-			} else {
-				// Deferred path: the return type is already resolved. Just
-				// validate that the rebuilt body columns are compatible.
-				if err := validateReturnType(
-					b.ctx, b.semaCtx, rTyp, stmtScope.cols,
-				); err != nil {
-					panic(err)
-				}
-			}
-			stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, insideDataSource, rTyp)
-		}
-		body[i] = stmtScope.expr
-		bodyProps[i] = stmtScope.makePhysicalProps()
+		expr, props, tag := b.buildOneBodyStmt(
+			ast, bodyScope, rTyp, funcExpr, inScope, isSetReturning, insideDataSource, i, lastIdx,
+		)
+		body[i] = expr
+		bodyProps[i] = props
 		// We don't need a statement tag for the artificial appended `SELECT NULL`
 		// statement.
-		if appendedNullForVoidReturn && i == len(stmtASTs)-1 {
+		if appendedNullForVoidReturn && i == lastIdx {
 			bodyTags[i] = ""
 		} else {
-			bodyTags[i] = ast.StatementTag()
+			bodyTags[i] = tag
 		}
 	}
 	return body, bodyProps, bodyTags
+}
+
+// buildOneBodyStmt builds a single SQL routine body statement at stmtIdx into a
+// RelExpr, returning the expression, its required physical properties, and its
+// statement tag. It is the shared per-statement helper used by both the eager
+// (plan-time) and deferred (execution-time) build paths.
+//
+// lastIdx is the index of the final body statement. The final statement
+// produces the routine's output, so when stmtIdx == lastIdx the statement
+// receives return-type handling and finalization (LIMIT 1 for
+// non-set-returning routines, tuple wrapping, and assignment casts) via
+// finishRoutineReturnStmt.
+//
+// funcExpr selects between the two build paths:
+//
+//   - Eager path (funcExpr != nil): called at plan time from
+//     buildSQLRoutineBodyStmts. The return type may still need finalization
+//     (e.g. resolving AnyTuple for RETURNS RECORD routines), so
+//     finalizeRoutineReturnType is called; funcExpr and inScope are required.
+//
+//   - Deferred path (funcExpr == nil): called at execution time from
+//     sqlRoutineBodyBuilder.Build and BuildStmt. The return type is already
+//     resolved, so only validateReturnType runs to confirm the rebuilt body
+//     columns are still compatible.
+func (b *Builder) buildOneBodyStmt(
+	ast tree.Statement,
+	bodyScope *scope,
+	rTyp *types.T,
+	funcExpr *tree.FuncExpr,
+	inScope *scope,
+	isSetReturning bool,
+	insideDataSource bool,
+	stmtIdx int,
+	lastIdx int,
+) (expr memo.RelExpr, props *physical.Required, tag string) {
+	// TODO(michae2): We should be checking the statement hints cache here to
+	// find any external statement hints that could apply to this statement.
+	stmtScope := b.buildStmtAtRootWithScope(ast, nil /* desiredTypes */, bodyScope)
+
+	// The last statement produces the output of the routine.
+	if stmtIdx == lastIdx {
+		if funcExpr != nil {
+			// Eager path: finalize the return type. This handles AnyTuple
+			// resolution for RETURNS RECORD routines, column-definition-list
+			// validation for data-source usage, and type annotation on the
+			// FuncExpr. See finalizeRoutineReturnType for details.
+			rTyp = b.finalizeRoutineReturnType(
+				funcExpr, stmtScope, inScope, insideDataSource,
+			)
+		} else {
+			// Deferred path: the return type is already resolved. Just
+			// validate that the rebuilt body columns are compatible.
+			if err := validateReturnType(
+				b.ctx, b.semaCtx, rTyp, stmtScope.cols,
+			); err != nil {
+				panic(err)
+			}
+		}
+		stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, insideDataSource, rTyp)
+	}
+	return stmtScope.expr, stmtScope.makePhysicalProps(), ast.StatementTag()
+}
+
+// maybeAppendVoidReturnStmt appends a synthetic VALUES (NULL) statement to
+// stmtASTs when the routine returns VOID, returning the (possibly extended)
+// statement list and whether the synthetic statement was appended. The input
+// slice is never mutated.
+//
+// The synthetic statement is required because we cannot simply project NULL
+// from the last statement: doing so would prune all columns and the contents
+// of the last statement would not be executed.
+func maybeAppendVoidReturnStmt(
+	stmtASTs []tree.Statement, rTyp *types.T,
+) (augmented []tree.Statement, appended bool) {
+	if rTyp.Family() != types.VoidFamily {
+		return stmtASTs, false
+	}
+	augmented = append(append([]tree.Statement(nil), stmtASTs...), &tree.Select{
+		Select: &tree.ValuesClause{
+			Rows: []tree.Exprs{{tree.DNull}},
+		},
+	})
+	return augmented, true
 }
 
 // finishRoutineReturnStmt manages the output columns for a statement that will
@@ -1004,7 +1045,17 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 // sqlRoutineBodyBuilder implements memo.RoutineBodyBuilder for SQL routines.
 // It captures all metadata needed to build the routine body at execution time
 // instead of plan time.
+//
+// Construct instances with newSQLRoutineBodyBuilder, which performs the
+// VOID-return statement augmentation once so that NumStmts is stable.
+//
+// TODO(janexing): when hooking deferred optbuild up with the production code,
+// use newSQLRoutineBodyBuilder (rather than the struct literal) to ensure the
+// VOID-return statement augmentation is in place.
 type sqlRoutineBodyBuilder struct {
+	// stmtASTs holds the body statements to build, including the synthetic
+	// VALUES (NULL) statement appended for VOID-returning routines. It is set
+	// by newSQLRoutineBodyBuilder.
 	stmtASTs         []tree.Statement
 	paramTypes       []*types.T
 	paramNames       []tree.Name
@@ -1018,8 +1069,24 @@ type sqlRoutineBodyBuilder struct {
 
 var _ memo.RoutineBodyBuilder = &sqlRoutineBodyBuilder{}
 
-// Build constructs the body RelExprs for a SQL routine in a fresh memo.
-// It is called at execution time, after plan-time metadata has been captured.
+// newSQLRoutineBodyBuilder returns a sqlRoutineBodyBuilder for the given
+// configuration. The caller supplies the raw (pre-VOID-append) body statements
+// in cfg.stmtASTs; the synthetic VALUES (NULL) statement for VOID-returning
+// routines is appended here so that NumStmts and per-statement indexing are
+// stable for the lifetime of the builder.
+func newSQLRoutineBodyBuilder(cfg sqlRoutineBodyBuilder) *sqlRoutineBodyBuilder {
+	cfg.stmtASTs, _ = maybeAppendVoidReturnStmt(cfg.stmtASTs, cfg.rTyp)
+	return &cfg
+}
+
+// NumStmts is part of the memo.RoutineBodyBuilder interface.
+func (rb *sqlRoutineBodyBuilder) NumStmts() int {
+	return len(rb.stmtASTs)
+}
+
+// Build is part of the memo.RoutineBodyBuilder interface. All body statements
+// are built into the single provided factory using one Builder, so that the
+// resulting RelExprs share a memo and a single set of parameter columns.
 func (rb *sqlRoutineBodyBuilder) Build(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
@@ -1030,8 +1097,80 @@ func (rb *sqlRoutineBodyBuilder) Build(
 	// Enact panic handling similar to Builder.Build().
 	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
 
+	b, bodyScope, params := rb.newBodyBuilder(ctx, semaCtx, evalCtx, catalog, factoryI)
+
+	// Builtin routines need access to internal tables.
+	if rb.routineType == tree.BuiltinRoutine {
+		defer b.DisableUnsafeInternalCheck()()
+	}
+
+	lastIdx := len(rb.stmtASTs) - 1
+	body = make([]memo.RelExpr, len(rb.stmtASTs))
+	bodyProps = make([]*physical.Required, len(rb.stmtASTs))
+	for i, ast := range rb.stmtASTs {
+		// Pass funcExpr=nil to indicate the deferred path (the return type is
+		// already resolved).
+		body[i], bodyProps[i], _ = b.buildOneBodyStmt(
+			ast, bodyScope, rb.rTyp, nil /* funcExpr */, nil, /* inScope */
+			rb.isSetReturning, rb.insideDataSource, i, lastIdx,
+		)
+	}
+	return body, bodyProps, params, nil
+}
+
+// BuildStmt is part of the memo.RoutineBodyBuilder interface. Each call uses a
+// fresh Builder so that the statement is built against the provided catalog,
+// which may reflect DDL applied by earlier statements.
+func (rb *sqlRoutineBodyBuilder) BuildStmt(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	catalog cat.Catalog,
+	factoryI interface{},
+	stmtIdx int,
+) (stmt memo.RelExpr, props *physical.Required, params opt.ColList, retErr error) {
+	// Enact panic handling similar to Builder.Build().
+	defer errorutil.MaybeCatchPanic(&retErr, nil /* errCallback */)
+
+	if stmtIdx < 0 || stmtIdx >= len(rb.stmtASTs) {
+		return nil, nil, nil, errors.AssertionFailedf(
+			"body statement index %d out of range [0, %d)", stmtIdx, len(rb.stmtASTs),
+		)
+	}
+
+	b, bodyScope, params := rb.newBodyBuilder(ctx, semaCtx, evalCtx, catalog, factoryI)
+
+	// Builtin routines need access to internal tables.
+	if rb.routineType == tree.BuiltinRoutine {
+		defer b.DisableUnsafeInternalCheck()()
+	}
+
+	// Pass funcExpr=nil to indicate the deferred path (the return type is
+	// already resolved).
+	stmt, props, _ = b.buildOneBodyStmt(
+		rb.stmtASTs[stmtIdx], bodyScope, rb.rTyp, nil /* funcExpr */, nil, /* inScope */
+		rb.isSetReturning, rb.insideDataSource, stmtIdx, len(rb.stmtASTs)-1,
+	)
+	return stmt, props, params, nil
+}
+
+// newBodyBuilder creates and configures a Builder for building this routine's
+// body statements at execution time, returning the builder, a body scope
+// populated with the routine's parameter columns, and the parameter column
+// list.
+//
+// Callers building a builtin routine must additionally disable the
+// unsafe-internals check on the returned builder for the duration of the build;
+// see Build and BuildStmt.
+func (rb *sqlRoutineBodyBuilder) newBodyBuilder(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	catalog cat.Catalog,
+	factoryI interface{},
+) (b *Builder, bodyScope *scope, params opt.ColList) {
 	factory := factoryI.(*norm.Factory)
-	b := New(ctx, semaCtx, evalCtx, catalog, factory, nil /* stmt */)
+	b = New(ctx, semaCtx, evalCtx, catalog, factory, nil /* stmt */)
 
 	// Initialize the statement tree from the captured init function.
 	if rb.stmtTreeInitFn != nil {
@@ -1043,11 +1182,6 @@ func (rb *sqlRoutineBodyBuilder) Build(
 	b.insideSQLRoutine = true
 	b.trackSchemaDeps = false
 
-	// Builtin routines need access to internal tables.
-	if rb.routineType == tree.BuiltinRoutine {
-		defer b.DisableUnsafeInternalCheck()()
-	}
-
 	// Restore the effective privilege user for SECURITY DEFINER contexts.
 	if rb.privilegeUser != "" {
 		privUser := username.MakeSQLUsernameFromPreNormalizedString(rb.privilegeUser)
@@ -1055,8 +1189,18 @@ func (rb *sqlRoutineBodyBuilder) Build(
 		b.executePrivilegeUserOverride = privUser
 	}
 
-	// Create body scope with parameter columns.
-	bodyScope := b.allocScope()
+	// The stable parameter-column-ID guarantee documented on
+	// RoutineBodyBuilder.BuildStmt holds only because the parameter columns are
+	// the first columns synthesized into the factory. Guard against a future
+	// change allocating a column earlier, which would silently shift the IDs.
+	if n := b.factory.Metadata().NumColumns(); n != 0 {
+		panic(errors.AssertionFailedf(
+			"expected no columns synthesized before routine parameters, found %d", n,
+		))
+	}
+
+	// Create the body scope with parameter columns.
+	bodyScope = b.allocScope()
 	params = make(opt.ColList, len(rb.paramTypes))
 	for i := range rb.paramTypes {
 		var name tree.Name
@@ -1070,16 +1214,7 @@ func (rb *sqlRoutineBodyBuilder) Build(
 		col.setParamOrd(i)
 		params[i] = col.id
 	}
-
-	// Build the body statements using the shared helper. Pass
-	// funcExpr=nil to indicate the deferred path (return type is already
-	// resolved).
-	body, bodyProps, _ = b.buildSQLRoutineBodyStmts(
-		rb.stmtASTs, bodyScope, rb.rTyp,
-		nil /* funcExpr */, nil, /* inScope */
-		rb.isSetReturning, rb.insideDataSource,
-	)
-	return body, bodyProps, params, nil
+	return b, bodyScope, params
 }
 
 // buildDoBody builds the body of the anonymous routine for a DO statement.

--- a/pkg/sql/opt/optbuilder/routine_test.go
+++ b/pkg/sql/opt/optbuilder/routine_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package optbuilder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/testcat"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+// routineBuilderHarness bundles the state needed to drive a
+// sqlRoutineBodyBuilder directly in a unit test, without going through
+// buildRoutine.
+type routineBuilderHarness struct {
+	ctx     context.Context
+	semaCtx tree.SemaContext
+	evalCtx eval.Context
+	catalog cat.Catalog
+}
+
+func newRoutineBuilderHarness() *routineBuilderHarness {
+	ctx := context.Background()
+	return &routineBuilderHarness{
+		ctx:     ctx,
+		semaCtx: tree.MakeSemaContext(nil /* resolver */),
+		evalCtx: eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
+		catalog: testcat.New(),
+	}
+}
+
+// freshFactory returns a norm.Factory backed by a new, empty memo. Build and
+// BuildStmt each require their own factory; a fresh factory also makes
+// column-ID allocation deterministic across calls.
+func (h *routineBuilderHarness) freshFactory() *norm.Factory {
+	var f norm.Factory
+	f.Init(h.ctx, &h.evalCtx, h.catalog)
+	return &f
+}
+
+func (h *routineBuilderHarness) parseBody(t *testing.T, body string) []tree.Statement {
+	stmts, err := parser.Parse(body)
+	require.NoError(t, err)
+	asts := make([]tree.Statement, len(stmts))
+	for i := range stmts {
+		asts[i] = stmts[i].AST
+	}
+	return asts
+}
+
+func (h *routineBuilderHarness) newBodyBuilder(
+	t *testing.T,
+	body string,
+	rTyp *types.T,
+	isSetReturning bool,
+	paramNames []tree.Name,
+	paramTypes []*types.T,
+) memo.RoutineBodyBuilder {
+	return newSQLRoutineBodyBuilder(sqlRoutineBodyBuilder{
+		stmtASTs:       h.parseBody(t, body),
+		paramTypes:     paramTypes,
+		paramNames:     paramNames,
+		rTyp:           rTyp,
+		isSetReturning: isSetReturning,
+		routineType:    tree.UDFRoutine,
+	})
+}
+
+// TestSQLRoutineBodyBuilderNumStmts verifies that NumStmts reflects the number
+// of body statements, including the synthetic VALUES (NULL) statement appended
+// for VOID-returning routines.
+func TestSQLRoutineBodyBuilderNumStmts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	h := newRoutineBuilderHarness()
+	testCases := []struct {
+		name             string
+		body             string
+		rTyp             *types.T
+		expectedNumStmts int
+	}{
+		{name: "single statement", body: "SELECT 1", rTyp: types.Int, expectedNumStmts: 1},
+		{name: "multiple statements", body: "SELECT 1; SELECT 2; SELECT 3", rTyp: types.Int, expectedNumStmts: 3},
+		{name: "void appends synthetic statement", body: "SELECT 1", rTyp: types.Void, expectedNumStmts: 2},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rb := h.newBodyBuilder(
+				t, tc.body, tc.rTyp, false /* isSetReturning */, nil /* paramNames */, nil, /* paramTypes */
+			)
+			require.Equal(t, tc.expectedNumStmts, rb.NumStmts())
+		})
+	}
+}
+
+// TestSQLRoutineBodyBuilderBuildStmtMatchesBuild verifies that building the body
+// one statement at a time via BuildStmt produces the same number of statements,
+// the same per-statement operators, and the same parameter columns as the
+// all-at-once Build.
+func TestSQLRoutineBodyBuilderBuildStmtMatchesBuild(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	h := newRoutineBuilderHarness()
+	rb := h.newBodyBuilder(
+		t, "SELECT 1; SELECT 2; SELECT 3", types.Int, false /* isSetReturning */, nil, nil,
+	)
+
+	body, bodyProps, params, err := rb.Build(
+		h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(),
+	)
+	require.NoError(t, err)
+	require.Len(t, body, rb.NumStmts())
+	require.Len(t, bodyProps, rb.NumStmts())
+
+	for i := 0; i < rb.NumStmts(); i++ {
+		stmt, props, perStmtParams, err := rb.BuildStmt(
+			h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(), i,
+		)
+		require.NoErrorf(t, err, "stmt %d", i)
+		require.NotNil(t, stmt)
+		require.NotNil(t, props)
+		require.Equalf(t, body[i].Op(), stmt.Op(), "operator mismatch at stmt %d", i)
+		require.Equalf(t, params, perStmtParams, "params mismatch at stmt %d", i)
+	}
+}
+
+// TestSQLRoutineBodyBuilderStableParamCols verifies that BuildStmt returns the
+// same parameter column IDs regardless of which statement index is built. The
+// interleaved build/execute path relies on this so that argument-to-parameter
+// mapping is consistent across statements.
+func TestSQLRoutineBodyBuilderStableParamCols(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	h := newRoutineBuilderHarness()
+	rb := h.newBodyBuilder(
+		t, "VALUES (1); SELECT 2; SELECT 3 UNION SELECT 4", types.Int, false, /* isSetReturning */
+		[]tree.Name{"a", "b"}, []*types.T{types.Int, types.String},
+	)
+
+	_, _, params0, err := rb.BuildStmt(h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(), 0)
+	require.NoError(t, err)
+	_, _, params1, err := rb.BuildStmt(h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(), 1)
+	require.NoError(t, err)
+	_, _, params2, err := rb.BuildStmt(h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(), 2)
+	require.NoError(t, err)
+	require.Len(t, params0, 2)
+	require.Equal(t, params0, params1)
+	require.Equal(t, params0, params2)
+}
+
+// TestSQLRoutineBodyBuilderLastStmtFinalization verifies that only the final
+// body statement is finalized as the routine's output. For a non-set-returning
+// routine, finalization applies an implicit LIMIT 1, which caps the statement's
+// cardinality.
+func TestSQLRoutineBodyBuilderLastStmtFinalization(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	h := newRoutineBuilderHarness()
+	rb := h.newBodyBuilder(
+		t, "VALUES (1), (2), (3); VALUES (4), (5), (6)", types.Int, false /* isSetReturning */, nil, nil,
+	)
+
+	last, _, _, err := rb.BuildStmt(h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(), 1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), last.Relational().Cardinality.Max)
+
+	first, _, _, err := rb.BuildStmt(h.ctx, &h.semaCtx, &h.evalCtx, h.catalog, h.freshFactory(), 0)
+	require.NoError(t, err)
+	require.Equal(t, uint32(3), first.Relational().Cardinality.Max)
+}


### PR DESCRIPTION
Deferred SQL routine bodies are currently built one batch at a time, so every body statement is built against the same catalog snapshot. That prevents a statement from seeing schema changes made by an earlier statement in the same routine, which is a prerequisite for supporting DDL inside stored procedures.

This change extends RoutineBodyBuilder so a body can be built one statement at a time. NumStmts reports the statement count and BuildStmt builds a single statement against the caller-provided catalog, allowing the catalog to be refreshed between statements in a later change. The existing all-at-once Build path is preserved and now shares the per-statement building logic. No behavior changes yet; there are no new callers of the per-statement API.

Informs: #171024
Epic: CRDB-31256

Release note: None