### PR TITLE
logical: return ErrStalePreviousValue from tombstone updater on stale CPut

### DIFF
--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -608,7 +608,6 @@ func (lww *lwwQuerier) AddTable(targetDescID int32, tc sqlProcessorTableConfig) 
 
 	lww.tombstoneUpdaters[td.GetID()] = sqlwriter.NewTombstoneUpdater(
 		lww.codec,
-		lww.db.KV(),
 		lww.leaseMgr,
 		catid.DescID(targetDescID),
 		lww.sd,
@@ -732,10 +731,21 @@ func (lww *lwwQuerier) DeleteRow(
 		return batchStats{}, err
 	}
 	if rowCount != 1 {
-		// NOTE: at this point we don't know if we are updating a tombstone or if
-		// we are losing LWW. As long as it is a LWW loss or a tombstone update,
-		// UpdateTombstoneAny will return okay.
-		lwwLoss, err := lww.tombstoneUpdaters[row.TableID].UpdateTombstoneAny(ctx, txn, row.MvccTimestamp, datums)
+		// NOTE: at this point we don't know if we are updating a tombstone or
+		// if we are losing LWW. UpdateTombstoneAny returns (true, nil) for a
+		// LWW loss, (false, nil) for a successful tombstone update, or
+		// (false, ErrStalePreviousValue) if a live row exists at the key.
+		tu := lww.tombstoneUpdaters[row.TableID]
+		var lwwLoss bool
+		if kvTxn != nil {
+			lwwLoss, err = tu.UpdateTombstoneAny(ctx, kvTxn, row.MvccTimestamp, datums)
+		} else {
+			err = lww.db.KV().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				var txnErr error
+				lwwLoss, txnErr = tu.UpdateTombstoneAny(ctx, txn, row.MvccTimestamp, datums)
+				return txnErr
+			})
+		}
 		if err != nil {
 			return batchStats{}, err
 		}

--- a/pkg/crosscluster/logical/sqlwriter/BUILD.bazel
+++ b/pkg/crosscluster/logical/sqlwriter/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/crosscluster/ldrrandgen",
+        "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/crosscluster/logical/sqlwriter/errors.go
+++ b/pkg/crosscluster/logical/sqlwriter/errors.go
@@ -45,6 +45,16 @@ func IsLwwLoser(err error) bool {
 	return false
 }
 
+// HasStalePreviousValue returns true if the error is a ConditionFailedError
+// with HadNewerOriginTimestamp set, indicating the write won the origin
+// timestamp comparison but the expected previous value was wrong.
+func HasStalePreviousValue(err error) bool {
+	if condErr := (*kvpb.ConditionFailedError)(nil); errors.As(err, &condErr) {
+		return condErr.HadNewerOriginTimestamp
+	}
+	return false
+}
+
 // CanDLQError returns nil if the error should send a row to the DLQ. It
 // returns a non-nil error if the error should not be DLQ'd, for example
 // because it indicates an internal or retryable problem. The idea is it is

--- a/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
@@ -138,6 +138,22 @@ func TestSQLRowWriter(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrStalePreviousValue)
 
+	// Test InsertRow with a newer origin timestamp against an existing row.
+	// The insert wins LWW but the row already exists, so the MVCC layer sets
+	// HadNewerOriginTimestamp. InsertRow converts this to ErrStalePreviousValue
+	// so the caller can refresh and retry as an update.
+	duplicateRow := makeTestRow(t, desc, 20, "duplicate")
+	firstTS := s.Clock().Now()
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, firstTS, duplicateRow)
+	})
+	require.NoError(t, err)
+	newerTS := s.Clock().Now()
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, newerTS, makeTestRow(t, desc, 20, "newer"))
+	})
+	require.ErrorIs(t, err, ErrStalePreviousValue)
+
 	// Test InsertRow LWW failure against existing row: inserting with an older
 	// timestamp than the existing row should return a ConditionFailedError.
 	existingRow := makeTestRow(t, desc, 10, "existing")

--- a/pkg/crosscluster/logical/sqlwriter/tombstone_updater.go
+++ b/pkg/crosscluster/logical/sqlwriter/tombstone_updater.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -32,7 +31,6 @@ var OriginID1Options = &kvpb.WriteOptions{OriginID: 1}
 // table. The lease should be released by calling ReleaseLeases.
 type TombstoneUpdater struct {
 	codec    keys.SQLCodec
-	db       *kv.DB
 	leaseMgr *lease.Manager
 	sd       *sessiondata.SessionData
 	settings *cluster.Settings
@@ -63,7 +61,6 @@ func (c *TombstoneUpdater) ReleaseLeases(ctx context.Context) {
 
 func NewTombstoneUpdater(
 	codec keys.SQLCodec,
-	db *kv.DB,
 	leaseMgr *lease.Manager,
 	descID descpb.ID,
 	sd *sessiondata.SessionData,
@@ -71,7 +68,6 @@ func NewTombstoneUpdater(
 ) *TombstoneUpdater {
 	return &TombstoneUpdater{
 		codec:    codec,
-		db:       db,
 		leaseMgr: leaseMgr,
 		descID:   descID,
 		sd:       sd,
@@ -82,7 +78,7 @@ func NewTombstoneUpdater(
 // UpdateTombstoneAny is an UpdateTombstone wrapper that accepts the []any
 // datum slice from the original sql writer's datum builder.
 func (tu *TombstoneUpdater) UpdateTombstoneAny(
-	ctx context.Context, txn isql.Txn, mvccTimestamp hlc.Timestamp, datums []any,
+	ctx context.Context, txn *kv.Txn, mvccTimestamp hlc.Timestamp, datums []any,
 ) (bool, error) {
 	tu.scratch = tu.scratch[:0]
 	for _, datum := range datums {
@@ -91,66 +87,25 @@ func (tu *TombstoneUpdater) UpdateTombstoneAny(
 	return tu.UpdateTombstone(ctx, txn, mvccTimestamp, tu.scratch)
 }
 
-// UpdateTombstone attempts to update the tombstone for the given row. This is
-// expected to always succeed. The delete will only return zero rows if the
-// operation loses LWW or the row does not exist. So if the cput fails on a
-// condition, it should also fail on LWW, which is treated as a success.
-//
-// It returns true if the update lost LWW (i.e. the local tombstone was already
-// newer).
+// UpdateTombstone attempts to update the tombstone for the given row. It
+// returns true if the update lost LWW (i.e. the local tombstone was already
+// newer). It returns ErrStalePreviousValue if a live row exists at the key
+// instead of a tombstone and the incoming origin timestamp is newer, meaning
+// the caller should refresh its local state and retry.
 func (tu *TombstoneUpdater) UpdateTombstone(
-	ctx context.Context, txn isql.Txn, mvccTimestamp hlc.Timestamp, afterRow []tree.Datum,
+	ctx context.Context, txn *kv.Txn, mvccTimestamp hlc.Timestamp, afterRow []tree.Datum,
 ) (bool, error) {
-	err := func() error {
-		if txn != nil {
-			// If UpdateTombstone is called in a transaction, create and run a
-			// batch in the transaction.
-			batch := txn.KV().NewBatch()
-			batch.Header.WriteOptions = OriginID1Options
-			if err := tu.AddToBatch(ctx, txn.KV(), batch, mvccTimestamp, afterRow); err != nil {
-				return err
-			}
-			return txn.KV().Run(ctx, batch)
-		}
-		// If UpdateTombstone is called outside of a transaction, create and
-		// run a 1pc transaction.
-		return tu.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			batch := txn.NewBatch()
-			batch.Header.WriteOptions = OriginID1Options
-			if err := tu.AddToBatch(ctx, txn, batch, mvccTimestamp, afterRow); err != nil {
-				return err
-			}
-			return txn.CommitInBatch(ctx, batch)
-		})
-	}()
-	if err != nil {
-		if IsLwwLoser(err) {
-			return true, nil
-		}
-		return false, err
-	}
-	return false, nil
-}
-
-// AddToBatch adds a tombstone delete operation to the given KV batch. The
-// caller is responsible for setting the batch's WriteOptions and running the
-// batch.
-func (tu *TombstoneUpdater) AddToBatch(
-	ctx context.Context,
-	txn *kv.Txn,
-	batch *kv.Batch,
-	mvccTimestamp hlc.Timestamp,
-	afterRow []tree.Datum,
-) error {
 	deleter, err := tu.getDeleter(ctx, txn)
 	if err != nil {
-		return err
+		return false, err
 	}
+
+	batch := txn.NewBatch()
+	batch.Header.WriteOptions = OriginID1Options
 
 	var ph row.PartialIndexUpdateHelper
 	var vh row.VectorIndexUpdateHelper
-
-	return deleter.DeleteRow(
+	if err := deleter.DeleteRow(
 		ctx,
 		batch,
 		afterRow,
@@ -162,7 +117,20 @@ func (tu *TombstoneUpdater) AddToBatch(
 		},
 		false, /* mustValidateOldPKValues */
 		false, /* traceKV */
-	)
+	); err != nil {
+		return false, err
+	}
+
+	if err := txn.Run(ctx, batch); err != nil {
+		if IsLwwLoser(err) {
+			return true, nil
+		}
+		if HasStalePreviousValue(err) {
+			return false, ErrStalePreviousValue
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 func (tu *TombstoneUpdater) hasValidLease(ctx context.Context, now hlc.Timestamp) bool {

--- a/pkg/crosscluster/logical/sqlwriter/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/sqlwriter/tombstone_updater_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/ldrrandgen"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
@@ -63,7 +63,7 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
 	tu := NewTombstoneUpdater(
-		s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager),
+		s.Codec(), s.LeaseManager().(*lease.Manager),
 		desc.GetID(), sd, s.ClusterSettings())
 	defer tu.ReleaseLeases(ctx)
 
@@ -84,14 +84,18 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 		before := s.Clock().Now()
 		after := s.Clock().Now()
 
-		err := s.InternalDB().(isql.DB).Txn(ctx,
-			func(ctx context.Context, txn isql.Txn) error {
-				_, err := tu.UpdateTombstone(ctx, txn, after, row)
-				return err
-			})
+		err := s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			_, err := tu.UpdateTombstone(ctx, txn, after, row)
+			return err
+		})
 		require.NoError(t, err)
 
-		lwwLoss, err := tu.UpdateTombstone(ctx, nil, before, row)
+		var lwwLoss bool
+		err = s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			var err error
+			lwwLoss, err = tu.UpdateTombstone(ctx, txn, before, row)
+			return err
+		})
 		require.NoError(t, err)
 		require.True(t, lwwLoss, "expected LWW loss for tombstone update")
 
@@ -118,6 +122,58 @@ func generateRandomRow(rng *rand.Rand, cols []catalog.Column) []tree.Datum {
 		row = append(row, datum)
 	}
 	return row
+}
+
+func TestTombstoneUpdaterStalePreviousValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartSlimServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE tombstone_stale_test (
+		id INT PRIMARY KEY,
+		name STRING,
+		extra STRING
+	)`)
+
+	desc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), tree.Name("tombstone_stale_test"))
+
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	tu := NewTombstoneUpdater(
+		s.Codec(), s.LeaseManager().(*lease.Manager),
+		desc.GetID(), sd, s.ClusterSettings())
+	defer tu.ReleaseLeases(ctx)
+
+	session := newInternalSession(t, s)
+	defer session.Close(ctx)
+
+	writer, err := NewRowWriter(ctx, desc, session)
+	require.NoError(t, err)
+
+	row := tree.Datums{
+		tree.NewDInt(1),
+		tree.NewDString("live"),
+		tree.DNull,
+	}
+
+	insertTS := s.Clock().Now()
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, insertTS, row)
+	})
+	require.NoError(t, err)
+
+	// UpdateTombstone on a live row should return ErrStalePreviousValue because
+	// the CPut expects a tombstone but finds a live value.
+	tombstoneTS := s.Clock().Now()
+	err = s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := tu.UpdateTombstone(ctx, txn, tombstoneTS, row)
+		return err
+	})
+	require.ErrorIs(t, err, ErrStalePreviousValue)
 }
 
 func TestTombstoneDescriptorLease(t *testing.T) {

--- a/pkg/crosscluster/logical/table_batch_handler.go
+++ b/pkg/crosscluster/logical/table_batch_handler.go
@@ -133,7 +133,7 @@ func newTableHandler(
 		return nil, err
 	}
 
-	tombstoneUpdater := sqlwriter.NewTombstoneUpdater(codec, db.KV(), leaseMgr, tableID, sd, settings)
+	tombstoneUpdater := sqlwriter.NewTombstoneUpdater(codec, leaseMgr, tableID, sd, settings)
 
 	return &tableHandler{
 		sqlReader:        reader,
@@ -186,22 +186,20 @@ func (t *tableHandler) attemptBatch(
 				}
 			case event.IsTombstoneUpdate():
 				stats.tombstoneUpdates++
-				// Use a KV savepoint so that a LWW-loser ConditionFailedError
-				// on one tombstone does not abort the surrounding transaction.
+				// Use a KV savepoint so that a ConditionFailedError on one
+				// tombstone does not abort the surrounding transaction.
+				var lwwLoss bool
 				err := t.session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
-					batch := txn.NewBatch()
-					batch.Header.WriteOptions = sqlwriter.OriginID1Options
-					if err := t.tombstoneUpdater.AddToBatch(ctx, txn, batch, event.RowTimestamp, event.Row); err != nil {
-						return err
-					}
-					return txn.Run(ctx, batch)
+					var err error
+					lwwLoss, err = t.tombstoneUpdater.UpdateTombstone(ctx, txn, event.RowTimestamp, event.Row)
+					return err
 				})
 				if err != nil {
-					if isLwwLoser(err) {
-						stats.kvLwwLosers++
-						continue
-					}
 					return err
+				}
+				if lwwLoss {
+					stats.kvLwwLosers++
+					continue
 				}
 			case event.IsInsertRow():
 				stats.inserts++

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -11,11 +11,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/sqlwriter"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -45,7 +44,7 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 	desc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		s.DB(), s.Codec(), dbNames[0], "tab")
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
-	tu := sqlwriter.NewTombstoneUpdater(s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
+	tu := sqlwriter.NewTombstoneUpdater(s.Codec(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
 	defer tu.ReleaseLeases(ctx)
 
 	// Set up 1 way logical replication. The replication stream is used to ensure
@@ -63,14 +62,14 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 		tree.DNull,                 // v (deleted)
 	}
 
-	_, err := tu.UpdateTombstone(ctx, nil, s.Clock().Now(), row)
+	err := s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := tu.UpdateTombstone(ctx, txn, s.Clock().Now(), row)
+		return err
+	})
 	require.NoError(t, err)
 
-	config := s.ExecutorConfig().(sql.ExecutorConfig)
-	err = sql.DescsTxn(ctx, &config, func(
-		ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
-	) error {
-		_, err = tu.UpdateTombstone(ctx, txn, s.Clock().Now(), row)
+	err = s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := tu.UpdateTombstone(ctx, txn, s.Clock().Now(), row)
 		return err
 	})
 	require.NoError(t, err)

--- a/pkg/crosscluster/logical/txnwriter/apply_batch.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch.go
@@ -105,24 +105,22 @@ func (tw *transactionWriter) tryApplyTransaction(
 				return ApplyResult{}, err
 			}
 		case row.IsTombstoneUpdate():
-			// Use a KV savepoint so that a LWW-loser ConditionFailedError
-			// on one tombstone does not abort the surrounding transaction.
+			// Use a KV savepoint so that a ConditionFailedError on one
+			// tombstone does not abort the surrounding transaction.
+			var lwwLoss bool
 			err := tw.session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				batch := txn.NewBatch()
-				batch.Header.WriteOptions = sqlwriter.OriginID1Options
-				if err := tw.tombstoneUpdaters[row.TableID].AddToBatch(
-					ctx, txn, batch, transaction.TxnID.Timestamp, row.Row,
-				); err != nil {
-					return err
-				}
-				return txn.Run(ctx, batch)
+				var err error
+				lwwLoss, err = tw.tombstoneUpdaters[row.TableID].UpdateTombstone(
+					ctx, txn, transaction.TxnID.Timestamp, row.Row,
+				)
+				return err
 			})
-			if sqlwriter.IsLwwLoser(err) {
-				lwwLosers++
-				continue
-			}
 			if err != nil {
 				return ApplyResult{}, err
+			}
+			if lwwLoss {
+				lwwLosers++
+				continue
 			}
 		case row.IsInsertRow():
 			err := tableWriter.InsertRow(ctx, transaction.TxnID.Timestamp, row.Row)

--- a/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
@@ -484,6 +484,36 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 			)
 		},
 	}, {
+		// Regression test for #171194 (uncovered by the
+		// ldr/transactional/conflict roachtest): a tombstone update that
+		// encounters a live row triggers a ConditionFailedError with
+		// HadNewerOriginTimestamp. The applier must convert this to
+		// ErrStalePreviousValue so the refresh path reads the live row
+		// and converts the tombstone update into a delete.
+		name: "refresh_converts_tombstone_update_to_delete",
+		setup: func(t *testing.T, baseID int) {
+			sqlDB.Exec(t, fmt.Sprintf(
+				`INSERT INTO parent (id, payload) VALUES (%d, 'live')`, baseID+1))
+		},
+		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
+			return ldrdecoder.Transaction{
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
+				WriteSet: []ldrdecoder.DecodedRow{{
+					Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
+					PrevRow:  nil, // tombstone update: no previous row
+					IsDelete: true,
+					TableID:  parentID,
+				}},
+			}
+		},
+		validate: func(t *testing.T, baseID int, result ApplyResult) {
+			require.Equal(t, ApplyResult{AppliedRows: 1}, result)
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT count(*) FROM parent WHERE id = %d`, baseID+1),
+				[][]string{{"0"}},
+			)
+		},
+	}, {
 		name: "refresh_converts_delete_to_tombstone_update",
 		setup: func(t *testing.T, baseID int) {
 		},

--- a/pkg/crosscluster/logical/txnwriter/writer.go
+++ b/pkg/crosscluster/logical/txnwriter/writer.go
@@ -119,7 +119,7 @@ func (tw *transactionWriter) initTable(ctx context.Context, tableID descpb.ID) e
 	tw.tableWriters[tableID] = writer
 	tw.tableReaders[tableID] = reader
 	tw.tombstoneUpdaters[tableID] = sqlwriter.NewTombstoneUpdater(
-		tw.codec, tw.db.KV(), tw.leaseMgr, tableID, tw.sd, tw.settings,
+		tw.codec, tw.leaseMgr, tableID, tw.sd, tw.settings,
 	)
 	return nil
 }


### PR DESCRIPTION
When a tombstone update encounters a live row instead of a tombstone, the CPut fails with ConditionFailedError{HadNewerOriginTimestamp: true}. This error was not recognized by any error handling path: IsLwwLoser only checks OriginTimestampOlderThan, it isn't ErrStalePreviousValue, and it lacks a pg code so CanDLQError rejects it. The CRUD writer (table_batch_handler) tolerates this because it performs a read refresh on every error, but the transactional writer requires explicit ErrStalePreviousValue to trigger a refresh. Without it, the LDR job gets stuck in an infinite retry loop.

Fix this by converting ConditionFailedError{HadNewerOriginTimestamp} to ErrStalePreviousValue in UpdateTombstone, matching the pattern already used by InsertRow. Refactor UpdateTombstone to accept *kv.Txn and always require a transaction from the caller, removing the internal nil-txn fallback that created a 1pc transaction. The 1pc path was only used by the SQL writer (lww_row_processor) for single-row batches; that caller now wraps the call in an explicit kv.Txn. This also removes the AddToBatch method so callers in apply_batch.go and table_batch_handler.go call UpdateTombstone directly, centralizing the error handling in one place.

Resolves: #171194
Epic: none

Release note: None