### PR TITLE
admission: observe transient elastic CPU waiters via sticky bit

### DIFF
--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -418,7 +418,16 @@ type storeRequester interface {
 type elasticCPULimiter interface {
 	getUtilizationLimit() float64
 	setUtilizationLimit(limit float64)
-	hasWaitingRequests() bool
+	// hasOrHadRecentWaitingRequests returns true if there are any waiting
+	// requests right now, OR if any work was enqueued since the previous call
+	// to this method. The "had recent" component is needed because the elastic
+	// CPU granter's tryGrant loop drains the queue as soon as tokens refill,
+	// so the queue spends most of its time empty even under sustained
+	// throttling; without this, the polling caller (the scheduler-latency
+	// listener, ticking at ~1Hz) would frequently observe an empty queue and
+	// incorrectly conclude there is no demand for elastic CPU. The "had
+	// recent" bit is consumed (cleared) by each call.
+	hasOrHadRecentWaitingRequests() bool
 	computeUtilizationMetric()
 }
 

--- a/pkg/util/admission/elastic_cpu_granter.go
+++ b/pkg/util/admission/elastic_cpu_granter.go
@@ -230,9 +230,31 @@ func (e *elasticCPUGranter) getUtilizationLimit() float64 {
 	return e.mu.utilizationLimit
 }
 
-// hasWaitingRequests is part of the elasticCPULimiter interface.
+// hasWaitingRequests returns whether the underlying requester currently has
+// any work waiting. It is used internally by tryGrant to decide whether to
+// pull from the queue. External pollers (the scheduler-latency listener)
+// should use hasOrHadRecentWaitingRequests instead.
 func (e *elasticCPUGranter) hasWaitingRequests() bool {
 	hasWaiting, _ := e.requester.hasWaitingRequests()
+	return hasWaiting
+}
+
+// hasOrHadRecentWaitingRequests is part of the elasticCPULimiter interface.
+// The instantaneous hasWaitingRequests signal is unreliable for the
+// scheduler-latency listener because tryGrant drains the requester's queue to
+// empty as soon as tokens refill, so a 1Hz poll typically lands in a window
+// where the queue is empty even under sustained throttling. We OR that signal
+// with the requester's "had recent waiters" sticky bit (set on every Admit
+// enqueue, cleared by this read) so the listener observes any work that was
+// queued between two ticks.
+func (e *elasticCPUGranter) hasOrHadRecentWaitingRequests() bool {
+	hasWaiting, _ := e.requester.hasWaitingRequests()
+	if hadRecent, ok := e.requester.(interface {
+		hadRecentWaitingRequests() bool
+	}); ok {
+		// Always call Swap so the bit is cleared, regardless of hasWaiting.
+		return hadRecent.hadRecentWaitingRequests() || hasWaiting
+	}
 	return hasWaiting
 }
 

--- a/pkg/util/admission/scheduler_latency_listener.go
+++ b/pkg/util/admission/scheduler_latency_listener.go
@@ -100,7 +100,7 @@ func (e *schedulerLatencyListener) SchedulerLatency(p99, period time.Duration) {
 
 	e.metrics.P99SchedulerLatency.Update(p99.Nanoseconds())
 
-	hasWaitingRequests := e.elasticCPULimiter.hasWaitingRequests()
+	hasWaitingRequests := e.elasticCPULimiter.hasOrHadRecentWaitingRequests()
 	oldUtilizationLimit := e.elasticCPULimiter.getUtilizationLimit()
 	newUtilizationLimit := oldUtilizationLimit
 

--- a/pkg/util/admission/scheduler_latency_listener_test.go
+++ b/pkg/util/admission/scheduler_latency_listener_test.go
@@ -6,6 +6,7 @@
 package admission
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -14,10 +15,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/guptarohit/asciigraph"
 	"github.com/stretchr/testify/require"
 )
@@ -347,7 +355,7 @@ func (t *testElasticCPUUtilizationLimiter) getUtilization() float64 {
 	return t.utilization
 }
 
-func (t *testElasticCPUUtilizationLimiter) hasWaitingRequests() bool {
+func (t *testElasticCPUUtilizationLimiter) hasOrHadRecentWaitingRequests() bool {
 	return t.hasWaitingRequestsVal
 }
 
@@ -360,6 +368,149 @@ func (t *testElasticCPUUtilizationLimiter) setHasWaitingRequests(hasWaitingReque
 }
 
 func (t *testElasticCPUUtilizationLimiter) computeUtilizationMetric() {}
+
+// TestSchedulerLatencyListenerObservesTransientWaiters demonstrates the bug
+// fix for #170400: under sustained throttling, work briefly queues between
+// scheduler-latency listener ticks but is drained by the elastic CPU
+// granter's tryGrant loop almost immediately, so a point-sample of
+// hasWaitingRequests() at tick time would frequently report no waiters and
+// cause the controller to decay the limit toward inactive_point. The fix is
+// for WorkQueue to set a sticky "had recent waiters" bit on every Admit
+// enqueue, which the listener atomically reads-and-clears each tick via
+// elasticCPUGranter.hasOrHadRecentWaitingRequests.
+func TestSchedulerLatencyListenerObservesTransientWaiters(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Build a real WorkQueue hooked up to a real elasticCPUGranter.
+	st := cluster.MakeTestingClusterSettings()
+	ambientCtx := log.MakeTestingAmbientContext(tracing.NewTracer())
+	registry := metric.NewRegistry()
+	wqMetrics := makeWorkQueueMetrics("test-elastic-cpu", registry)
+	granterMetrics := makeElasticCPUGranterMetrics()
+	granter := newElasticCPUGranter(ambientCtx, st, granterMetrics)
+
+	wq := &WorkQueue{}
+	// Disable the fast path so Admit always pushes to the heap, and pin the
+	// utilization limit at 0 so the granter's tryGrant cannot drain the
+	// queue. Together these guarantee the request stays parked until the
+	// test cancels it.
+	initWorkQueue(wq, ambientCtx, KVWork, "test-elastic-cpu-queue", granter, st, wqMetrics,
+		workQueueOptions{
+			mode:                         usesTokens,
+			disableEpochClosingGoroutine: true,
+			disableGCGroupsAndResetUsed:  true,
+		}, &TestingKnobs{DisableWorkQueueFastPath: true})
+	defer wq.close()
+	granter.setRequester(wq)
+	granter.setUtilizationLimit(0)
+
+	// Sanity: with no work admitted, the new method returns false.
+	require.False(t, granter.hasOrHadRecentWaitingRequests(),
+		"expected no waiters initially")
+
+	// Submit one Admit in a goroutine with a cancelable context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	admitDone := make(chan struct{})
+	go func() {
+		defer close(admitDone)
+		_, _ = wq.Admit(ctx, WorkInfo{
+			TenantID:       roachpb.SystemTenantID,
+			Priority:       admissionpb.NormalPri,
+			RequestedCount: 1,
+		})
+	}()
+
+	// Wait until Admit has finished pushing the work onto the heap and set
+	// the sticky bit. Looking at hadWaitingRequests directly (not via the
+	// public Swap-clearing method) so this synchronization step does not
+	// consume the bit we want to observe below.
+	testutils.SucceedsSoon(t, func() error {
+		if !wq.hadWaitingRequests.Load() {
+			return errors.New("waiting for Admit to enqueue and set sticky bit")
+		}
+		return nil
+	})
+
+	// Cancel the in-flight Admit and let its goroutine drain so the queue
+	// returns to empty -- this models the production scenario where tryGrant
+	// has just drained the queue between two listener ticks.
+	cancel()
+	<-admitDone
+	hasWaiting, _ := wq.hasWaitingRequests()
+	require.False(t, hasWaiting,
+		"queue should be empty after Admit returns; otherwise the test does not "+
+			"actually exercise the sticky-bit path")
+
+	// First poll observes the recent-waiter bit even though the queue is now
+	// empty. This is the behavior the bug fix introduces: a point-sample of
+	// hasWaitingRequests would have returned false here.
+	require.True(t, granter.hasOrHadRecentWaitingRequests(),
+		"expected sticky bit to surface the recent enqueue")
+
+	// Second poll consumes nothing (Swap cleared the bit and the queue is
+	// still empty), so it returns false.
+	require.False(t, granter.hasOrHadRecentWaitingRequests(),
+		"sticky bit should have been cleared by the previous read")
+}
+
+// TestElasticCPUGranterHasOrHadRecentWaitingRequestsORs verifies that
+// elasticCPUGranter.hasOrHadRecentWaitingRequests ORs the instantaneous
+// hasWaitingRequests signal with the WorkQueue's sticky "had recent waiters"
+// bit. Both inputs surface as true; the read clears only the sticky bit.
+func TestElasticCPUGranterHasOrHadRecentWaitingRequestsORs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	st := cluster.MakeTestingClusterSettings()
+	ambientCtx := log.MakeTestingAmbientContext(tracing.NewTracer())
+	registry := metric.NewRegistry()
+	wqMetrics := makeWorkQueueMetrics("test-elastic-cpu-or", registry)
+	granterMetrics := makeElasticCPUGranterMetrics()
+	granter := newElasticCPUGranter(ambientCtx, st, granterMetrics)
+
+	wq := &WorkQueue{}
+	initWorkQueue(wq, ambientCtx, KVWork, "test-elastic-cpu-or-queue", granter, st, wqMetrics,
+		workQueueOptions{
+			mode:                         usesTokens,
+			disableEpochClosingGoroutine: true,
+			disableGCGroupsAndResetUsed:  true,
+		}, &TestingKnobs{DisableWorkQueueFastPath: true})
+	defer wq.close()
+	granter.setRequester(wq)
+	granter.setUtilizationLimit(0)
+
+	// Submit an Admit that stays parked in the queue. Use a context tied to
+	// the test lifetime; we cancel it at the end to release the goroutine.
+	ctx, cancel := context.WithCancel(context.Background())
+	admitDone := make(chan struct{})
+	go func() {
+		defer close(admitDone)
+		_, _ = wq.Admit(ctx, WorkInfo{
+			TenantID:       roachpb.SystemTenantID,
+			Priority:       admissionpb.NormalPri,
+			RequestedCount: 1,
+		})
+	}()
+	defer func() {
+		cancel()
+		<-admitDone
+	}()
+
+	// Wait for the request to land in the heap (and set the sticky bit).
+	testutils.SucceedsSoon(t, func() error {
+		hasWaiting, _ := wq.hasWaitingRequests()
+		if !hasWaiting {
+			return errors.New("waiting for Admit to enqueue")
+		}
+		return nil
+	})
+
+	// First call: both signals true; method returns true and clears sticky.
+	require.True(t, granter.hasOrHadRecentWaitingRequests())
+	// Sticky bit is cleared, but the request is still queued, so the
+	// instantaneous hasWaitingRequests path still surfaces true.
+	require.True(t, granter.hasOrHadRecentWaitingRequests())
+}
 
 func (p schedulerLatencyListenerParams) String() string {
 	inactiveUtilizationLimit := p.minUtilization +

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -310,6 +310,16 @@ type WorkQueue struct {
 	usesAsyncAdmit bool
 	settings       *cluster.Settings
 
+	// hadWaitingRequests is set whenever Admit enqueues work, and cleared by
+	// hadRecentWaitingRequests via Swap. It exists so that consumers polling at
+	// a coarse cadence (the elastic CPU controller runs at ~1Hz) can observe
+	// enqueues that happened between polls even when the queue has already
+	// drained to empty by the time of the poll. The instantaneous
+	// hasWaitingRequests signal is unreliable for this purpose because the
+	// elastic CPU granter's tryGrant loop drains the queue as soon as tokens
+	// refill.
+	hadWaitingRequests atomic.Bool
+
 	onAdmittedReplicatedWork onAdmittedReplicatedWork
 
 	mu struct {
@@ -1040,6 +1050,10 @@ func (q *WorkQueue) Admit(ctx context.Context, info WorkInfo) (AdmitResponse, er
 	q.mu.Unlock()
 
 	q.metrics.recordStartWait(info.Priority)
+	// Record that work was queued so the elastic CPU controller can observe
+	// this enqueue at its next tick even if the queue drains in the meantime.
+	// See WorkQueue.hadWaitingRequests.
+	q.hadWaitingRequests.Store(true)
 	if info.ReplicatedWorkInfo.Enabled {
 		if log.V(1) {
 			q.mu.Lock()
@@ -1259,6 +1273,15 @@ func (q *WorkQueue) hasWaitingRequests() (bool, burstQualification) {
 		return false, noBurst /*arbitrary*/
 	}
 	return true, q.mu.groupHeap[0].cpuTimeBurstBucket.burstQualification()
+}
+
+// hadRecentWaitingRequests returns whether Admit has enqueued any work since
+// the last call to this method, atomically clearing the underlying flag. The
+// intended caller is the elastic CPU scheduler-latency listener, which polls
+// at a coarse cadence (~1Hz) and would otherwise miss enqueues that drain
+// between polls.
+func (q *WorkQueue) hadRecentWaitingRequests() bool {
+	return q.hadWaitingRequests.Swap(false)
 }
 
 func (q *WorkQueue) granted(grantChainID grantChainID) int64 {


### PR DESCRIPTION
The elastic CPU controller's scheduler-latency listener point-samples the
WorkQueue's `hasWaitingRequests` at ~1Hz. The granter's `tryGrant` loop
drains the queue to empty as soon as tokens refill, so the queue spends
most of its time empty even under sustained throttling. The listener's
poll frequently lands in those empty windows and takes the inactive-decay
branch, pulling the utilization limit down toward `inactive_point` (~12%)
even when scheduler latency is well under target and there is clearly
demand for more elastic CPU.

This PR adds a sticky "had recent waiters" atomic bool on `WorkQueue`,
set on every `Admit` enqueue and cleared by an atomic Swap from the
listener each tick. A new `elasticCPULimiter.hasOrHadRecentWaitingRequests`
ORs this with the instantaneous `hasWaitingRequests` signal so any
enqueue between two ticks is durably visible to the controller, even if
the queue subsequently drained.

Fixes #170400

Epic: none

Release note (bug fix): Fix the elastic CPU admission controller holding
the elastic-work CPU utilization limit at its inactive floor (~12%) even
when there was sustained demand under the scheduling-latency target. The
controller's 1Hz poll could miss queued work that the granter drained
between ticks, causing it to incorrectly conclude there was no demand
and decay the limit.