### PR TITLE
security: remove CCL imports

### DIFF
--- a/pkg/security/jwtauth/BUILD.bazel
+++ b/pkg/security/jwtauth/BUILD.bazel
@@ -41,7 +41,6 @@ go_test(
     embed = [":jwtauth"],
     deps = [
         "//pkg/base",
-        "//pkg/ccl",
         "//pkg/security/certnames",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/security/jwtauth/main_test.go
+++ b/pkg/security/jwtauth/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,7 +19,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(

--- a/pkg/security/ldapauth/BUILD.bazel
+++ b/pkg/security/ldapauth/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     embed = [":ldapauth"],
     deps = [
         "//pkg/base",
-        "//pkg/ccl",
         "//pkg/security/certnames",
         "//pkg/security/distinguishedname",
         "//pkg/security/securityassets",

--- a/pkg/security/ldapauth/ldap_util.go
+++ b/pkg/security/ldapauth/ldap_util.go
@@ -125,7 +125,7 @@ func (lu *ldapUtil) ListGroups(
 	return ldapGroupsDN, nil
 }
 
-// ILDAPUtil is an interface for the `ldapauthccl` library to wrap various LDAP
+// ILDAPUtil is an interface for the `ldapauth` library to wrap various LDAP
 // functionalities exposed by `go-ldap` library as part of CRDB modules for
 // authN and authZ.
 type ILDAPUtil interface {

--- a/pkg/security/ldapauth/main_test.go
+++ b/pkg/security/ldapauth/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,7 +19,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(

--- a/pkg/security/oidcauth/BUILD.bazel
+++ b/pkg/security/oidcauth/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
     embed = [":oidcauth"],
     deps = [
         "//pkg/base",
-        "//pkg/ccl",
         "//pkg/roachpb",
         "//pkg/security/certnames",
         "//pkg/security/provisioning",

--- a/pkg/security/oidcauth/main_test.go
+++ b/pkg/security/oidcauth/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -20,7 +19,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(


### PR DESCRIPTION
TestingEnableEnterprise is a no-op. Removing the CCL import can impact the transitive dependency set of the packages, but these security packages should really be leaf packages with few non-test dependencies.

Epic: none
Informs #164337