### PR TITLE
release-26.2: roachtest: retain old descriptor versions for concurrent npgsql tests

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql.go
+++ b/pkg/cmd/roachtest/tests/npgsql.go
@@ -58,6 +58,12 @@ func registerNpgsql(r registry.Registry) {
 			`GRANT admin TO npgsql_tests`,
 			`DROP DATABASE IF EXISTS npgsql_tests`,
 			`CREATE DATABASE npgsql_tests`,
+			// The npgsql test suite runs many tests in parallel. Concurrent DDL
+			// modify the database descriptor and cause concurrent transactions
+			// to fail with a retry error which npgsql does not retry. Retain
+			// the old descriptor versions to prevent the un-retried errors from
+			// percolating.
+			`SET CLUSTER SETTING sql.catalog.descriptor_lease.lock_old_versions.enabled = 'true'`,
 		} {
 			if _, err := db.ExecContext(ctx, cmd); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Backport 1/1 commits from #171123 on behalf of @bghal.

----

The test suite doesn't retry on the retryable
error. This change has the server retain the old
versions so that the test can succeed without
erroring on a error it doesn't retry on.

Epic: none
Fixes: #170627

Release note: None


----

Release justification: test only fix