### PR TITLE
sql: deflake TestTrackOnlyUserOpenTransactionsAndActiveStatements

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -2191,10 +2191,21 @@ func TestTrackOnlyUserOpenTransactionsAndActiveStatements(t *testing.T) {
 		// Begin a user-initiated transaction.
 		testTx := testDB.Begin(t)
 
-		// Check that the number of open transactions has incremented, but not the
-		// internal metric.
+		// Check that the user-facing open-transaction gauge incremented due to the
+		// transaction we just began.
+		//
+		// We intentionally do not assert that the internal open-transaction gauge is
+		// unchanged here: it is not stable at any given instant. shouldBlock only
+		// blocks internal statements inside the AfterExecute hook, which does not stop
+		// a background internal transaction (lease acquisition, stats collection, etc.)
+		// from either incrementing the gauge before its first statement reaches the
+		// hook, or decrementing it in recordTransactionFinish if it had already passed
+		// the hook before shouldBlock was set. An exact-equality assertion against a
+		// captured baseline therefore raced with this background activity in both
+		// directions and was the cause of #170861 and a long line of earlier flakes.
+		// The user/internal separation is still verified below, where the user gauges
+		// must stay constant while the internal gauges rise above their baselines.
 		require.Equal(t, int64(1), sqlServer.Metrics.EngineMetrics.SQLTxnsOpen.Value())
-		require.Equal(t, prevInternalTxnsOpen, sqlServer.InternalMetrics.EngineMetrics.SQLTxnsOpen.Value())
 
 		// Create a state of contention. Use a cancellable context so that the
 		// other queries that get blocked on this one don't deadlock if the test


### PR DESCRIPTION
The test captured a baseline of the internal open-transaction gauge
(`InternalMetrics.EngineMetrics.SQLTxnsOpen`), began a user transaction,
and then asserted via `require.Equal` that the internal gauge was
unchanged. That assertion is racy: the internal gauge is not stable at
any instant.

The test's `shouldBlock` flag only blocks internal statements inside the
`AfterExecute` hook. It does not stop a background internal transaction
(lease acquisition, stats collection, etc.) from either incrementing the
gauge in `recordTransactionStart` before its first statement reaches the
hook, or decrementing it in `recordTransactionFinish` if it had already
passed the hook before `shouldBlock` was set. The captured baseline could
therefore drift in both directions before the assertion ran, which is why
prior failures showed both `expected=0/actual=1` and `expected=1/actual=0`.

This was verified locally: the test failed on the first run at the failure
SHA, and instrumenting the gauge over the window between baseline capture
and the assertion showed it transitioning even with `shouldBlock` set.

This PR drops the exact-equality assertion on the internal gauge and
explains why it cannot be made deterministic. The user/internal separation
the test cares about is still verified below, where the user gauges must
stay constant while the internal gauges rise above their baselines.

Fixes #170861

Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)