### PR TITLE
workload/kv: skip defining the follower-read statement when unused

### DIFF
--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -582,7 +582,10 @@ func (w *kv) Ops(
 			numEmptyResults: &numEmptyResults,
 		}
 		op.readStmt = op.sr.Define(readStmtStr)
-		op.followerReadStmt = op.sr.Define(followerReadStmtStr)
+		// Skip when unused to avoid startup AOST prepare churn.
+		if w.followerReadPercent > 0 {
+			op.followerReadStmt = op.sr.Define(followerReadStmtStr)
+		}
 		if !op.config.prepareReadOnly {
 			op.writeStmt = op.sr.Define(writeStmtStr)
 		}


### PR DESCRIPTION
Fixes #171185.

Verified locally on a single-node cluster:
- Default flags (`--follower-read-percent=0`): zero `name=kv-2` prepare warnings (was ~19k per the issue) and no first-second startup stall.
- `--follower-read-percent=20` after a brief warmup: 8.8k follower-reads complete cleanly over 15s, with no regression in the follower-read path.

Leaves the orthogonal BeforeAcquire / `follower_read_timestamp()` warmup behavior alone; that's the separate concern called out in the issue and warrants a separate change.

Epic: none
Release note: None