### PR TITLE
kvserver: apply non-trivial side effects in standalone log replay

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -241,22 +241,29 @@ func (b *appBatch) runPostAddTriggers(
 // (replicaAppBatch.Stage) calls the same underlying methods with replica-only
 // steps interleaved.
 //
+// The WriteBatch is staged in b.batch and committed later by the caller. Any
+// non-trivial side effects (AddSSTable / LinkExternalSSTable / Excise) are
+// applied directly to env.eng by runPostAddTriggers; they bypass b.batch and
+// take effect immediately, so the caller must ensure that any prior commands
+// in the same batch have been committed before applyEntry is called for a
+// non-trivial entry.
+//
 // Commands that fail CheckForcedErr are applied as empty no-ops: their
 // WriteBatch and ReplicatedEvalResult are zeroed out, but the applied index
 // still advances. This matches the online path's behavior.
 //
-// TODO(mira): Apply non-trivial side effects such as AddSSTable ingestions
-// (runPostAddTriggers). Currently only the WriteBatch is applied.
-//
 // The caller is responsible for calling addAppliedStateToBatch and committing
 // the batch after applying one or more entries.
-func (b *appBatch) applyEntry(ctx context.Context, cmd *replicatedCmd) error {
+func (b *appBatch) applyEntry(ctx context.Context, cmd *replicatedCmd, env postAddEnv) error {
 	fr, err := b.assertAndCheckCommand(ctx, &cmd.ReplicatedCmd, false /* isLocal */)
 	if err != nil {
 		return err
 	}
 	b.toCheckedCmd(ctx, &cmd.ReplicatedCmd, fr)
 	if err := b.addWriteBatch(ctx, cmd); err != nil {
+		return err
+	}
+	if err := b.runPostAddTriggers(ctx, &cmd.ReplicatedCmd, env); err != nil {
 		return err
 	}
 	b.stageTrivialResult(&cmd.ReplicatedCmd, fr)
@@ -322,6 +329,9 @@ type replayBatch struct {
 	// cmd is reused across ApplyEntry calls. Decode resets all fields before
 	// populating, so no state leaks between entries.
 	cmd replicatedCmd
+	// env carries the dependencies needed to apply non-trivial side effects
+	// (AddSSTable, LinkExternalSSTable, Excise) directly to the state engine.
+	env postAddEnv
 }
 
 // AppliedIndex implements kvstorage.ReplayBatch.
@@ -329,15 +339,40 @@ func (rb *replayBatch) AppliedIndex() kvpb.RaftIndex {
 	return rb.ab.state.RaftAppliedIndex
 }
 
-// ApplyEntry implements kvstorage.ReplayBatch.
+// Sideloaded implements kvstorage.ReplayBatch.
+func (rb *replayBatch) Sideloaded() logstore.SideloadStorage {
+	return rb.env.sideloaded
+}
+
+// ApplyEntry implements kvstorage.ReplayBatch. Sideloaded payloads must
+// already be inlined by the caller before applying the entry.
+//
+// Returns needsReload=true in two situations, which the caller handles the
+// same way (commit batch, reload state, continue replay):
+//
+//   - The entry is non-trivial and was applied alone in this batch. State
+//     may have changed (lease, GC threshold, etc.) in ways subsequent
+//     entries need to see, so the caller reloads before continuing.
+//
+//   - The entry is non-trivial and was refused because the batch already
+//     contains staged writes from preceding trivial entries. Non-trivial
+//     side effects (AddSSTable, LinkExternalSSTable, Excise) bypass the
+//     staged batch and run directly against the engine; applying them
+//     while the batch holds uncommitted writes would let those writes
+//     shadow or be shadowed by the side effects in the wrong order. The
+//     entry will be re-fed as the first entry of the next batch.
 func (rb *replayBatch) ApplyEntry(ctx context.Context, ent raftpb.Entry) (bool, error) {
 	if err := rb.cmd.Decode(&ent); err != nil {
 		return false, err
 	}
-	if err := rb.ab.applyEntry(ctx, &rb.cmd); err != nil {
+	trivial := rb.cmd.IsTrivial()
+	if !trivial && !rb.ab.batch.State().Empty() {
+		return true /* needsReload */, nil
+	}
+	if err := rb.ab.applyEntry(ctx, &rb.cmd, rb.env); err != nil {
 		return false, err
 	}
-	return rb.cmd.IsTrivial(), nil
+	return !trivial /* needsReload */, nil
 }
 
 // Commit implements kvstorage.ReplayBatch.
@@ -360,7 +395,10 @@ func (rb *replayBatch) Close() {
 // The state engine (not a snapshot) must be passed so that reads see writes
 // committed by previous replay batches.
 func MakeNewReplayBatchFn(
-	stateEng storage.Engine, bf *kvstorage.BatchFactory,
+	st *cluster.Settings,
+	stateEng storage.Engine,
+	bf *kvstorage.BatchFactory,
+	bulkLimiter *rate.Limiter,
 ) kvstorage.NewReplayBatchFn {
 	return func(
 		ctx context.Context, rangeID roachpb.RangeID, startKey roachpb.RKey,
@@ -376,12 +414,23 @@ func MakeNewReplayBatchFn(
 		if err != nil {
 			return nil, err
 		}
+		// DiskSideloadStorage is used both to inline sideloaded payloads (via
+		// Sideloaded()) and to ingest AddSSTable payloads (via runPostAddTriggers)
+		sideloaded := logstore.NewDiskSideloadStorage(
+			st, rangeID, stateEng.GetAuxiliaryDir(), bulkLimiter, stateEng.Env(),
+		)
 		return &replayBatch{
 			ab: appBatch{
 				state:                  state,
 				batch:                  bf.NewBatch(),
 				sl:                     sl,
 				initialForceFlushIndex: state.ForceFlushIndex,
+			},
+			env: postAddEnv{
+				st:          st,
+				eng:         stateEng,
+				sideloaded:  sideloaded,
+				bulkLimiter: bulkLimiter,
 			},
 		}, nil
 	}

--- a/pkg/kv/kvserver/app_batch_test.go
+++ b/pkg/kv/kvserver/app_batch_test.go
@@ -8,6 +8,7 @@ package kvserver
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -15,15 +16,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
 )
 
 // makeTestEntry creates a raftpb.Entry with an encoded RaftCommand for testing.
@@ -102,9 +107,9 @@ func TestAppBatchApplyEntry(t *testing.T) {
 	// Apply multiple entries into the same batch.
 	var cmd replicatedCmd
 	require.NoError(t, cmd.Decode(&ent1))
-	require.NoError(t, ab.applyEntry(ctx, &cmd))
+	require.NoError(t, ab.applyEntry(ctx, &cmd, postAddEnv{}))
 	require.NoError(t, cmd.Decode(&ent2))
-	require.NoError(t, ab.applyEntry(ctx, &cmd))
+	require.NoError(t, ab.applyEntry(ctx, &cmd, postAddEnv{}))
 
 	// Write the applied state and commit atomically.
 	require.NoError(t, ab.addAppliedStateToBatch(ctx))
@@ -123,4 +128,110 @@ func TestAppBatchApplyEntry(t *testing.T) {
 		require.Len(t, kvs, 1)
 		require.Equal(t, []byte(kv.v), kvs[0].Value)
 	}
+}
+
+// TestReplayBatchAddSSTable verifies the standalone replay path's handling
+// of AddSSTable: it triggers needsReload (without being applied) when it
+// follows another entry in the batch, and it applies cleanly (and the SST
+// is ingested) when it's the first entry in a batch.
+//
+// TODO(mira): once #170818 lands, fold this into the kvserver replica
+// lifecycle datadriven suite.
+func TestReplayBatchAddSSTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	st := cluster.MakeTestingClusterSettings()
+	eng := kvstorage.MakeSeparatedEnginesForTesting(
+		storage.NewDefaultInMemForTesting(), storage.NewDefaultInMemForTesting(),
+	)
+	defer eng.Close()
+	var seq wag.Seq
+	bf := kvstorage.MakeBatchFactory(&eng, &seq)
+	stateEng := eng.StateEngine()
+	bulkLimiter := rate.NewLimiter(rate.Inf, math.MaxInt64)
+	rangeID := roachpb.RangeID(1)
+	sideloaded := logstore.NewDiskSideloadStorage(
+		st, rangeID, stateEng.GetAuxiliaryDir(), bulkLimiter, stateEng.Env(),
+	)
+	lease := roachpb.Lease{Sequence: 1}
+
+	newBatch := func(appliedIdx kvpb.RaftIndex) *replayBatch {
+		return &replayBatch{
+			ab: appBatch{
+				state: kvserverpb.ReplicaState{
+					RaftAppliedIndex: appliedIdx,
+					Lease:            &lease,
+					GCThreshold:      &hlc.Timestamp{},
+					Desc:             &roachpb.RangeDescriptor{RangeID: rangeID},
+					Stats:            &enginepb.MVCCStats{},
+				},
+				batch: bf.NewBatch(),
+				sl:    kvstorage.MakeStateLoader(rangeID),
+			},
+			env: postAddEnv{st: st, eng: stateEng, sideloaded: sideloaded, bulkLimiter: bulkLimiter},
+		}
+	}
+
+	// Build a single SST and reuse it across the three attempts below.
+	sstData, ingested := MakeSSTable(ctx, "sstk", "v", hlc.Timestamp{WallTime: 1})
+	addSST := func(idx kvpb.RaftIndex) raftpb.Entry {
+		return makeTestEntry(t, idx, 1, kvserverpb.RaftCommand{
+			ProposerLeaseSequence: lease.Sequence,
+			MaxLeaseIndex:         kvpb.LeaseAppliedIndex(idx),
+			ReplicatedEvalResult: kvserverpb.ReplicatedEvalResult{
+				AddSSTable: &kvserverpb.ReplicatedEvalResult_AddSSTable{
+					Data: sstData, CRC32: util.CRC32(sstData),
+				},
+			},
+		})
+	}
+
+	t.Run("refused after another entry", func(t *testing.T) {
+		rb := newBatch(10)
+		defer rb.Close()
+		trivial := makeTestEntry(t, 11, 1, kvserverpb.RaftCommand{
+			ProposerLeaseSequence: lease.Sequence,
+			MaxLeaseIndex:         11,
+			WriteBatch:            makeWriteBatch(t, stateEng, "trivk", "v"),
+		})
+		needsReload, err := rb.ApplyEntry(ctx, trivial)
+		require.NoError(t, err)
+		require.False(t, needsReload)
+
+		needsReload, err = rb.ApplyEntry(ctx, addSST(12))
+		require.NoError(t, err)
+		require.True(t, needsReload)
+		require.Equal(t, kvpb.RaftIndex(11), rb.AppliedIndex())
+	})
+
+	t.Run("first in batch", func(t *testing.T) {
+		rb := newBatch(10)
+		defer rb.Close()
+		needsReload, err := rb.ApplyEntry(ctx, addSST(11))
+		require.NoError(t, err)
+		require.True(t, needsReload)
+		require.NoError(t, rb.Commit(ctx))
+
+		got, err := storage.Scan(ctx, stateEng, ingested.Key.Key, ingested.Key.Key.Next(), 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, ingested.Value, got[0].Value)
+	})
+
+	t.Run("after another non-trivial", func(t *testing.T) {
+		// The production driver would stop after the first non-trivial and
+		// reload before applying another, so this case doesn't arise in
+		// practice. Verify ApplyEntry still signals reload if it does.
+		rb := newBatch(10)
+		defer rb.Close()
+		needsReload, err := rb.ApplyEntry(ctx, addSST(11))
+		require.NoError(t, err)
+		require.True(t, needsReload)
+
+		needsReload, err = rb.ApplyEntry(ctx, addSST(12))
+		require.NoError(t, err)
+		require.True(t, needsReload)
+	})
 }

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/kv/kvserver/kvstorage/wag",
         "//pkg/kv/kvserver/kvstorage/wag/wagpb",
         "//pkg/kv/kvserver/logstore",
-        "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/spanset",
         "//pkg/raft/raftpb",

--- a/pkg/kv/kvserver/kvstorage/wag_replay.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -93,12 +93,24 @@ type raftCatchUpTarget struct {
 // their writes. The caller must call Close when done, whether or not Commit
 // was called.
 type ReplayBatch interface {
-	// ApplyEntry applies a single raft entry. Returns whether the entry had
-	// only trivial side effects (no lease change, GC threshold bump, etc.).
-	ApplyEntry(context.Context, raftpb.Entry) (trivial bool, _ error)
+	// ApplyEntry applies a single raft entry. The entry's sideloaded payload
+	// (if any) must already be inlined; the replay driver uses Sideloaded()
+	// to do this before calling ApplyEntry.
+	//
+	// needsReload=true signals that the caller should commit the batch and
+	// reload state before applying further entries. It is returned both when
+	// a non-trivial entry has been applied (state may have changed in ways
+	// subsequent entries need to see) and when a non-trivial entry could not
+	// be applied to this batch because it already contains staged writes
+	// from preceding trivial entries.
+	ApplyEntry(context.Context, raftpb.Entry) (needsReload bool, _ error)
 	// AppliedIndex returns the raft applied index after the last ApplyEntry,
 	// or the initial applied index if no entries have been applied yet.
 	AppliedIndex() kvpb.RaftIndex
+	// Sideloaded returns the sideloaded storage for the range this batch
+	// applies to. The replay driver inlines sideloaded payloads using it
+	// before yielding entries to ApplyEntry.
+	Sideloaded() logstore.SideloadStorage
 	// Commit writes the applied state and commits the batch.
 	Commit(context.Context) error
 	// Close releases batch resources. Safe to call after Commit.
@@ -283,9 +295,10 @@ func ReplayWAG(
 
 // replayRaftLog replays raft log entries for a range from its current applied
 // index up to the target index. It creates a ReplayBatch, iterates entries via
-// raftlog.Visit, and applies each one. Non-trivial entries (lease changes, GC
-// threshold bumps, etc.) trigger a batch flush and state reload so that
-// subsequent entries are checked against up-to-date state.
+// logstore.VisitInlined (so any sideloaded payloads are inlined), and applies
+// each one. Non-trivial entries (lease changes, GC threshold bumps, etc.)
+// trigger a batch flush and state reload so that subsequent entries are
+// checked against up-to-date state.
 func replayRaftLog(
 	ctx context.Context, raftRO RaftRO, target raftCatchUpTarget, newBatch NewReplayBatchFn,
 ) error {
@@ -327,21 +340,21 @@ func replayRaftLogBatch(
 	// TODO(mira): Add a max batch size policy to bound memory usage. Large
 	// ranges with many entries could produce an oversized batch here.
 	var needsReload bool
-	// NB: Visit uses [start, end) semantics.
-	err = raftlog.Visit(ctx, raftRO, target.rangeID, lo+1, hi+1, func(ent raftpb.Entry) error {
-		trivial, err := rb.ApplyEntry(ctx, ent)
-		if err != nil {
-			return err
-		}
-		if !trivial {
-			// Non-trivial entries may change state (lease, GC threshold)
-			// that affects accept/reject decisions for subsequent entries.
-			// Stop iteration so the caller can flush and reload.
-			needsReload = true
-			return iterutil.StopIteration()
-		}
-		return nil
-	})
+	// NB: VisitInlined uses [start, end) semantics. Standalone replay has no
+	// raft entry cache, so inlined reads always fall through to sideloaded
+	// storage.
+	err = logstore.VisitInlined(
+		ctx, raftRO, target.rangeID, rb.Sideloaded(), nil, /* entryCache */
+		lo+1, hi+1, func(ent raftpb.Entry) error {
+			var err error
+			if needsReload, err = rb.ApplyEntry(ctx, ent); err != nil {
+				return err
+			} else if needsReload {
+				return iterutil.StopIteration()
+			}
+			return nil
+		},
+	)
 	if err = iterutil.Map(err); err != nil {
 		return false, err
 	}

--- a/pkg/kv/kvserver/kvstorage/wag_replay.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay.go
@@ -8,6 +8,7 @@ package kvstorage
 import (
 	"context"
 	"iter"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
@@ -15,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -294,8 +294,8 @@ func ReplayWAG(
 }
 
 // replayRaftLog replays raft log entries for a range from its current applied
-// index up to the target index. It creates a ReplayBatch, iterates entries via
-// logstore.VisitInlined (so any sideloaded payloads are inlined), and applies
+// index up to the target index. It creates a ReplayBatch, loads entries via
+// logstore.LoadEntries (so any sideloaded payloads are inlined), and applies
 // each one. Non-trivial entries (lease changes, GC threshold bumps, etc.)
 // trigger a batch flush and state reload so that subsequent entries are
 // checked against up-to-date state.
@@ -339,24 +339,20 @@ func replayRaftLogBatch(
 
 	// TODO(mira): Add a max batch size policy to bound memory usage. Large
 	// ranges with many entries could produce an oversized batch here.
-	var needsReload bool
-	// NB: VisitInlined uses [start, end) semantics. Standalone replay has no
-	// raft entry cache, so inlined reads always fall through to sideloaded
-	// storage.
-	err = logstore.VisitInlined(
-		ctx, raftRO, target.rangeID, rb.Sideloaded(), nil, /* entryCache */
-		lo+1, hi+1, func(ent raftpb.Entry) error {
-			var err error
-			if needsReload, err = rb.ApplyEntry(ctx, ent); err != nil {
-				return err
-			} else if needsReload {
-				return iterutil.StopIteration()
-			}
-			return nil
-		},
+	ents, _, _, err := logstore.LoadEntries(
+		ctx, raftRO, target.rangeID, nil, /* eCache */
+		rb.Sideloaded(), lo+1, hi+1, math.MaxUint64, nil, /* bytesAccount */
 	)
-	if err = iterutil.Map(err); err != nil {
+	if err != nil {
 		return false, err
+	}
+	var needsReload bool
+	for _, ent := range ents {
+		if needsReload, err = rb.ApplyEntry(ctx, ent); err != nil {
+			return false, err
+		} else if needsReload {
+			break
+		}
 	}
 	if err := rb.Commit(ctx); err != nil {
 		return false, err

--- a/pkg/kv/kvserver/kvstorage/wag_replay_test.go
+++ b/pkg/kv/kvserver/kvstorage/wag_replay_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/wag/wagpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -152,8 +153,8 @@ func TestCanApply(t *testing.T) {
 }
 
 // writeRaftLogEntries writes empty raft log entries for the given range and
-// index range [lo, hi] to the log engine so that raftlog.Visit can iterate
-// over them during catch-up replay.
+// index range [lo, hi] to the log engine so that the replay driver can
+// iterate over them during catch-up.
 func writeRaftLogEntries(
 	t *testing.T, logEng storage.Engine, rangeID roachpb.RangeID, lo, hi kvpb.RaftIndex,
 ) {
@@ -295,7 +296,14 @@ func (b *simpleReplayBatch) AppliedIndex() kvpb.RaftIndex {
 
 func (b *simpleReplayBatch) ApplyEntry(_ context.Context, ent raftpb.Entry) (bool, error) {
 	b.as.RaftAppliedIndex = kvpb.RaftIndex(ent.Index)
-	return true, nil
+	return false /* needsReload */, nil
+}
+
+// Sideloaded returns nil — this test batch doesn't apply sideloaded entries.
+// The driver passes the returned value to logstore.VisitInlined; since the
+// test entries are never sideloaded, VisitInlined never dereferences it.
+func (b *simpleReplayBatch) Sideloaded() logstore.SideloadStorage {
+	return nil
 }
 
 func (b *simpleReplayBatch) Commit(ctx context.Context) error {

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -856,6 +856,12 @@ func LoadEntries(
 	// stopping once we have enough.
 	expectedIndex := hitIndex
 
+	// TODO(mira): Consider refactoring this to use logstore.VisitInlined. The
+	// challenge is that LoadEntries gates iteration on a gap check that must
+	// run before sideloaded payload inlining (so a truncation that races a
+	// disk read doesn't trigger a wasted sideloaded read, or surface a
+	// spurious errSideloadedFileNotFound on the boundary entry). VisitInlined
+	// inlines before yielding, which inverts that order.
 	scanFunc := func(ent raftpb.Entry) error {
 		// Exit early if we have any gaps or it has been compacted.
 		if kvpb.RaftIndex(ent.Index) != expectedIndex {

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -798,9 +798,10 @@ func LoadEntry(
 }
 
 // LoadEntries loads a slice of consecutive log entries in [lo, hi), starting
-// from lo. It inlines the sideloaded entries, and caches all the loaded
-// entries. The size of the returned entries does not exceed maxSize, unless the
-// first entry exceeds the limit (in which case it is returned regardless).
+// from lo. It inlines the sideloaded entries, and (when eCache is non-nil)
+// caches all the loaded entries. The size of the returned entries does not
+// exceed maxSize, unless the first entry exceeds the limit (in which case it
+// is returned regardless).
 //
 // The valid range for lo/hi is: Compacted < lo <= hi <= LastIndex+1. The caller
 // should check the bounds before making this call.
@@ -810,13 +811,14 @@ func LoadEntry(
 // error is generally unexpected and means something bad.
 //
 // The bytesAccount is used to account for and limit the loaded bytes. It can be
-// nil when the accounting / limiting is not needed.
+// nil when the accounting / limiting is not needed. Pass nil for eCache when
+// no cache is available (e.g. standalone log replay).
 //
 // TODO(pavelkalinnikov): return all entries we've read, consider maxSize a
 // target size. Currently we may read one extra entry and drop it.
 func LoadEntries(
 	ctx context.Context,
-	eng storage.Engine,
+	reader storage.Reader,
 	rangeID roachpb.RangeID,
 	eCache *raftentry.Cache, // TODO(#145562): this should be the caller's concern
 	sideloaded SideloadStorage,
@@ -829,7 +831,10 @@ func LoadEntries(
 	}
 
 	ents := make([]raftpb.Entry, 0, min(hi-lo, 100))
-	ents, _, hitIndex, _ := eCache.Scan(ents, rangeID, lo, hi, maxBytes)
+	hitIndex := lo
+	if eCache != nil {
+		ents, _, hitIndex, _ = eCache.Scan(ents, rangeID, lo, hi, maxBytes)
+	}
 
 	// TODO(pav-kv): pass the sizeHelper to eCache.Scan above, to avoid scanning
 	// the same entries twice, and computing their sizes.
@@ -856,12 +861,6 @@ func LoadEntries(
 	// stopping once we have enough.
 	expectedIndex := hitIndex
 
-	// TODO(mira): Consider refactoring this to use logstore.VisitInlined. The
-	// challenge is that LoadEntries gates iteration on a gap check that must
-	// run before sideloaded payload inlining (so a truncation that races a
-	// disk read doesn't trigger a wasted sideloaded read, or surface a
-	// spurious errSideloadedFileNotFound on the boundary entry). VisitInlined
-	// inlines before yielding, which inverts that order.
 	scanFunc := func(ent raftpb.Entry) error {
 		// Exit early if we have any gaps or it has been compacted.
 		if kvpb.RaftIndex(ent.Index) != expectedIndex {
@@ -888,12 +887,12 @@ func LoadEntries(
 		return nil
 	}
 
-	reader := eng.NewReader(storage.StandardDurability)
-	defer reader.Close()
 	if err := raftlog.Visit(ctx, reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
 		return nil, 0, 0, err
 	}
-	eCache.Add(rangeID, ents, false /* truncate */)
+	if eCache != nil {
+		eCache.Add(rangeID, ents, false /* truncate */)
+	}
 
 	// Did the correct number of results come back? If so, we're all good.
 	// Did we hit the size limits? If so, return what we have.

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -13,10 +13,45 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
+
+// VisitInlined iterates raft entries in [lo, hi) for rangeID, inlining any
+// sideloaded payloads before yielding each fat entry to fn. Pass nil for
+// entryCache when no cache is available (the inline path then falls through
+// to sideloaded storage).
+//
+// Used by standalone log replay. LoadEntries does equivalent work inline but
+// can't share this helper because its gap check must run before any inline
+// read — see the TODO there.
+func VisitInlined(
+	ctx context.Context,
+	reader storage.Reader,
+	rangeID roachpb.RangeID,
+	sideloaded SideloadStorage,
+	entryCache *raftentry.Cache,
+	lo, hi kvpb.RaftIndex,
+	fn func(raftpb.Entry) error,
+) error {
+	return raftlog.Visit(ctx, reader, rangeID, lo, hi, func(ent raftpb.Entry) error {
+		typ, _, err := raftlog.EncodingOf(ent)
+		if err != nil {
+			return err
+		}
+		if typ.IsSideloaded() {
+			ent, err = MaybeInlineSideloadedRaftCommand(
+				ctx, rangeID, ent, sideloaded, entryCache,
+			)
+			if err != nil {
+				return err
+			}
+		}
+		return fn(ent)
+	})
+}
 
 var errSideloadedFileNotFound = errors.New("sideloaded file not found")
 
@@ -148,8 +183,10 @@ func MaybeSideloadEntries(
 
 // MaybeInlineSideloadedRaftCommand takes an entry and inspects it. If its
 // command encoding version indicates a sideloaded entry, it uses the entryCache
-// or SideloadStorage to inline the payload, and returns a new entry (which must
-// be treated as immutable by the caller).
+// (if non-nil) or SideloadStorage to inline the payload, and returns a new
+// entry (which must be treated as immutable by the caller). Callers without
+// an entry cache (e.g. standalone log replay) may pass nil; the payload will
+// then always be read from sideloaded storage.
 //
 // If a payload is missing, returns an error whose Cause() is
 // errSideloadedFileNotFound.
@@ -167,9 +204,11 @@ func MaybeInlineSideloadedRaftCommand(
 	log.Event(ctx, "inlining sideloaded SSTable")
 	// We could unmarshal this yet again, but if it's committed we are very likely
 	// to have appended it recently, in which case we can save work.
-	if entry, hit := entryCache.Get(rangeID, kvpb.RaftIndex(ent.Index)); hit {
-		log.Event(ctx, "using cache hit")
-		return entry, nil
+	if entryCache != nil {
+		if entry, hit := entryCache.Get(rangeID, kvpb.RaftIndex(ent.Index)); hit {
+			log.Event(ctx, "using cache hit")
+			return entry, nil
+		}
 	}
 
 	log.Event(ctx, "inlined entry not cached")

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -13,45 +13,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
-
-// VisitInlined iterates raft entries in [lo, hi) for rangeID, inlining any
-// sideloaded payloads before yielding each fat entry to fn. Pass nil for
-// entryCache when no cache is available (the inline path then falls through
-// to sideloaded storage).
-//
-// Used by standalone log replay. LoadEntries does equivalent work inline but
-// can't share this helper because its gap check must run before any inline
-// read — see the TODO there.
-func VisitInlined(
-	ctx context.Context,
-	reader storage.Reader,
-	rangeID roachpb.RangeID,
-	sideloaded SideloadStorage,
-	entryCache *raftentry.Cache,
-	lo, hi kvpb.RaftIndex,
-	fn func(raftpb.Entry) error,
-) error {
-	return raftlog.Visit(ctx, reader, rangeID, lo, hi, func(ent raftpb.Entry) error {
-		typ, _, err := raftlog.EncodingOf(ent)
-		if err != nil {
-			return err
-		}
-		if typ.IsSideloaded() {
-			ent, err = MaybeInlineSideloadedRaftCommand(
-				ctx, rangeID, ent, sideloaded, entryCache,
-			)
-			if err != nil {
-				return err
-			}
-		}
-		return fn(ent)
-	})
-}
 
 var errSideloadedFileNotFound = errors.New("sideloaded file not found")
 

--- a/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
+++ b/pkg/kv/kvserver/replica_lifecycle_datadriven_test.go
@@ -1065,7 +1065,12 @@ func (b *testReplayBatch) AppliedIndex() kvpb.RaftIndex {
 
 func (b *testReplayBatch) ApplyEntry(_ context.Context, ent raftpb.Entry) (bool, error) {
 	b.as.RaftAppliedIndex = kvpb.RaftIndex(ent.Index)
-	return true, nil
+	return false /* needsReload */, nil
+}
+
+// Sideloaded returns nil — this test batch doesn't apply sideloaded entries.
+func (b *testReplayBatch) Sideloaded() logstore.SideloadStorage {
+	return nil
 }
 
 func (b *testReplayBatch) Commit(ctx context.Context) error {

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -166,8 +167,10 @@ func (r *replicaLogStorage) entriesLocked(
 	//
 	// TODO(pav-kv): we need better safety guardrails here. The log storage type
 	// can remember the readable bounds, and assert that reads do not cross them.
+	reader := r.ls.Engine.NewReader(storage.StandardDurability)
+	defer reader.Close()
 	entries, _, loadedSize, err := logstore.LoadEntries(
-		r.ctx, r.ls.Engine, r.ls.RangeID, r.cache, r.ls.Sideload,
+		r.ctx, reader, r.ls.RangeID, r.cache, r.ls.Sideload,
 		lo, hi, maxBytes,
 		nil, // bytesAccount is not used when reading under Replica.mu
 	)
@@ -345,8 +348,10 @@ func (r *replicaRaftMuLogSnap) entriesRaftMuLocked(
 	if lo <= r.shMu.trunc.Index {
 		return nil, raft.ErrCompacted
 	}
+	reader := r.ls.Engine.NewReader(storage.StandardDurability)
+	defer reader.Close()
 	entries, _, loadedSize, err := logstore.LoadEntries(
-		r.ctx, r.ls.Engine, r.ls.RangeID, r.cache, r.ls.Sideload,
+		r.ctx, reader, r.ls.RangeID, r.cache, r.ls.Sideload,
 		lo, hi, maxBytes,
 		&r.raftMu.bytesAccount,
 	)


### PR DESCRIPTION
Standalone raft log replay (replayBatch, used by WAG replay) previously
applied only the WriteBatch portion of each command, leaving AddSSTable,
LinkExternalSSTable, and Excise side effects unapplied.

Wire runPostAddTriggers into appBatch.applyEntry so these effects are
applied directly against the state engine. Since they bypass the pebble
batch, the standalone replay loop relies on its existing IsTrivial check
to guarantee that any prior commands in the batch have been committed
before a non-trivial entry is applied.

Sideloaded payloads are inlined before reaching the apply layer; the
replay driver uses a new logstore.VisitInlined helper for this.

Informs: #75729

Release note: None