### PR TITLE
release-25.4: roachtest: ignore flaky hibernate test

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -25,6 +25,7 @@ var hibernateIgnoreList = blocklist{
 	`org.hibernate.orm.test.jpa.txn.JtaTransactionJoiningTest.control()`:                                 "flaky",
 	`org.hibernate.orm.test.jpa.txn.JtaTransactionJoiningTest.testImplicitJoining()`:                     "flaky",
 	"org.hibernate.orm.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[0]":              "flaky",
+	"org.hibernate.orm.test.schemaupdate.SchemaUpdateTest.testSchemaUpdateAndValidation[1]":              "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
 	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #171142 on behalf of @bghal.

----

The test flakes it gets ignored.

Epic: none
Fixes: #170801

Release note: None


----

Release justification: