### PR TITLE
sql: reject equal bounds in width_bucket

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2999,6 +2999,28 @@ SELECT width_bucket('Infinity'::numeric, 1, 10, 0)
 statement error pgcode 2201G pq: count must be greater than zero
 SELECT width_bucket('-Infinity'::numeric, 1, 10, -1)
 
+# Match PostgreSQL's "lower bound cannot equal upper bound" rejection
+# for both overloads, across operand positions (above, below, at the
+# degenerate point). Without the guard, the helper divides by zero
+# and casts +/-Inf or NaN to int, producing INT64_MAX, INT64_MIN, or 0.
+statement error pgcode 2201G pq: lower bound cannot equal upper bound
+SELECT width_bucket(7::numeric, 5::numeric, 5::numeric, 10::int)
+
+statement error pgcode 2201G pq: lower bound cannot equal upper bound
+SELECT width_bucket(3::numeric, 5::numeric, 5::numeric, 10::int)
+
+statement error pgcode 2201G pq: lower bound cannot equal upper bound
+SELECT width_bucket(5::numeric, 5::numeric, 5::numeric, 10::int)
+
+statement error pgcode 2201G pq: lower bound cannot equal upper bound
+SELECT width_bucket(7, 5, 5, 10)
+
+statement error pgcode 2201G pq: lower bound cannot equal upper bound
+SELECT width_bucket(3, 5, 5, 10)
+
+statement error pgcode 2201G pq: lower bound cannot equal upper bound
+SELECT width_bucket(5, 5, 5, 10)
+
 
 # Sanity check pg_type_is_visible.
 query BBB

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -739,6 +739,12 @@ var mathBuiltins = map[string]builtinDefinition{
 						"count must be greater than zero",
 					)
 				}
+				if b1 == b2 {
+					return nil, pgerror.New(
+						pgcode.InvalidArgumentForWidthBucketFunction,
+						"lower bound cannot equal upper bound",
+					)
+				}
 				if math.IsInf(operand, 1) {
 					return tree.NewDInt(tree.DInt(count + 1)), nil
 				}
@@ -764,6 +770,12 @@ var mathBuiltins = map[string]builtinDefinition{
 					return nil, pgerror.New(
 						pgcode.InvalidArgumentForWidthBucketFunction,
 						"count must be greater than zero",
+					)
+				}
+				if b1 == b2 {
+					return nil, pgerror.New(
+						pgcode.InvalidArgumentForWidthBucketFunction,
+						"lower bound cannot equal upper bound",
 					)
 				}
 				return tree.NewDInt(tree.DInt(widthBucket(operand, b1, b2, count))), nil


### PR DESCRIPTION
Fixes #171263

PostgreSQL rejects `width_bucket(operand, b1, b2, count)` when the lower and upper bounds are equal with the message "lower bound cannot equal upper bound" (pgcode `invalid_argument_for_width_bucket_function`, `2201G`). CockroachDB silently returned garbage: the helper computes `width = (b2 - b1) / count = 0`, then `int(math.Floor(diff/0) + 1)` casts `+Inf`, `-Inf`, or `NaN` to int, producing `INT64_MAX`, `INT64_MIN`, or `0` depending on operand position.

This adds the guard to both the numeric and int overloads, using the same pgcode that the sibling NaN and finite-bound checks already raise. In the numeric overload, the guard is placed after the existing NaN/finite-bound guards and before the +/-Infinity operand shortcuts, matching PostgreSQL's check precedence.

This is a sibling of #171234 (`count <= 0`), already addressed by #171259, but independent and self-contained.

Epic: none

Release note (bug fix): width_bucket(operand, b1, b2, count) now returns "lower bound cannot equal upper bound" when the two bounds are equal, matching PostgreSQL.