### PR TITLE
sql: populate pg_auth_members.grantor

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3149,8 +3149,8 @@ query OOOOBBB colnames
 SELECT oid, roleid, member, grantor, admin_option, inherit_option, set_option
 FROM pg_catalog.pg_auth_members
 ----
-oid         roleid      member      grantor  admin_option  inherit_option  set_option
-3818609862  2310524507  1546506610  NULL     true          true            true
+oid         roleid      member      grantor     admin_option  inherit_option  set_option
+3818609862  2310524507  1546506610  2310524507  true          true            true
 
 ## pg_catalog.pg_user
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -851,10 +851,16 @@ https://www.postgresql.org/docs/18/catalog-pg-auth-members.html`,
 					h.RoleMembershipOid(roleName, memberName), // oid
 					h.UserOid(roleName),                       // roleid
 					h.UserOid(memberName),                     // member
-					tree.DNull,                                // grantor
-					tree.MakeDBool(tree.DBool(isAdmin)),       // admin_option
-					tree.MakeDBool(tree.DBool(true)),          // inherit_option
-					tree.MakeDBool(tree.DBool(true)),          // set_option
+					// CockroachDB does not track the grantor of a role
+					// membership, so the admin role is reported as a stand-in. A
+					// real, non-droppable grantor is required for tools like
+					// pg_dumpall to emit the membership rather than treating it
+					// as orphaned and silently dropping it. See
+					// https://github.com/cockroachdb/cockroach/issues/67442.
+					adminOID,                            // grantor
+					tree.MakeDBool(tree.DBool(isAdmin)), // admin_option
+					tree.MakeDBool(tree.DBool(true)),    // inherit_option
+					tree.MakeDBool(tree.DBool(true)),    // set_option
 				)
 			},
 		)


### PR DESCRIPTION
The grantor column of the pg_catalog.pg_auth_members virtual table was hardcoded to NULL. PostgreSQL 16+ requires a valid, resolvable grantor on every role-membership row, and tools that read it treat a NULL or unresolvable grantor as an orphaned membership. In particular, pg_dumpall --roles-only silently drops every role membership from its output (emitting a "found orphaned pg_auth_members entry" warning), losing all GRANT <role> TO <member> statements in the dump.

CockroachDB does not track the grantor of a role membership: the system.role_members table has no grantor column and the GRANT-role write path never records the executing user. The grantor is therefore reported as the admin role, mirroring the existing convention for object ACLs that substitutes a stand-in grantor (see #67442). The admin role is a non-droppable superuser role, so it always resolves and pg_dumpall no longer treats memberships as orphaned.

See also: #67442
Epic: CRDB-28751
Release note: None