### PR TITLE
roachprod/aws: skip empty cluster detection when instance listing fails

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1751,11 +1751,16 @@ func (p *Provider) listRegionsFiltered(
 		namesFilter = fmt.Sprintf("Name=tag:Name,Values=%s", strings.Join(names, ","))
 	}
 
+	failedRegions := make(map[string]bool)
+	var failedRegionsMux syncutil.Mutex
 	for _, r := range regions {
 		g.GoCtx(func(ctx context.Context) error {
 			vms, err := p.describeInstances(ctx, l, r, opts, listOpts, namesFilter)
 			if err != nil {
 				l.Printf("Failed to list AWS VMs in region: %s\n%v\n", r, err)
+				failedRegionsMux.Lock()
+				failedRegions[r] = true
+				failedRegionsMux.Unlock()
 				return nil
 			}
 			mux.Lock()
@@ -1783,6 +1788,10 @@ func (p *Provider) listRegionsFiltered(
 		}
 
 		for _, r := range regions {
+			if failedRegions[r] {
+				l.Printf("Skipping empty cluster detection in region %s: instance listing failed", r)
+				continue
+			}
 			clusterNames, err := p.listManagedLaunchTemplates(l, r)
 			if err != nil {
 				l.Printf("Failed to list managed launch templates in region %s: %v", r, err)


### PR DESCRIPTION
## Summary

- Fix a bug where a transient `describeInstances` failure for an AWS
  region caused roachprod GC to incorrectly destroy managed clusters
  as "empty cluster/dangling resource."
- Track which regions had instance listing failures and skip empty
  cluster detection (`listManagedLaunchTemplates`) for those regions.
- This caused the `drt-chaos-aws` production DRT cluster to be
  destroyed on 2026-05-30 when `ec2.us-east-2.amazonaws.com` was
  transiently unreachable from the GC cronjob.

### Root cause

In `listRegionsFiltered`, `describeInstances` errors are silently
swallowed (logged but returned as nil). `listManagedLaunchTemplates`
then runs independently on the same region. If instance listing
failed but template listing succeeded, every managed launch template
in that region appeared "orphaned" — GC created false `EmptyCluster`
placeholders and destroyed the ASG + launch template.

Confirmed via GC cronjob logs:
```
Failed to list AWS VMs in region: us-east-2
Could not connect to the endpoint URL: "https://ec2.us-east-2.amazonaws.com/"
```

Epic: none