### PR TITLE
release-26.1: sql: enforce statement_timeout on descriptor waits

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -237,19 +237,21 @@ func (tc *Collection) ReleaseSpecifiedLeases(ctx context.Context, descs []lease.
 // locked lease timestamp gets bumped.
 func (tc *Collection) MaybeWaitForLeaseTimestampBump(
 	ctx context.Context, commitTime hlc.Timestamp,
-) {
+) error {
 	// This transaction does not require any leased timestamp bump.
 	if !tc.waitForLockedLeaseBump {
-		return
+		return nil
 	}
 	// Confirm the lease manager is leasing out any new descriptor versions
 	// at the commit time.
 	r := retry.StartWithCtx(ctx, retry.Options{})
 	for r.Next() {
 		if !tc.leased.lm.GetSafeReplicationTS().Less(commitTime) {
-			break
+			return nil
 		}
 	}
+	// Otherwise, the context has timed out or has been cancelled.
+	return ctx.Err()
 }
 
 // ReleaseLeases releases all leases. Errors are logged but ignored.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -148,25 +148,26 @@ func (m *Manager) WaitForNoVersion(
 	defer decAfterWait()
 	wsTracker := startWaitStatsTracker(ctx)
 	defer wsTracker.end()
-	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
+	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		now := m.storage.clock.Now()
 		detail, err := countLeasesWithDetail(ctx, m.storage.db, m.Codec(), regions, m.settings, versions, now, true /*forAnyVersion*/)
 		if err != nil {
 			return err
 		}
 		if detail.count == 0 {
-			break
+			return nil
 		}
 		if detail.count != lastCount {
 			lastCount = detail.count
 			wsTracker.updateProgress(detail)
 			log.Dev.Infof(ctx, "waiting for %d leases to expire: desc=%d", detail.count, id)
 		}
-		if lastCount == 0 {
-			break
-		}
 	}
-	return nil
+	// Return context cancellation back if detected.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return errors.New("exited lease wait loop before success")
 }
 
 // maybeGetDescriptorsWithoutValidation gets descriptors without validating from
@@ -359,7 +360,8 @@ func (m *Manager) WaitForInitialVersion(
 	for _, id := range descriptorsIds {
 		ids.Add(id)
 	}
-	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
+	success := false
+	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		descs, err := m.maybeGetDescriptorsWithoutValidation(ctx, ids.Ordered(), false /* existenceExpected */)
 		if err != nil {
 			return err
@@ -521,6 +523,7 @@ func (m *Manager) WaitForInitialVersion(
 		}
 		// All the expected sessions are there now.
 		if totalCount == totalExpectedCount {
+			success = true
 			break
 		}
 		if totalCount != lastCount {
@@ -531,6 +534,12 @@ func (m *Manager) WaitForInitialVersion(
 			})
 		}
 		lastCount = totalCount
+	}
+	if !success {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return errors.New("exited lease wait loop before success")
 	}
 	return nil
 }
@@ -559,7 +568,8 @@ func (m *Manager) WaitForOneVersion(
 	defer wsTracker.end()
 
 	var desc catalog.Descriptor
-	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
+	success := false
+	for lastCount, r := 0, retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		var err error
 		desc, err = m.maybeGetDescriptorWithoutValidation(ctx, id, true)
 		if err != nil {
@@ -575,6 +585,7 @@ func (m *Manager) WaitForOneVersion(
 			return nil, err
 		}
 		if detail.count == 0 {
+			success = true
 			log.Dev.Infof(ctx, "all leases have expired at %v: desc=%v", now, descs)
 			break
 		}
@@ -584,7 +595,9 @@ func (m *Manager) WaitForOneVersion(
 			log.Dev.Infof(ctx, "waiting for %d leases to expire: desc=%v", detail.count, descs)
 		}
 	}
-
+	if !success && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	return desc, nil
 }
 
@@ -612,7 +625,7 @@ func (m *Manager) WaitForNewVersion(
 	// also holds a lease on the current version of the descriptor (`for all
 	// session: (session in Prev => session in Curr)` for the set theory
 	// enjoyers).
-	for r := retry.Start(retryOpts); r.Next(); {
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		var err error
 		desc, err = m.maybeGetDescriptorWithoutValidation(ctx, id, true)
 		if err != nil {
@@ -682,6 +695,10 @@ func (m *Manager) WaitForNewVersion(
 		}
 	}
 	if !success {
+		// Return context cancellation back if detected.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		return nil, errors.New("Exited lease acquisition loop before success")
 	}
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -91,6 +91,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tochar"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -4227,25 +4228,33 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// wait for one version (if no job exists) or the initial version to be
 		// acquired.
 		if ex.extraTxnState.descCollection.HasUncommittedDescriptors() {
-			cachedRegions, err := regions.NewCachedDatabaseRegions(ex.Ctx(), ex.server.cfg.DB, ex.server.cfg.LeaseManager)
+			// Apply statement timeout on any waiting logic.
+			err = ex.runWithStatementTimeout(func(ctx context.Context) error {
+				cachedRegions, err := regions.NewCachedDatabaseRegions(ctx, ex.server.cfg.DB, ex.server.cfg.LeaseManager)
+				if err != nil {
+					return err
+				}
+				if err := ex.waitOneVersionForNewVersionDescriptorsWithoutJobs(ctx, descIDsInJobs, cachedRegions); err != nil {
+					return err
+				}
+				if err := ex.waitForNewVersionPropagation(ctx, descIDsInJobs, cachedRegions); err != nil {
+					return err
+				}
+				if err := ex.waitForInitialVersionForNewDescriptors(ctx, cachedRegions); err != nil {
+					return err
+				}
+				// If a repair query was executed, then we need to confirm that the lease manager
+				// is handing out the new descriptor version. This is covered by the previous waits
+				// if the prior version was valid, but if it was invalid, then we need the lease manager
+				// to have a new timestamp available.
+				return ex.extraTxnState.descCollection.MaybeWaitForLeaseTimestampBump(ctx, advInfo.txnEvent.commitTimestamp)
+			}, func() error {
+				return ex.planner.noticeSender.SendNotice(ex.Ctx(), pgnotice.Newf("The statement has timed out while waiting for the "+
+					"schema change to be visible on all nodes."), true /* immediateFlush */)
+			})
 			if err != nil {
-				return advanceInfo{}, err
+				handleErr(err)
 			}
-			if err := ex.waitOneVersionForNewVersionDescriptorsWithoutJobs(descIDsInJobs, cachedRegions); err != nil {
-				return advanceInfo{}, err
-			}
-			if err := ex.waitForNewVersionPropagation(descIDsInJobs, cachedRegions); err != nil {
-				return advanceInfo{}, err
-			}
-			if err := ex.waitForInitialVersionForNewDescriptors(cachedRegions); err != nil {
-				return advanceInfo{}, err
-			}
-			// If a repair query was executed, then we need to confirm that the lease manager
-			// is handing out the new descirptor version. This is covered by the previous waits
-			// if the prior version was valid, but if it was invalid then we need the lease manager
-			// to have a new timestamp available.
-			ex.extraTxnState.descCollection.MaybeWaitForLeaseTimestampBump(ex.Ctx(), advInfo.txnEvent.commitTimestamp)
-
 			execCfg := ex.planner.ExecCfg()
 			if err := UpdateDescriptorCount(ex.Ctx(), execCfg, execCfg.SchemaChangerMetrics); err != nil {
 				log.Dev.Warningf(ex.Ctx(), "failed to update descriptor count metric: %v", err)
@@ -4271,24 +4280,27 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		return advanceInfo{}, errors.AssertionFailedf(
 			"unexpected event: %v", errors.Safe(advInfo.txnEvent))
 	}
+
 	return advInfo, nil
 }
 
-// waitForTxnJobs waits for any jobs created inside this txn
-// and respects the statement timeout for implicit transactions.
-func (ex *connExecutor) waitForTxnJobs() error {
-	var retErr error
-	if len(ex.extraTxnState.jobs.created) == 0 {
-		return nil
-	}
-	ex.mu.IdleInSessionTimeout.Stop()
-	defer ex.startIdleInSessionTimeout()
-	ex.server.cfg.JobRegistry.NotifyToResume(
-		ex.ctxHolder.connCtx, ex.extraTxnState.jobs.created...,
-	)
-	// Set up a context for waiting for the jobs, which can be cancelled if
-	// a statement timeout exists.
-	jobWaitCtx := ex.ctxHolder.ctx()
+// onTxnStart performs bookkeeping when a new transaction starts, including
+// recording the transaction start event and marking the session as active.
+func (ex *connExecutor) onTxnStart(txnID uuid.UUID) error {
+	ex.recordTransactionStart(txnID)
+	ex.totalActiveTimeStopWatch.Start()
+	return ex.maybeSetSQLLivenessSessionAndGeneration()
+}
+
+// runWithStatementTimeout runs the given function with a context that has
+// the statement timeout applied. If the statement timeout is exceeded,
+// the onTimeoutError function is called and the return value of the function
+// is returned.
+func (ex *connExecutor) runWithStatementTimeout(
+	execFn func(ctx context.Context) error, onTimeoutError func() error,
+) error {
+	// Set up a context that can be cancelled when the statement timeout is exceeded.
+	waitCtx := ex.ctxHolder.ctx()
 	var queryTimedout atomic.Bool
 	if ex.sessionData().StmtTimeout > 0 {
 		timePassed := ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived).Elapsed()
@@ -4296,18 +4308,47 @@ func (ex *connExecutor) waitForTxnJobs() error {
 			queryTimedout.Store(true)
 		} else {
 			var cancelFn context.CancelFunc
-			jobWaitCtx, cancelFn = context.WithCancel(jobWaitCtx)
+			waitCtx, cancelFn = context.WithCancel(waitCtx)
 			queryTimeTicker := time.AfterFunc(ex.sessionData().StmtTimeout-timePassed, func() {
-				// Before the cancellation make sure that the query
-				// is marked as timed out.
-				queryTimedout.Store(true)
 				cancelFn()
+				queryTimedout.Store(true)
 			})
 			defer cancelFn()
 			defer queryTimeTicker.Stop()
 		}
 	}
-	if !queryTimedout.Load() && len(ex.extraTxnState.jobs.created) > 0 {
+	if queryTimedout.Load() {
+		if err := onTimeoutError(); err != nil {
+			log.Dev.Warningf(ex.Ctx(), "failed to send timeout notice: %v", err)
+		}
+		return sqlerrors.QueryTimeoutError
+	}
+	err := execFn(waitCtx)
+	// Detect a context cancelled or a query cancelled error.
+	if (errors.Is(err, context.Canceled) ||
+		errors.Is(err, cancelchecker.QueryCanceledError)) && queryTimedout.Load() {
+		if err := onTimeoutError(); err != nil {
+			log.Dev.Warningf(ex.Ctx(), "failed to send timeout notice: %v", err)
+		}
+		return sqlerrors.QueryTimeoutError
+	}
+	return err
+}
+
+// waitForTxnJobs waits for any jobs created inside this txn
+// and respects the statement timeout for implicit transactions.
+func (ex *connExecutor) waitForTxnJobs() error {
+	if len(ex.extraTxnState.jobs.created) == 0 {
+		return nil
+	}
+
+	ex.mu.IdleInSessionTimeout.Stop()
+	defer ex.startIdleInSessionTimeout()
+	ex.server.cfg.JobRegistry.NotifyToResume(
+		ex.ctxHolder.connCtx, ex.extraTxnState.jobs.created...,
+	)
+
+	return ex.runWithStatementTimeout(func(ctx context.Context) error {
 		if !ex.sessionData().DisableWaitForJobsNotice {
 			jobIDs := strings.Builder{}
 			for i, jobID := range ex.extraTxnState.jobs.created {
@@ -4323,37 +4364,29 @@ func (ex *connExecutor) waitForTxnJobs() error {
 				return err
 			}
 		}
-		if err := ex.server.cfg.JobRegistry.WaitForJobs(jobWaitCtx,
-			ex.extraTxnState.jobs.created); err != nil {
-			if errors.Is(err, context.Canceled) && queryTimedout.Load() {
-				retErr = sqlerrors.QueryTimeoutError
-				err = nil
-			} else {
+		return ex.server.cfg.JobRegistry.WaitForJobs(ctx,
+			ex.extraTxnState.jobs.created)
+	},
+		func() error {
+			jobList := strings.Builder{}
+			for i, j := range ex.extraTxnState.jobs.created {
+				if i > 0 {
+					jobList.WriteString(",")
+				}
+				jobList.WriteString(j.String())
+			}
+			if err := ex.planner.noticeSender.SendNotice(
+				ex.ctxHolder.connCtx,
+				pgnotice.Newf(
+					"The statement has timed out, but the following "+
+						"background jobs have been created and will continue running: %s.",
+					jobList.String()),
+				false, /* immediateFlush */
+			); err != nil {
 				return err
 			}
-		}
-	}
-	// If the query timed out indicate that there are jobs left behind.
-	if queryTimedout.Load() {
-		jobList := strings.Builder{}
-		for i, j := range ex.extraTxnState.jobs.created {
-			if i > 0 {
-				jobList.WriteString(",")
-			}
-			jobList.WriteString(j.String())
-		}
-		if err := ex.planner.noticeSender.SendNotice(
-			ex.ctxHolder.connCtx,
-			pgnotice.Newf(
-				"The statement has timed out, but the following "+
-					"background jobs have been created and will continue running: %s.",
-				jobList.String()),
-			false, /* immediateFlush */
-		); err != nil {
-			return err
-		}
-	}
-	return retErr
+			return nil
+		})
 }
 
 func (ex *connExecutor) maybeSetSQLLivenessSessionAndGeneration() error {

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1146,11 +1147,16 @@ func TestStatementTimeoutForSchemaChangeCommit(t *testing.T) {
 				if implicitTxn {
 					_, err := conn.DB.ExecContext(ctx, "ALTER TABLE t1 ADD COLUMN j INT DEFAULT 32")
 					require.ErrorContains(t, err, sqlerrors.QueryTimeoutError.Error())
-					require.Equal(t, 2, len(actualNotices))
+					// There will be one notice for the job and one from the WaitForOneVersion
+					// operation. In addition to the notice from the job that was created.
+					require.Equal(t, 3, len(actualNotices))
 					require.Regexp(t, "waiting for job\\(s\\) to complete: \\d+", actualNotices[0])
 					require.Regexp(t,
 						"The statement has timed out, but the following background jobs have been created and will continue running: \\d+",
 						actualNotices[1])
+					require.Regexp(t,
+						"The statement has timed out while waiting for the schema change to be visible on all nodes.",
+						actualNotices[2])
 				} else {
 					txn := conn.Begin(t)
 					_, err := txn.Exec("SET LOCAL autocommit_before_ddl=off")
@@ -1161,5 +1167,101 @@ func TestStatementTimeoutForSchemaChangeCommit(t *testing.T) {
 					require.NoError(t, err)
 				}
 			})
+	}
+}
+
+// TestStatementTimeoutForSchemaChangeWaitForOneVersion confirms that waiting new versions
+// also respects the statement timeout.
+func TestStatementTimeoutForSchemaChangeWaitForOneVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	skip.UnderDuress(t, "sets a long timeout")
+
+	numNodes := 1
+	tc := serverutils.StartCluster(t, numNodes,
+		base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	url, cleanup := tc.ApplicationLayer(0).PGUrl(t)
+	defer cleanup()
+	baseConn, err := pq.NewConnector(url.String())
+	require.NoError(t, err)
+	actualNotices := make([]string, 0)
+	connector := pq.ConnectorWithNoticeHandler(baseConn, func(n *pq.Error) {
+		actualNotices = append(actualNotices, n.Message)
+	})
+	dbWithHandler := gosql.OpenDB(connector)
+	defer dbWithHandler.Close()
+
+	conn := sqlutils.MakeSQLRunner(dbWithHandler)
+	for _, test := range []struct {
+		description              string
+		setup                    string
+		blockingTxn              string
+		schemaChange             string
+		forceLegacySchemaChanger bool
+		expectJobMessage         bool
+	}{
+		{
+			description:  "WaitForOneVersion",
+			setup:        "CREATE TABLE t1 (n int);",
+			blockingTxn:  "SELECT * FROM t1;",
+			schemaChange: "ALTER TABLE t1 ADD COLUMN j INT DEFAULT 32",
+		},
+		{
+			description:  "WaitForNoVersion",
+			setup:        "CREATE TABLE t2 (n int);",
+			blockingTxn:  "SELECT * FROM t2",
+			schemaChange: "DROP TABLE t2",
+		},
+		{
+			description:  "WaitForInitialVersion",
+			setup:        "SELECT 1",
+			blockingTxn:  "DELETE FROM system.lease;",
+			schemaChange: "CREATE TABLE t3 (n int)",
+		},
+		{
+			description:  "waitForTxnJobs",
+			setup:        "CREATE TABLE t4(n int) WITH (schema_locked=false)",
+			blockingTxn:  "SELECT * FROM t4",
+			schemaChange: "ALTER TABLE t4 ADD COLUMN j int;",
+			// The legacy schema changer will execute the WaitForOneVersion in
+			// the job. So, this allows us to confirm the job wait code can be
+			// canceled as well.
+			forceLegacySchemaChanger: true,
+			// We expect the message to occur while waiting for the job.
+			expectJobMessage: true,
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			conn.Exec(t, "RESET statement_timeout")
+			conn.Exec(t, "RESET use_declarative_schema_changer")
+			conn.Exec(t, test.setup)
+			txn := conn.Begin(t)
+			_, err := txn.Exec(test.blockingTxn)
+			require.NoError(t, err)
+			if test.forceLegacySchemaChanger {
+				conn.Exec(t, "SET use_declarative_schema_changer='off'")
+			}
+			conn.Exec(t, "SET statement_timeout = '1s'")
+			conn.ExpectErr(t, "pq: query execution canceled due to statement timeout", test.schemaChange)
+			err = txn.Rollback()
+			require.NoError(t, err)
+			foundSchemaChangeNotice := false
+			for _, notice := range actualNotices {
+				expectedNotice := "The statement has timed out while waiting for the schema change to be visible on all nodes."
+				if test.expectJobMessage {
+					expectedNotice = `The statement has timed out, but the following background jobs have been created and will continue running: \d+.`
+				}
+				noticeRegex := regexp.MustCompile(expectedNotice)
+				if noticeRegex.MatchString(notice) {
+					foundSchemaChangeNotice = true
+					break
+				}
+			}
+			require.True(t, foundSchemaChangeNotice, "schema change notice not found: %v", actualNotices)
+			actualNotices = actualNotices[:0]
+		})
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #160076.

Manually resolved backport.

Fixes: #171096
Fixes: #170907

/cc @cockroachdb/release

---

Previously, when a schema change was execute with a statement_timeout, we would enforce any statement timeouts on the job waits. However, there was also additional logic to wait for descriptors, that could apply afterwards. This patch, ensures that any extra logic complies with the statement_timeout, which will generate a similar query timeout error.

Fixes: #158272

Release note: None

Release justification: WIP. In discussion.
