### PR TITLE
sql/optbuilder: add extra columns from lock scope to pre-projection scope

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -640,3 +640,39 @@ RESET optimizer_use_lock_op_for_serializable
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+subtest regression_170749
+
+# Regression test for #170749: a Lock operator (READ COMMITTED FOR UPDATE)
+# combined with ORDER BY under non-default NULLS ordering must not fail
+# execbuild.
+statement ok
+CREATE TABLE t_170749 (
+  id UUID NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NULL,
+  used_at TIMESTAMP NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT now(),
+  INDEX queued_users_inserted_at_index (inserted_at ASC),
+  INDEX queued_users_used_at_index (used_at ASC),
+  FAMILY fam_0 (id, user_id, used_at, inserted_at)
+)
+
+statement ok
+SET null_ordered_last = true
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+query T
+SELECT user_id FROM t_170749
+WHERE used_at IS NULL ORDER BY inserted_at ASC LIMIT 1
+FOR UPDATE SKIP LOCKED
+----
+
+statement ok
+COMMIT
+
+statement ok
+RESET null_ordered_last
+
+subtest end

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1333,6 +1333,9 @@ func (b *Builder) buildSelectClause(
 	b.validateLockingInFrom(sel, lockCtx.locking, fromScope)
 
 	if preProjectionScope != nil {
+		if lockScope != nil {
+			preProjectionScope.addExtraColumns(lockScope.cols)
+		}
 		// Construct the pre-projection for the ordering expressions.
 		b.constructProjectForScope(outScope, preProjectionScope)
 		outScope.expr = preProjectionScope.expr


### PR DESCRIPTION
We add the PK to the lock scope for FOR UPDATE + RC isolation level, but
this column could be missed in preProjectionScope as it was snapshoted
before we build the lock args. As a result, the main projection would
reference columns its input does not produce.

This commit forward the lock columns into the pre-projection.

Fixes: https://github.com/cockroachdb/cockroach/issues/170749

Release note (bug fix): Fixed an internal error that could occur when running
SELECT ... FOR UPDATE/FOR SHARE with an ORDER BY using a non-default NULL
ordering (e.g. null_ordered_last) under READ COMMITTED.