### PR TITLE
crosscluster/logical: checkpoint partition URIs in transactional LDR

### DIFF
--- a/pkg/crosscluster/logical/resume_txn.go
+++ b/pkg/crosscluster/logical/resume_txn.go
@@ -97,8 +97,13 @@ func (r *logicalReplicationResumer) runTxnCoordinator(
 		return err
 	}
 
-	// TODO(jeffswenson): checkpoint partition URIs via
-	// r.checkpointPartitionURIs once plan generation is added.
+	uris, err := r.getClusterUris(ctx, r.job, jobExecCtx.ExecCfg().InternalDB)
+	if err != nil {
+		return err
+	}
+	if err := r.checkpointPartitionURIs(ctx, uris, sourcePlan.Topology.SerializedClusterUris()); err != nil {
+		return err
+	}
 
 	flowPlan, planCtx, applierInstanceIDs, err :=
 		txnmode.PlanTxnReplication(ctx, r.job, jobExecCtx, sourcePlan, replicatedTime, endTime)

--- a/pkg/crosscluster/logical/txnmode/txnmode_test.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_test.go
@@ -85,6 +85,10 @@ func (s *cpuHandleAssertingSession) Txn(ctx context.Context, do func(context.Con
 	return s.Session.Txn(ctx, do)
 }
 
+// TestTxnModeSmoketest exercises basic transactional LDR and is the preferred
+// place to add non-invasive assertions about internal job state (e.g. partition
+// URIs, CPU handles). Extend this test rather than spinning up a new cluster
+// for each trivial assertion.
 func TestTxnModeSmoketest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderDeadlock(t)
@@ -135,6 +139,17 @@ func TestTxnModeSmoketest(t *testing.T) {
 
 	destDB.CheckQueryResults(t, "SELECT * FROM parent ORDER BY id", [][]string{})
 	destDB.CheckQueryResults(t, "SELECT * FROM child ORDER BY id", [][]string{})
+
+	// Verify partition URIs are checkpointed in job progress. In gateway
+	// routing mode (set by the stream-use-gateway-routing-mode metamorphic
+	// constant), checkpointPartitionURIs intentionally skips saving URIs.
+	progress := jobutils.GetJobProgress(t, destDB, jobID)
+	ldrProgress := progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
+	if replicationtestutils.IsGatewayRoutingMode() {
+		require.Empty(t, ldrProgress.PartitionConnUris)
+	} else {
+		require.NotEmpty(t, ldrProgress.PartitionConnUris)
+	}
 
 	// Verify that at least one session had its CPU handle checked, confirming
 	// that the writer goroutines are running with per-goroutine handles.

--- a/pkg/crosscluster/replicationtestutils/uri_util.go
+++ b/pkg/crosscluster/replicationtestutils/uri_util.go
@@ -21,6 +21,12 @@ import (
 var useGatewayRoutingMode = metamorphic.ConstantWithTestBool("stream-use-gateway-routing-mode", false)
 var useExternalConnection = metamorphic.ConstantWithTestBool("stream-use-external-connection", true)
 
+// IsGatewayRoutingMode returns true if the metamorphic constant selects
+// gateway routing mode for the current test binary invocation.
+func IsGatewayRoutingMode() bool {
+	return useGatewayRoutingMode
+}
+
 func GetExternalConnectionURI(
 	t *testing.T,
 	sourceCluster serverutils.ApplicationLayerInterface,


### PR DESCRIPTION
The transactional LDR code path did not call checkpointPartitionURIs, leaving progress.PartitionConnUris empty. When the job retried after a source node failure, getClusterUris only returned the single SourceClusterConnUri from the job payload. If that URI pointed to the failed node, the job entered an infinite retry loop unable to connect to any surviving source node.

Call getClusterUris and checkpointPartitionURIs in resume_txn.go after GetSourcePlan returns, matching the existing pattern in resume_row.go.

Add an assertion to TestTxnModeSmoketest verifying that partition URIs are checkpointed in job progress. This is also covered e2e by the ldr/transactional/kv0/shutdown_node roachtest.

Fixes: #171274
Epic: none
Jira: CRDB-64413

Release note: None