### PR TITLE
logical,txnmode: shard unit tests

### DIFF
--- a/pkg/crosscluster/logical/txnmode/BUILD.bazel
+++ b/pkg/crosscluster/logical/txnmode/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "txnmode_test.go",
     ],
     embed = [":txnmode"],
+    shard_count = 4,
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
These tests were OOMing on engflow under duress.

Fixes: https://github.com/cockroachdb/cockroach/issues/171252
Release note: none