### PR TITLE
release-25.2: sql: skip `ALTER TYPE` in `TestExplainGist`

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -292,6 +292,14 @@ func TestExplainGist(t *testing.T) {
 						return true
 					}
 				}
+				// ALTER TYPE schema changes wait on descriptor leases without
+				// honoring statement_timeout. In release branches that lack
+				// either the post-commit fix (#160076) or the pre-commit fix
+				// (#169331), the wait can run for the full lease duration,
+				// exhausting the test's three-minute limit.
+				if strings.HasPrefix(stmt, "ALTER TYPE") {
+					return true
+				}
 				return false
 			}(); shouldSkip {
 				continue


### PR DESCRIPTION
Backport 1/1 commits from #171197 on behalf of @bghal.

----

Backporting the fixes isn't justifiable. This skip
will be backported to all all the release branches
to quiet the tests.

Fixes: #171096

Epic: none

Release note: None

Release justification: Test-only change.


----

Release justification: Test-only change.