### PR TITLE
testutils/testcluster: shard testcluster_test

### DIFF
--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     ],
     embed = [":testcluster"],
     exec_properties = {"test.Pool": "large"},
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/keys",


### PR DESCRIPTION
Previously, `//pkg/testutils/testcluster:testcluster_test` ran as a single medium-sized `Bazel` target under race.

This was inadequate because slower race runs could consume most of the target timeout before `TestRestart` ran, causing `Bazel` to kill the binary rather than report a test failure.

This patch brings `shard_count = 4` to the target, giving the package tests separate shard timeout budgets and reducing the longest local race shard runtime.

Epic: none
Fixes #171163
Release note: None