### PR TITLE
sql: deflake TestStreamerTightBudget by fixing the streamer's initial estimate

### DIFF
--- a/pkg/sql/mem_limit_test.go
+++ b/pkg/sql/mem_limit_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -178,6 +179,38 @@ func TestStreamerTightBudget(t *testing.T) {
 	// Set the workmem limit to a low value such that it will allow the Streamer
 	// to have at most one request to be "in progress".
 	sqlDB.Exec(t, fmt.Sprintf("SET distsql_workmem = '%dB'", blobSize))
+
+	// Give the Streamer an accurate initial estimate of the response size (each
+	// row's blob is blobSize). Without this, the Streamer starts with its tiny
+	// default estimate (1KiB) and issues all lookup requests eagerly on the
+	// first pass. Those eager requests use AllowEmpty=true, so when a response
+	// exceeds the tiny TargetBytes the KV layer returns it empty with a resume
+	// span, and the Streamer re-issues it (observable as 9 KV gRPC calls for 5
+	// rows: 5 eager + 4 resumes). During this eager/resume churn multiple full
+	// responses can transiently be held at once under unfavorable goroutine
+	// scheduling, pushing memory usage well above the expected ~2 MiB and
+	// flaking this assertion (see #170853). With an accurate initial estimate,
+	// the first head-of-line request alone exhausts the budget, so the Streamer
+	// deterministically keeps a single request in progress (5 KV gRPC calls,
+	// no resumes) - exactly the behavior this test means to verify. In
+	// production this estimate comes from optimizer stats; here we set it
+	// explicitly since the test table has no stats.
+	sqlDB.Exec(t, fmt.Sprintf(
+		"SET CLUSTER SETTING sql.distsql.streamer.initial_avg_response_size = '%dB'", blobSize,
+	))
+	// Cluster settings propagate asynchronously, so wait until the new value is
+	// observable before running the measured query.
+	wantSetting := string(humanizeutil.IBytes(blobSize))
+	testutils.SucceedsSoon(t, func() error {
+		var got string
+		sqlDB.QueryRow(
+			t, "SHOW CLUSTER SETTING sql.distsql.streamer.initial_avg_response_size",
+		).Scan(&got)
+		if got != wantSetting {
+			return errors.Newf("setting not yet propagated: got %q, want %q", got, wantSetting)
+		}
+		return nil
+	})
 
 	// Perform an index join to read the blobs.
 	query := "EXPLAIN ANALYZE (VERBOSE) SELECT sum(length(blob)) FROM t@t_k_idx WHERE k = 1"


### PR DESCRIPTION
TestStreamerTightBudget gives the Streamer a budget so tight that a
single 1 MiB result puts it in debt, and asserts that peak memory usage
stays around the expected ~2 MiB. The assertion flaked, observing usage
as high as 4.6 MiB.

The cause is the Streamer's cold initial response-size estimate. With no
stats on the test table, the Streamer starts from its 1 KiB default
estimate and issues all five lookup requests eagerly on the first pass.
Eager (non-head-of-line) requests are sent with `AllowEmpty=true`, so
when a 1 MiB blob exceeds the tiny `TargetBytes` the KV layer returns an
empty response with a resume span, and the Streamer re-issues it. For
five rows this produces nine KV gRPC calls (five eager + four resumes)
rather than five — matching the "KV gRPC calls: 9" in the failure. During
that eager/resume churn, multiple full responses can transiently be held
at once under unfavorable goroutine scheduling, pushing peak memory well
above 2 MiB and tripping the assertion.

This gives the Streamer an accurate initial estimate (the blob size) via
the `sql.distsql.streamer.initial_avg_response_size` cluster setting. The
first head-of-line request then exhausts the budget on its own, so no
eager requests are issued and the Streamer deterministically keeps a
single request in progress (five KV gRPC calls, no resumes) — exactly the
behavior this test means to verify. In production this estimate is
supplied by optimizer stats.

Verified with 300 stress runs; measured usage is a stable 2.1 MiB.

Fixes: #170853
Epic: none
Release note: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
