### PR TITLE
sql: reject non-positive count in width_bucket

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2979,6 +2979,26 @@ SELECT width_bucket('-Infinity'::numeric, 1, 10, 10);
 statement error pgcode 2201G pq: operand, lower bound, and upper bound cannot be NaN
 SELECT width_bucket('NaN', 3.0, 4.0, 888);
 
+statement error pgcode 2201G pq: count must be greater than zero
+SELECT width_bucket(5::numeric, 1::numeric, 10::numeric, 0::int)
+
+statement error pgcode 2201G pq: count must be greater than zero
+SELECT width_bucket(5::numeric, 1::numeric, 10::numeric, -1::int)
+
+statement error pgcode 2201G pq: count must be greater than zero
+SELECT width_bucket(5, 1, 10, 0)
+
+statement error pgcode 2201G pq: count must be greater than zero
+SELECT width_bucket(5, 1, 10, -1)
+
+# count must be validated even when operand is +/-Infinity (otherwise the
+# numeric overload's Infinity shortcut would mask the invalid count).
+statement error pgcode 2201G pq: count must be greater than zero
+SELECT width_bucket('Infinity'::numeric, 1, 10, 0)
+
+statement error pgcode 2201G pq: count must be greater than zero
+SELECT width_bucket('-Infinity'::numeric, 1, 10, -1)
+
 
 # Sanity check pg_type_is_visible.
 query BBB

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -733,6 +733,12 @@ var mathBuiltins = map[string]builtinDefinition{
 						"lower and upper bounds must be finite",
 					)
 				}
+				if count <= 0 {
+					return nil, pgerror.New(
+						pgcode.InvalidArgumentForWidthBucketFunction,
+						"count must be greater than zero",
+					)
+				}
 				if math.IsInf(operand, 1) {
 					return tree.NewDInt(tree.DInt(count + 1)), nil
 				}
@@ -754,6 +760,12 @@ var mathBuiltins = map[string]builtinDefinition{
 				b1 := float64(tree.MustBeDInt(args[1]))
 				b2 := float64(tree.MustBeDInt(args[2]))
 				count := int(tree.MustBeDInt(args[3]))
+				if count <= 0 {
+					return nil, pgerror.New(
+						pgcode.InvalidArgumentForWidthBucketFunction,
+						"count must be greater than zero",
+					)
+				}
 				return tree.NewDInt(tree.DInt(widthBucket(operand, b1, b2, count))), nil
 			},
 			Info: "return the bucket number to which operand would be assigned in a histogram having count " +


### PR DESCRIPTION
Fixes #171234

PostgreSQL rejects `width_bucket(operand, b1, b2, count)` when `count` is zero or negative with the message "count must be greater than zero" (pgcode `invalid_argument_for_width_bucket_function`, `2201G`).
CockroachDB silently returned a computed bucket number; in the int overload, `count = 0` also caused a division by zero inside the `widthBucket` helper.

This adds the guard to both the numeric and int overloads, using the same pgcode that the sibling NaN and finite-bound checks already raise. The numeric overload checks count before its +/-Infinity operand
shortcuts, so an invalid count is still reported in those cases.

Epic: none

Release note (bug fix): width_bucket(operand, b1, b2, count) now returns "count must be greater than zero" when count is zero or negative, matching PostgreSQL.