### PR TITLE
sql: default pg_dump_compatibility for dump/restore clients

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -956,6 +956,29 @@ func (s *Server) SetupConn(
 ) (ConnectionHandler, error) {
 	sd := newSessionData(args)
 	sds := sessiondata.NewStack(sd)
+
+	// For the PostgreSQL dump/restore client tools (pg_dump, pg_restore,
+	// pg_dumpall), default pg_dump_compatibility to "cockroachdb" so that dumps
+	// are correct out of the box. We only do this when the client has not
+	// configured pg_dump_compatibility explicitly, so that an explicit value
+	// (including "off") is always honored. The decision is keyed off the
+	// startup application_name and is applied through the normal session-default
+	// path below, which also validates the value. The resulting notice is
+	// delivered to the client during sendInitialConnData.
+	var startupNotices []pgnotice.Notice
+	if _, explicit := args.SessionDefaults["pg_dump_compatibility"]; !explicit {
+		appName := args.SessionDefaults["application_name"]
+		if val, ok := sessiondatapb.DefaultPgDumpCompatibilityForAppName(appName); ok {
+			args.SessionDefaults["pg_dump_compatibility"] = val
+			notice := pgnotice.Newf(
+				"setting pg_dump_compatibility = %q because application_name is %q", val, appName,
+			)
+			notice = pgnotice.Notice(errors.WithHint(notice,
+				"set pg_dump_compatibility explicitly (e.g. 'off' or 'postgres') to override this default"))
+			startupNotices = append(startupNotices, notice)
+		}
+	}
+
 	// Set the SessionData from args.SessionDefaults. This also validates the
 	// respective values.
 	sdMutIterator := sessionmutator.MakeSessionDataMutatorIterator(sds, args.SessionDefaults, s.cfg.Settings)
@@ -998,7 +1021,7 @@ func (s *Server) SetupConn(
 		false, /* underOuterTxn */
 		nil,   /* postSetupFn */
 	)
-	return ConnectionHandler{ex}, nil
+	return ConnectionHandler{ex: ex, startupNotices: startupNotices}, nil
 }
 
 // IncrementConnectionCount increases connectionCount by 1 if possible and
@@ -1077,6 +1100,18 @@ func (s *Server) GetConnectionCount() int64 {
 // it away from other packages.
 type ConnectionHandler struct {
 	ex *connExecutor
+	// startupNotices are NOTICE messages accumulated during connection setup
+	// (e.g. when pg_dump_compatibility is defaulted for a dump/restore client).
+	// They are delivered to the client during sendInitialConnData, before the
+	// initial ReadyForQuery.
+	startupNotices []pgnotice.Notice
+}
+
+// GetStartupNotices returns the NOTICE messages that were accumulated during
+// connection setup. These should be sent to the client before the initial
+// ReadyForQuery.
+func (h ConnectionHandler) GetStartupNotices() []pgnotice.Notice {
+	return h.startupNotices
 }
 
 // SetOnTCPKeepAliveChange registers a callback that is invoked when any

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -189,6 +189,7 @@ go_test(
         "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
         "//pkg/util/uuid",

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -327,6 +327,15 @@ func (c *conn) sendInitialConnData(
 		return sql.ConnectionHandler{}, err
 	}
 
+	// Deliver any notices accumulated during connection setup (e.g. defaulting
+	// pg_dump_compatibility for a dump/restore client) before signaling that the
+	// connection is ready for queries.
+	for _, notice := range connHandler.GetStartupNotices() {
+		if err := c.bufferNotice(ctx, notice); err != nil {
+			return sql.ConnectionHandler{}, err
+		}
+	}
+
 	if err := c.bufferInitialReadyForQuery(connHandler.GetQueryCancelKey()); err != nil {
 		return sql.ConnectionHandler{}, err
 	}

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgconn"
 	pgproto3 "github.com/jackc/pgproto3/v2"
 	pgx "github.com/jackc/pgx/v4"
 	"github.com/lib/pq"
@@ -1802,6 +1804,85 @@ func TestSessionParameters(t *testing.T) {
 			t.Logf("server says %s = %q", test.varName, gotVal)
 			if gotVal != test.val {
 				t.Fatalf("expected %q, got %q", test.val, gotVal)
+			}
+		})
+	}
+}
+
+// TestPgDumpCompatibilityAppNameDefault verifies that connecting with the
+// application_name used by the PostgreSQL dump/restore client tools defaults
+// pg_dump_compatibility to "cockroachdb" (emitting a NOTICE), while an explicit
+// value in the connection string is always honored and ordinary applications
+// are unaffected.
+func TestPgDumpCompatibilityAppNameDefault(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	host, ports, _ := net.SplitHostPort(s.AdvSQLAddr())
+	port, _ := strconv.Atoi(ports)
+
+	baseCfg, err := pgx.ParseConfig(
+		fmt.Sprintf("postgresql://%s@%s:%d/defaultdb?sslmode=disable", username.RootUser, host, port),
+	)
+	require.NoError(t, err)
+	baseCfg.TLSConfig = nil
+
+	testData := []struct {
+		name           string
+		appName        string
+		explicit       string // if non-empty, pg_dump_compatibility sent explicitly
+		expectedCompat string
+		expectNotice   bool
+	}{
+		{name: "pg_dump defaults to cockroachdb", appName: "pg_dump", expectedCompat: "cockroachdb", expectNotice: true},
+		{name: "pg_restore defaults to cockroachdb", appName: "pg_restore", expectedCompat: "cockroachdb", expectNotice: true},
+		{name: "pg_dumpall defaults to cockroachdb", appName: "pg_dumpall", expectedCompat: "cockroachdb", expectNotice: true},
+		{name: "explicit off is honored", appName: "pg_dump", explicit: "off", expectedCompat: "off", expectNotice: false},
+		{name: "explicit postgres is honored", appName: "pg_dump", explicit: "postgres", expectedCompat: "postgres", expectNotice: false},
+		{name: "ordinary app name is unaffected", appName: "psql", expectedCompat: "off", expectNotice: false},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+			var mu syncutil.Mutex
+			var notices []string
+			cfg := baseCfg.Copy()
+			cfg.RuntimeParams = map[string]string{"application_name": test.appName}
+			if test.explicit != "" {
+				cfg.RuntimeParams["pg_dump_compatibility"] = test.explicit
+			}
+			cfg.OnNotice = func(_ *pgconn.PgConn, n *pgconn.Notice) {
+				mu.Lock()
+				defer mu.Unlock()
+				notices = append(notices, n.Message)
+			}
+
+			db, err := pgx.ConnectConfig(ctx, cfg)
+			require.NoError(t, err)
+			defer func() { _ = db.Close(ctx) }()
+
+			var gotCompat string
+			require.NoError(t, db.QueryRow(ctx, "SHOW pg_dump_compatibility").Scan(&gotCompat))
+			require.Equal(t, test.expectedCompat, gotCompat)
+
+			mu.Lock()
+			defer mu.Unlock()
+			var pgDumpNotices []string
+			for _, msg := range notices {
+				if strings.Contains(msg, "pg_dump_compatibility") {
+					pgDumpNotices = append(pgDumpNotices, msg)
+				}
+			}
+			if test.expectNotice {
+				require.Lenf(t, pgDumpNotices, 1, "notices: %v", notices)
+				require.Contains(t, pgDumpNotices[0], test.appName)
+			} else {
+				require.Emptyf(t, pgDumpNotices, "unexpected notices: %v", notices)
 			}
 		})
 	}

--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -468,6 +468,31 @@ func PgDumpCompatibilityFromString(val string) (_ string, ok bool) {
 	}
 }
 
+// PgDumpClientAppNames are the application_name values reported by the
+// PostgreSQL dump/restore client tools (pg_dump, pg_restore, pg_dumpall) via
+// libpq's fallback_application_name. The match is exact and case-sensitive,
+// since that is precisely what those tools send.
+var PgDumpClientAppNames = []string{"pg_dump", "pg_restore", "pg_dumpall"}
+
+// DefaultPgDumpCompatibilityForAppName returns the pg_dump_compatibility value
+// to apply by default for a connection whose application_name is appName, along
+// with whether such a default applies. A default is returned only for the
+// PostgreSQL dump/restore client tools (see PgDumpClientAppNames). The chosen
+// value is PgDumpCompatibilityCockroachDB so that dumps round-trip into another
+// CockroachDB cluster without further configuration.
+//
+// Callers are responsible for applying this default only when the client has
+// not explicitly configured pg_dump_compatibility, so that an explicit value
+// (including "off") is always respected.
+func DefaultPgDumpCompatibilityForAppName(appName string) (_ string, ok bool) {
+	for _, name := range PgDumpClientAppNames {
+		if appName == name {
+			return PgDumpCompatibilityCockroachDB, true
+		}
+	}
+	return "", false
+}
+
 // CanaryStatsMode controls which table statistics the optimizer uses for
 // query planning in this session. See the comments on each mode for details.
 type CanaryStatsMode int64

--- a/pkg/sql/sessiondatapb/session_data_test.go
+++ b/pkg/sql/sessiondatapb/session_data_test.go
@@ -33,3 +33,28 @@ func TestSerialNormalizationRoundTrip(t *testing.T) {
 		require.Equal(t, expectedVal, actualVal)
 	}
 }
+
+func TestDefaultPgDumpCompatibilityForAppName(t *testing.T) {
+	tests := []struct {
+		name        string
+		appName     string
+		expectedVal string
+		expectedOk  bool
+	}{
+		{name: "pg_dump", appName: "pg_dump", expectedVal: PgDumpCompatibilityCockroachDB, expectedOk: true},
+		{name: "pg_restore", appName: "pg_restore", expectedVal: PgDumpCompatibilityCockroachDB, expectedOk: true},
+		{name: "pg_dumpall", appName: "pg_dumpall", expectedVal: PgDumpCompatibilityCockroachDB, expectedOk: true},
+		{name: "unrelated app name", appName: "psql", expectedOk: false},
+		{name: "empty app name", appName: "", expectedOk: false},
+		// The match is case-sensitive because that is exactly what the tools send.
+		{name: "wrong case is not matched", appName: "PG_DUMP", expectedOk: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			val, ok := DefaultPgDumpCompatibilityForAppName(tc.appName)
+			require.Equal(t, tc.expectedOk, ok)
+			require.Equal(t, tc.expectedVal, val)
+		})
+	}
+}


### PR DESCRIPTION
When a client connects with an application_name used by the PostgreSQL
dump/restore tools (pg_dump, pg_restore, or pg_dumpall), the session now
defaults pg_dump_compatibility to "cockroachdb" so that dumps are correct
out of the box without the user configuring the setting manually. A NOTICE
is emitted to the client when this default is applied.

The default is only applied when the client has not set
pg_dump_compatibility explicitly in the connection string, so an explicit
value (including "off") is always honored. The decision is made at
connection time from the startup application_name; a later
SET application_name does not trigger it.

The "cockroachdb" mode keeps CockroachDB-specific syntax, so the resulting
dump is intended for restoring into another CockroachDB cluster; users
targeting PostgreSQL can set pg_dump_compatibility=postgres, which the
NOTICE points them toward.

Informs: #20296
Epic: CRDB-62553

Release note (sql change): Connecting with an application_name of pg_dump,
pg_restore, or pg_dumpall now automatically sets the pg_dump_compatibility
session setting to "cockroachdb" (emitting a NOTICE), unless the setting is
provided explicitly in the connection string. This makes dumps taken with
these tools compatible with CockroachDB out of the box.