### PR TITLE
roachtest: add transactional LDR test suite

### DIFF
--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -38,6 +38,12 @@ type latencyVerifier struct {
 	jobFetcher               jobFetcher
 	setTestStatus            func(...interface{})
 
+	// expectBacklog enables the convergence-from-behind logic for jobs that
+	// start with a backlog (e.g. initial scan). When false, the verifier
+	// assumes replication starts with no lag and simply checks that lag
+	// stays below targetSteadyLatency on every poll.
+	expectBacklog bool
+
 	initialScanHighwater time.Time
 	initialScanLatency   time.Duration
 
@@ -82,6 +88,11 @@ func makeLatencyVerifier(
 }
 
 func (lv *latencyVerifier) noteHighwater(highwaterTime time.Time) {
+	if !lv.expectBacklog {
+		lv.noteHighwaterNoBacklog(highwaterTime)
+		return
+	}
+
 	// Highwater timestamps received before the statement time indicate an initial
 	// scan is taking place.
 	if highwaterTime.Before(lv.statementTime) {
@@ -153,6 +164,30 @@ func (lv *latencyVerifier) noteHighwater(highwaterTime time.Time) {
 	if justSwitchedToSteadyState {
 		lv.logger.Printf("just reached steady state, sleeping for 2 minutes to ensure no temporary latency regressions")
 		time.Sleep(2 * time.Minute)
+	}
+}
+
+// noteHighwaterNoBacklog is the simple no-backlog path. It assumes replication
+// starts with no lag and just checks that lag stays below the threshold.
+func (lv *latencyVerifier) noteHighwaterNoBacklog(highwaterTime time.Time) {
+	if highwaterTime.IsZero() {
+		return
+	}
+	latency := timeutil.Since(highwaterTime)
+	lv.latencyBecameSteady = true
+	if err := lv.latencyHist.RecordValue(latency.Nanoseconds()); err != nil {
+		if lv.tooLargeEveryN.ShouldLog() {
+			lv.logger.Printf("%s: could not record value %s: %s\n", lv.name, latency, err)
+		}
+	}
+	if latency > lv.maxSeenSteadyLatency {
+		lv.maxSeenSteadyLatency = latency
+	}
+	if lv.maxSeenSteadyEveryN.ShouldLog() {
+		update := fmt.Sprintf(
+			"%s: end-to-end steady latency %s; max steady latency so far %s; highwater %s",
+			lv.name, latency.Truncate(time.Millisecond), lv.maxSeenSteadyLatency.Truncate(time.Millisecond), highwaterTime)
+		lv.setTestStatus(update)
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -79,6 +81,9 @@ type LDRWorkload struct {
 	manualSchemaSetup bool
 	dbName            string
 	tableNames        []string
+	// skipDLQCheck skips DLQ table validation. Transactional mode does not
+	// create DLQ tables.
+	skipDLQCheck bool
 }
 
 func registerLogicalDataReplicationTests(r registry.Registry) {
@@ -243,6 +248,28 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 			run: TestLDRCreateTablesTPCC,
 		},
 		{
+			name: "ldr/transactional/create/tpcc",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{
+				initialScanTimeout: 10 * time.Minute,
+				createTables:       true,
+				mode:               ModeTransactional,
+				workloadDuration:   15 * time.Minute,
+			},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDRCreateTablesTPCC,
+		},
+		{
 			name: "ldr/conflict",
 			clusterSpec: multiClusterSpec{
 				leftNodes:  3,
@@ -307,6 +334,132 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 			run:                 TestLDRUniqueConstraintUpdate,
 			monitor:             true,
 		},
+		{
+			name: "ldr/transactional/kv0/basic",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{mode: ModeTransactional, initWithSeed: true},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDRBasic,
+		},
+		{
+			name: "ldr/transactional/kv0/update_heavy",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{mode: ModeTransactional, initWithSeed: true},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDRUpdateHeavy,
+		},
+		{
+			name: "ldr/transactional/kv0/shutdown_node",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{mode: ModeTransactional, initWithSeed: true},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDROnNodeShutdown,
+		},
+		{
+			name: "ldr/transactional/kv0/network_partition",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{mode: ModeTransactional, initWithSeed: true},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDROnNetworkPartition,
+		},
+		{
+			name: "ldr/transactional/kv0/schema_change",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{mode: ModeTransactional, initWithSeed: true},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDRSchemaChange,
+		},
+		{
+			name: "ldr/transactional/tpcc",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(8),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(8),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{
+				mode:         ModeTransactional,
+				initWithSeed: true,
+			},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum: clusterversion.V26_3,
+			run:                 TestLDRTPCC,
+		},
+		{
+			name: "ldr/transactional/conflict",
+			clusterSpec: multiClusterSpec{
+				leftNodes:  3,
+				rightNodes: 3,
+				clusterOpts: []spec.Option{
+					spec.CPU(4),
+					spec.WorkloadNode(),
+					spec.WorkloadNodeCPU(4),
+					spec.VolumeSize(100),
+				},
+			},
+			ldrConfig: ldrConfig{
+				createTables: true,
+				mode:         ModeTransactional,
+			},
+			// Transactional mode is new in v26.3 and won't work on older binaries.
+			mixedVersionMinimum:        clusterversion.V26_3,
+			requiresDeprecatedWorkload: true,
+			run:                        TestLDRConflict,
+		},
 	}
 
 	for _, sp := range specs {
@@ -360,14 +513,15 @@ func TestLDRBasic(
 			initWithSplitAndScatter: !c.IsLocal(),
 			uniform:                 true,
 		},
-		dbName:     "kv",
-		tableNames: []string{"kv"},
+		dbName:       "kv",
+		tableNames:   []string{"kv"},
+		skipDLQCheck: ldrConfig.mode.SkipDLQCheck(),
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 	workloadDoneCh := make(chan struct{})
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
-	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, 2*time.Minute)
+	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, 2*time.Minute, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
@@ -397,15 +551,16 @@ func TestLDRSchemaChange(
 			tolerateErrors:          true,
 			uniform:                 true,
 		},
-		dbName:     "kv",
-		tableNames: []string{"kv"},
+		dbName:       "kv",
+		tableNames:   []string{"kv"},
+		skipDLQCheck: ldrConfig.mode.SkipDLQCheck(),
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 
 	workloadDoneCh := make(chan struct{})
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
-	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, 2*time.Minute)
+	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, 2*time.Minute, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
@@ -452,26 +607,44 @@ func TestLDRTPCC(
 		dbName:            "tpcc",
 		manualSchemaSetup: true,
 		tableNames:        []string{"customer", "district", "history", "item", "new_order", "order_line", "order", "stock", "warehouse"},
+		skipDLQCheck:      ldrConfig.mode.SkipDLQCheck(),
 	}
 
-	// Init the clusters manually, so the left has 10 warehouses and the right has
-	// 1. Ideally the right cluster's table's would be empty, but you cant run
-	// tpcc with 0 warehouses.
-	//
-	// TODO(msbutler): eventually LDR will create the right cluster's replicating
-	// tables.
-	c.Run(ctx,
-		option.WithNodes(setup.workloadNode),
-		fmt.Sprintf("./cockroach workload init tpcc --warehouses=1 --fks=false {pgurl:%d:system}", setup.right.nodes[0]))
-	c.Run(ctx,
-		option.WithNodes(setup.workloadNode),
-		fmt.Sprintf("./cockroach workload init tpcc --warehouses=10 --fks=false {pgurl:%d:system}", setup.left.nodes[0]))
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, workload, ldrConfig)
+	var cursor string
+	if ldrConfig.initWithSeed {
+		// Transactional LDR cannot safely perform initial scans
+		// (#169338). Init both clusters with identical data using a random
+		// seed, then use a cursor to skip the initial scan.
+		seed := setup.rng.Int63()
+		t.L().Printf("using workload seed %d", seed)
+		initCmd := fmt.Sprintf(
+			"./cockroach workload init tpcc --warehouses=%d --fks=false --seed=%d",
+			warehouses, seed)
+		c.Run(ctx, option.WithNodes(setup.workloadNode),
+			fmt.Sprintf("%s {pgurl:%d:system}", initCmd, setup.right.nodes[0]))
+		c.Run(ctx, option.WithNodes(setup.workloadNode),
+			fmt.Sprintf("%s {pgurl:%d:system}", initCmd, setup.left.nodes[0]))
+		cursor = getMinCursor(t, setup)
+	} else {
+		// Init the clusters manually, so the left has 10 warehouses and
+		// the right has 1. Ideally the right cluster's tables would be
+		// empty, but you can't run tpcc with 0 warehouses.
+		//
+		// TODO(msbutler): eventually LDR will create the right cluster's
+		// replicating tables.
+		c.Run(ctx,
+			option.WithNodes(setup.workloadNode),
+			fmt.Sprintf("./cockroach workload init tpcc --warehouses=1 --fks=false {pgurl:%d:system}", setup.right.nodes[0]))
+		c.Run(ctx,
+			option.WithNodes(setup.workloadNode),
+			fmt.Sprintf("./cockroach workload init tpcc --warehouses=10 --fks=false {pgurl:%d:system}", setup.left.nodes[0]))
+	}
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, workload, ldrConfig, cursor)
 
 	workloadDoneCh := make(chan struct{})
 	maxExpectedLatency := 3 * time.Minute
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
-	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
@@ -509,11 +682,15 @@ func TestLDRConflict(
 	c.Run(ctx, option.WithNodes(setup.workloadNode), "./workload", "init", "conflict", leftURL)
 
 	t.Status("creating bidirectional replication job")
-	setup.right.sysSQL.QueryRow(t, `
+	modeOpt := ""
+	if ldrConfig.mode != Default {
+		modeOpt = fmt.Sprintf(", MODE = '%s'", ldrConfig.mode)
+	}
+	setup.right.sysSQL.QueryRow(t, fmt.Sprintf(`
 	CREATE LOGICALLY REPLICATED TABLE conflict.conflict FROM TABLE conflict.conflict
 		ON 'external://left'
-		WITH BIDIRECTIONAL ON 'external://right'
-	`).Scan(&rightJobID)
+		WITH BIDIRECTIONAL ON 'external://right'%s
+	`, modeOpt)).Scan(&rightJobID)
 
 	t.Status("waiting for right job to start up")
 	waitForReplicatedTime(t, rightJobID, setup.right.db, getLogicalDataReplicationJobInfo, 2*time.Minute)
@@ -544,7 +721,7 @@ func TestLDRConflict(
 		leftURL)
 
 	t.Status("verifying results")
-	verifyConflictCorrectness(ctx, t, setup, leftJobID, rightJobID)
+	verifyConflictCorrectness(ctx, t, setup, leftJobID, rightJobID, ldrConfig.mode.SkipDLQCheck())
 }
 
 // verifyConflictCorrectness waits for replication to catch up, checks DLQs,
@@ -555,14 +732,22 @@ func TestLDRConflict(
 // on both sides, the test passes. Otherwise, the test fails and prints the
 // diffs.
 func verifyConflictCorrectness(
-	ctx context.Context, t test.Test, setup multiClusterSetup, leftJobID, rightJobID int,
+	ctx context.Context,
+	t test.Test,
+	setup multiClusterSetup,
+	leftJobID, rightJobID int,
+	skipDLQCheck bool,
 ) {
 	now := timeutil.Now()
 	t.Status("waiting for replicated times to catchup")
 	waitForReplicatedTimeToReachTimestamp(t, leftJobID, setup.left.db, getLogicalDataReplicationJobInfo, 2*time.Minute, now)
-	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.left.db, "conflict"))
+	if !skipDLQCheck {
+		require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.left.db, "conflict"))
+	}
 	waitForReplicatedTimeToReachTimestamp(t, rightJobID, setup.right.db, getLogicalDataReplicationJobInfo, 2*time.Minute, now)
-	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.right.db, "conflict"))
+	if !skipDLQCheck {
+		require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.right.db, "conflict"))
+	}
 
 	t.Status("comparing fingerprints")
 	fpQuery := "SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE conflict.conflict"
@@ -606,22 +791,27 @@ func verifyConflictCorrectness(
 	}
 }
 
-// TestLDRCreateTablesTPCC inits the left cluster with 1000 warehouse tpcc,
-// begins unidirectional fast initial scan LDR, starts a tpcc 1000 wh workload
+// TestLDRCreateTablesTPCC inits the left cluster with tpcc warehouses,
+// begins unidirectional fast initial scan LDR, starts a tpcc workload
 // on the left, and observes initial scan, catchup scan, and steady state
 // performance.
 func TestLDRCreateTablesTPCC(
 	ctx context.Context, t test.Test, c cluster.Cluster, setup multiClusterSetup, ldrConfig ldrConfig,
 ) {
-	// duration is 30 minutes because during this time, the following occurs:
-	// - 10 minute initial scan
-	// - 5 mins with logical_replication.consumer.low_admission_priority.enabled =
-	// false (during initial benchmarking, flipping this to true caused the
-	// catchup scan to take 15 minutes).
-	// - 15 mins of steady state. If the above scans take too long, the latency
-	// verifier may trip.
-	duration := 30 * time.Minute
-	schemaWarehouses, workloadWarehouses := 1000, 500
+	duration := ldrConfig.workloadDuration
+	schemaWarehouses, workloadWarehouses := 750, 750
+	if ldrConfig.mode != ModeTransactional {
+		// Duration is 30 minutes because during this time, the following occurs:
+		// - 10 minute initial scan
+		// - 5 mins with low_admission_priority.enabled = false (during initial
+		//   benchmarking, flipping this to true caused the catchup scan to take
+		//   15 minutes).
+		// - 15 mins of steady state. If the above scans take too long, the
+		//   latency verifier may trip.
+		duration = 30 * time.Minute
+		schemaWarehouses, workloadWarehouses = 1000, 500
+		setup.right.sysSQL.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.low_admission_priority.enabled = false")
+	}
 	if c.IsLocal() {
 		duration = 3 * time.Minute
 		schemaWarehouses, workloadWarehouses = 10, 10
@@ -636,10 +826,10 @@ func TestLDRCreateTablesTPCC(
 		dbName:            "tpcc",
 		manualSchemaSetup: true,
 		tableNames:        []string{"customer", "district", "history", "item", "new_order", "order_line", "order", "stock", "warehouse"},
+		skipDLQCheck:      ldrConfig.mode.SkipDLQCheck(),
 	}
 
 	setup.right.sysSQL.Exec(t, "CREATE DATABASE tpcc")
-	setup.right.sysSQL.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.low_admission_priority.enabled = false")
 	c.Run(ctx,
 		option.WithNodes(setup.workloadNode),
 		fmt.Sprintf("./cockroach workload init tpcc --warehouses=%d --fks=false {pgurl:%d:system}", schemaWarehouses, setup.left.nodes[0]))
@@ -648,25 +838,21 @@ func TestLDRCreateTablesTPCC(
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
-		// Run workload on the left cluster. Unlike other ldr tests at the moment,
-		// this one spins up the source workload before LDR begins. This tests LWW
-		// on data ingested via the offline initial scan.
 		return c.RunE(ctx, option.WithNodes(setup.workloadNode), workload.workload.sourceRunCmd("system", setup.left.nodes))
 	})
 
 	// Setup LDR after the workload starts. This verifies we can catch up on
 	// backlog, ensures that writing to source table during the initial scan does
-	// not trigger any buts, and allows the test to run more quickly because the
-	// workload 30 minute timer overlaps with the ldr initial scan.
-	_, rightJobID := setupLDR(ctx, t, c, setup, workload, ldrConfig)
+	// not trigger any bugs, and allows the test to run more quickly because the
+	// workload timer overlaps with the LDR initial scan.
+	_, rightJobID := setupLDR(ctx, t, c, setup, workload, ldrConfig, "")
 
 	maxExpectedLatency := 3 * time.Minute
-	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	monitor.Wait()
 	validateLatency()
 
-	// On the 1000 tpcc workload, this takes about 12 minutes.
 	VerifyCorrectness(ctx, c, t, setup, 0 /* leftJobID */, rightJobID, 2*time.Minute, workload)
 }
 
@@ -686,16 +872,17 @@ func TestLDRUpdateHeavy(
 			initRows:         1000,
 			initSplits:       1000,
 		},
-		dbName:     "ycsb",
-		tableNames: []string{"usertable"},
+		dbName:       "ycsb",
+		tableNames:   []string{"usertable"},
+		skipDLQCheck: ldrConfig.mode.SkipDLQCheck(),
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 
 	workloadDoneCh := make(chan struct{})
 	maxExpectedLatency := 3 * time.Minute
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
-	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
@@ -726,11 +913,12 @@ func TestLDROnNodeShutdown(
 			initWithSplitAndScatter: true,
 			uniform:                 true,
 		},
-		dbName:     "kv",
-		tableNames: []string{"kv"},
+		dbName:       "kv",
+		tableNames:   []string{"kv"},
+		skipDLQCheck: ldrConfig.mode.SkipDLQCheck(),
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 
 	findCoordinatorNode := func(info *clusterInfo, jobID int, rightSide bool) int {
 		var coordinatorNode int
@@ -801,7 +989,7 @@ func TestLDROnNodeShutdown(
 	maxExpectedLatency := 5 * time.Minute
 	workloadDoneCh := make(chan struct{})
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
-	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
@@ -846,11 +1034,12 @@ func TestLDROnNetworkPartition(
 			initWithSplitAndScatter: true,
 			uniform:                 true,
 		},
-		dbName:     "kv",
-		tableNames: []string{"kv"},
+		dbName:       "kv",
+		tableNames:   []string{"kv"},
+		skipDLQCheck: ldrConfig.mode.SkipDLQCheck(),
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 
 	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	monitor.Go(func(ctx context.Context) error {
@@ -915,12 +1104,12 @@ func TestLDRHotKeyUpdate(
 		option.WithNodes(setup.workloadNode),
 		ldrWorkload.workload.sourceInitCmd("system", setup.left.nodes))
 
-	_, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	_, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 
 	workloadDoneCh := make(chan struct{})
 	maxExpectedLatency := 10 * time.Minute
 	group := t.NewGroup()
-	validateLatency := setupLatencyVerifiersWithGroup(t, c, group, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+	validateLatency := setupLatencyVerifiersWithGroup(t, c, group, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	group.Go(func(ctx context.Context, _ *logger.Logger) error {
 		defer close(workloadDoneCh)
@@ -958,12 +1147,12 @@ func TestLDRUniqueConstraintUpdate(
 		option.WithNodes(setup.workloadNode),
 		ldrWorkload.workload.sourceInitCmd("system", setup.left.nodes))
 
-	_, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
+	_, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig, "")
 
 	workloadDoneCh := make(chan struct{})
 	maxExpectedLatency := 10 * time.Minute
 	group := t.NewGroup()
-	validateLatency := setupLatencyVerifiersWithGroup(t, c, group, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
+	validateLatency := setupLatencyVerifiersWithGroup(t, c, group, 0 /* leftJobID */, rightJobID, setup, workloadDoneCh, maxExpectedLatency, !ldrConfig.initWithSeed /* expectBacklog */)
 
 	group.Go(func(ctx context.Context, _ *logger.Logger) error {
 		defer close(workloadDoneCh)
@@ -974,27 +1163,44 @@ func TestLDRUniqueConstraintUpdate(
 	validateLatency()
 }
 
+// ldrJobInfo reads LDR job progress from crdb_internal.jobs which sources
+// high_water_timestamp from system.job_progress rather than the legacy
+// progress proto.
 type ldrJobInfo struct {
-	*jobRecord
+	status    string
+	highWater time.Time
+	finished  time.Time
+	errMsg    string
 }
 
-// GetHighWater returns the replicated time.
-func (c *ldrJobInfo) GetHighWater() time.Time {
-	replicatedTime := c.progress.GetLogicalReplication().ReplicatedTime
-	if replicatedTime.IsEmpty() {
-		return time.Time{}
-	}
-	return replicatedTime.GoTime()
-}
+func (c *ldrJobInfo) GetHighWater() time.Time    { return c.highWater }
+func (c *ldrJobInfo) GetFinishedTime() time.Time { return c.finished }
+func (c *ldrJobInfo) GetStatus() string          { return c.status }
+func (c *ldrJobInfo) GetError() string           { return c.errMsg }
 
 var _ jobInfo = (*ldrJobInfo)(nil)
 
 func getLogicalDataReplicationJobInfo(db *gosql.DB, jobID int) (jobInfo, error) {
-	jr, err := getJobRecord(db, jobID)
-	if err != nil {
+	var info ldrJobInfo
+	var hwDecimal *string
+	var finished *time.Time
+	if err := db.QueryRow(
+		`SELECT status, high_water_timestamp::STRING, finished, error
+		 FROM crdb_internal.jobs WHERE job_id = $1`, jobID,
+	).Scan(&info.status, &hwDecimal, &finished, &info.errMsg); err != nil {
 		return nil, err
 	}
-	return &ldrJobInfo{jr}, nil
+	if hwDecimal != nil {
+		hwNanos, err := strconv.ParseInt(strings.Split(*hwDecimal, ".")[0], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parsing high_water_timestamp: %w", err)
+		}
+		info.highWater = timeutil.Unix(0, hwNanos)
+	}
+	if finished != nil {
+		info.finished = *finished
+	}
+	return &info, nil
 }
 
 type ldrTestSpec struct {
@@ -1019,15 +1225,24 @@ func (m mode) String() string {
 		return "immediate"
 	case ModeValidated:
 		return "validated"
+	case ModeTransactional:
+		return "transactional"
 	default:
 		return "default"
 	}
+}
+
+// SkipDLQCheck returns true if DLQ table validation should be skipped
+// for this mode. Transactional mode does not create DLQ tables.
+func (m mode) SkipDLQCheck() bool {
+	return m == ModeTransactional
 }
 
 const (
 	Default = iota
 	ModeImmediate
 	ModeValidated
+	ModeTransactional
 )
 
 type multiClusterSpec struct {
@@ -1100,6 +1315,11 @@ func (mc *multiCluster) StartCluster(
 	sqlRunner := sqlutils.MakeSQLRunner(db)
 
 	sqlRunner.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING physical_replication.producer.timestamp_granularity = '100ms'`)
+	sqlRunner.Exec(t, `SET CLUSTER SETTING physical_replication.producer.min_checkpoint_frequency='100ms'`)
 
 	cleanup := func() {
 		if t.Failed() {
@@ -1189,6 +1409,31 @@ type ldrConfig struct {
 	mode               mode
 	initialScanTimeout time.Duration
 	createTables       bool
+	// workloadDuration overrides the default workload duration for the test.
+	// If zero, the test uses its own default.
+	workloadDuration time.Duration
+	// initWithSeed initializes both clusters with identical data
+	// using a random seed, then grabs a cursor to skip the initial scan.
+	// This is required for transactional LDR which cannot safely perform
+	// initial scans because it reorders rows by MVCC timestamp (#169338).
+	initWithSeed bool
+}
+
+// getMinCursor queries both clusters for their current logical timestamp and
+// returns the earlier one. This is used as a cursor when starting LDR streams
+// to skip the initial scan.
+func getMinCursor(t test.Test, setup multiClusterSetup) string {
+	var leftCursor, rightCursor string
+	setup.left.sysSQL.QueryRow(t,
+		"SELECT cluster_logical_timestamp()").Scan(&leftCursor)
+	setup.right.sysSQL.QueryRow(t,
+		"SELECT cluster_logical_timestamp()").Scan(&rightCursor)
+	cursor := leftCursor
+	if rightCursor < leftCursor {
+		cursor = rightCursor
+	}
+	t.L().Printf("using cursor %s to skip initial scan", cursor)
+	return cursor
 }
 
 func setupLDR(
@@ -1198,15 +1443,30 @@ func setupLDR(
 	setup multiClusterSetup,
 	ldrWorkload LDRWorkload,
 	ldrConfig ldrConfig,
+	cursor string,
 ) (int, int) {
 	if !ldrWorkload.manualSchemaSetup {
-		c.Run(ctx,
-			option.WithNodes(setup.workloadNode),
-			ldrWorkload.workload.sourceInitCmd("system", setup.right.nodes))
+		rightInitCmd := ldrWorkload.workload.sourceInitCmd("system", setup.right.nodes)
+		leftInitCmd := ldrWorkload.workload.sourceInitCmd("system", setup.left.nodes)
 
-		c.Run(ctx,
-			option.WithNodes(setup.workloadNode),
-			ldrWorkload.workload.sourceInitCmd("system", setup.left.nodes))
+		// When initWithSeed is set, both clusters are initialized with
+		// identical data using a random seed. After init a cursor is
+		// grabbed to skip the initial scan. This is required for
+		// transactional LDR which cannot safely perform initial scans
+		// (#169338).
+		if ldrConfig.initWithSeed {
+			seed := setup.rng.Int63()
+			t.L().Printf("using workload seed %d", seed)
+			rightInitCmd += fmt.Sprintf(" --seed=%d", seed)
+			leftInitCmd += fmt.Sprintf(" --seed=%d", seed)
+		}
+
+		c.Run(ctx, option.WithNodes(setup.workloadNode), rightInitCmd)
+		c.Run(ctx, option.WithNodes(setup.workloadNode), leftInitCmd)
+
+		if ldrConfig.initWithSeed {
+			cursor = getMinCursor(t, setup)
+		}
 	}
 
 	tableNamesToStr := func(dbname string, tableNames []string) string {
@@ -1226,18 +1486,39 @@ func setupLDR(
 
 	startLDR := func(targetDB *sqlutils.SQLRunner, sourceURL string) int {
 
-		options := ""
+		var optParts []string
 		if ldrConfig.mode != Default {
-			options = fmt.Sprintf("WITH mode='%s'", ldrConfig.mode)
+			optParts = append(optParts, fmt.Sprintf("MODE = '%s'", ldrConfig.mode))
+		}
+		if cursor != "" {
+			optParts = append(optParts, "CURSOR = $2")
 		}
 		targetDB.Exec(t, fmt.Sprintf("USE %s", dbName))
-		ldrCmd := fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLES %s ON $1 INTO TABLES %s %s", tableNamesStr, tableNamesStr, options)
+
+		var ldrCmd string
 		if ldrConfig.createTables {
-			ldrCmd = fmt.Sprintf("CREATE LOGICALLY REPLICATED TABLES %s FROM TABLES %s ON $1 %s WITH UNIDIRECTIONAL", tableNamesStr, tableNamesStr, options)
+			optParts = append(optParts, "UNIDIRECTIONAL")
+			options := ""
+			if len(optParts) > 0 {
+				options = "WITH " + strings.Join(optParts, ", ")
+			}
+			ldrCmd = fmt.Sprintf("CREATE LOGICALLY REPLICATED TABLES %s FROM TABLES %s ON $1 %s",
+				tableNamesStr, tableNamesStr, options)
+		} else {
+			options := ""
+			if len(optParts) > 0 {
+				options = "WITH " + strings.Join(optParts, ", ")
+			}
+			ldrCmd = fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLES %s ON $1 INTO TABLES %s %s",
+				tableNamesStr, tableNamesStr, options)
+		}
+		args := []interface{}{sourceURL}
+		if cursor != "" {
+			args = append(args, cursor)
 		}
 		r := targetDB.QueryRow(t,
 			ldrCmd,
-			sourceURL,
+			args...,
 		)
 		var jobID int
 		r.Scan(&jobID)
@@ -1285,7 +1566,10 @@ func setupLDR(
 
 // setupLatencyVerifiers sets up latency verifiers for the left and right ldr
 // jobs. If the left job ID is 0, then this function assumes the left job does
-// not exist.
+// not exist. If expectBacklog is true, the verifier uses a
+// convergence-from-behind algorithm that waits for lag to drop below the
+// threshold. If false, the verifier checks that lag stays below the threshold
+// on every poll.
 func setupLatencyVerifiers(
 	ctx context.Context,
 	t test.Test,
@@ -1295,17 +1579,20 @@ func setupLatencyVerifiers(
 	setup multiClusterSetup,
 	workloadDoneCh chan struct{},
 	maxExpectedLatency time.Duration,
+	expectBacklog bool,
 ) func() {
 
 	var llv *latencyVerifier
 	if leftJobID != 0 {
 		llv = makeLatencyVerifier("ldr-left", 0, maxExpectedLatency, t.L(),
 			getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
+		llv.expectBacklog = expectBacklog
 		defer llv.maybeLogLatencyHist()
 	}
 
 	rlv := makeLatencyVerifier("ldr-right", 0, maxExpectedLatency, t.L(),
 		getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
+	rlv.expectBacklog = expectBacklog
 	defer rlv.maybeLogLatencyHist()
 
 	debugZipFetcher := &sync.Once{}
@@ -1346,15 +1633,18 @@ func setupLatencyVerifiersWithGroup(
 	setup multiClusterSetup,
 	workloadDoneCh chan struct{},
 	maxExpectedLatency time.Duration,
+	expectBacklog bool,
 ) func() {
 	var llv *latencyVerifier
 	if leftJobID != 0 {
 		llv = makeLatencyVerifier("ldr-left", 0, maxExpectedLatency, t.L(),
 			getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
+		llv.expectBacklog = expectBacklog
 	}
 
 	rlv := makeLatencyVerifier("ldr-right", 0, maxExpectedLatency, t.L(),
 		getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
+	rlv.expectBacklog = expectBacklog
 
 	debugZipFetcher := &sync.Once{}
 
@@ -1401,10 +1691,14 @@ func VerifyCorrectness(
 	t.Status("waiting for replicated times to catchup before verifying left and right clusters")
 	if leftJobID != 0 {
 		waitForReplicatedTimeToReachTimestamp(t, leftJobID, setup.left.db, getLogicalDataReplicationJobInfo, waitTime, now)
-		require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.left.db, ldrWorkload.dbName))
+		if !ldrWorkload.skipDLQCheck {
+			require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.left.db, ldrWorkload.dbName))
+		}
 	}
 	waitForReplicatedTimeToReachTimestamp(t, rightJobID, setup.right.db, getLogicalDataReplicationJobInfo, waitTime, now)
-	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.right.db, ldrWorkload.dbName))
+	if !ldrWorkload.skipDLQCheck {
+		require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, setup.right.db, ldrWorkload.dbName))
+	}
 
 	t.Status("verifying equality of left and right clusters")
 

--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -608,7 +608,6 @@ func (lww *lwwQuerier) AddTable(targetDescID int32, tc sqlProcessorTableConfig) 
 
 	lww.tombstoneUpdaters[td.GetID()] = sqlwriter.NewTombstoneUpdater(
 		lww.codec,
-		lww.db.KV(),
 		lww.leaseMgr,
 		catid.DescID(targetDescID),
 		lww.sd,
@@ -732,10 +731,21 @@ func (lww *lwwQuerier) DeleteRow(
 		return batchStats{}, err
 	}
 	if rowCount != 1 {
-		// NOTE: at this point we don't know if we are updating a tombstone or if
-		// we are losing LWW. As long as it is a LWW loss or a tombstone update,
-		// UpdateTombstoneAny will return okay.
-		lwwLoss, err := lww.tombstoneUpdaters[row.TableID].UpdateTombstoneAny(ctx, txn, row.MvccTimestamp, datums)
+		// NOTE: at this point we don't know if we are updating a tombstone or
+		// if we are losing LWW. UpdateTombstoneAny returns (true, nil) for a
+		// LWW loss, (false, nil) for a successful tombstone update, or
+		// (false, ErrStalePreviousValue) if a live row exists at the key.
+		tu := lww.tombstoneUpdaters[row.TableID]
+		var lwwLoss bool
+		if kvTxn != nil {
+			lwwLoss, err = tu.UpdateTombstoneAny(ctx, kvTxn, row.MvccTimestamp, datums)
+		} else {
+			err = lww.db.KV().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+				var txnErr error
+				lwwLoss, txnErr = tu.UpdateTombstoneAny(ctx, txn, row.MvccTimestamp, datums)
+				return txnErr
+			})
+		}
 		if err != nil {
 			return batchStats{}, err
 		}

--- a/pkg/crosscluster/logical/resume_txn.go
+++ b/pkg/crosscluster/logical/resume_txn.go
@@ -97,8 +97,13 @@ func (r *logicalReplicationResumer) runTxnCoordinator(
 		return err
 	}
 
-	// TODO(jeffswenson): checkpoint partition URIs via
-	// r.checkpointPartitionURIs once plan generation is added.
+	uris, err := r.getClusterUris(ctx, r.job, jobExecCtx.ExecCfg().InternalDB)
+	if err != nil {
+		return err
+	}
+	if err := r.checkpointPartitionURIs(ctx, uris, sourcePlan.Topology.SerializedClusterUris()); err != nil {
+		return err
+	}
 
 	flowPlan, planCtx, applierInstanceIDs, err :=
 		txnmode.PlanTxnReplication(ctx, r.job, jobExecCtx, sourcePlan, replicatedTime, endTime)

--- a/pkg/crosscluster/logical/sqlwriter/BUILD.bazel
+++ b/pkg/crosscluster/logical/sqlwriter/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/crosscluster/ldrrandgen",
+        "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/crosscluster/logical/sqlwriter/errors.go
+++ b/pkg/crosscluster/logical/sqlwriter/errors.go
@@ -45,6 +45,16 @@ func IsLwwLoser(err error) bool {
 	return false
 }
 
+// HasStalePreviousValue returns true if the error is a ConditionFailedError
+// with HadNewerOriginTimestamp set, indicating the write won the origin
+// timestamp comparison but the expected previous value was wrong.
+func HasStalePreviousValue(err error) bool {
+	if condErr := (*kvpb.ConditionFailedError)(nil); errors.As(err, &condErr) {
+		return condErr.HadNewerOriginTimestamp
+	}
+	return false
+}
+
 // CanDLQError returns nil if the error should send a row to the DLQ. It
 // returns a non-nil error if the error should not be DLQ'd, for example
 // because it indicates an internal or retryable problem. The idea is it is

--- a/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sqlwriter/sql_row_writer_test.go
@@ -138,6 +138,22 @@ func TestSQLRowWriter(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrStalePreviousValue)
 
+	// Test InsertRow with a newer origin timestamp against an existing row.
+	// The insert wins LWW but the row already exists, so the MVCC layer sets
+	// HadNewerOriginTimestamp. InsertRow converts this to ErrStalePreviousValue
+	// so the caller can refresh and retry as an update.
+	duplicateRow := makeTestRow(t, desc, 20, "duplicate")
+	firstTS := s.Clock().Now()
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, firstTS, duplicateRow)
+	})
+	require.NoError(t, err)
+	newerTS := s.Clock().Now()
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, newerTS, makeTestRow(t, desc, 20, "newer"))
+	})
+	require.ErrorIs(t, err, ErrStalePreviousValue)
+
 	// Test InsertRow LWW failure against existing row: inserting with an older
 	// timestamp than the existing row should return a ConditionFailedError.
 	existingRow := makeTestRow(t, desc, 10, "existing")

--- a/pkg/crosscluster/logical/sqlwriter/tombstone_updater.go
+++ b/pkg/crosscluster/logical/sqlwriter/tombstone_updater.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -32,7 +31,6 @@ var OriginID1Options = &kvpb.WriteOptions{OriginID: 1}
 // table. The lease should be released by calling ReleaseLeases.
 type TombstoneUpdater struct {
 	codec    keys.SQLCodec
-	db       *kv.DB
 	leaseMgr *lease.Manager
 	sd       *sessiondata.SessionData
 	settings *cluster.Settings
@@ -63,7 +61,6 @@ func (c *TombstoneUpdater) ReleaseLeases(ctx context.Context) {
 
 func NewTombstoneUpdater(
 	codec keys.SQLCodec,
-	db *kv.DB,
 	leaseMgr *lease.Manager,
 	descID descpb.ID,
 	sd *sessiondata.SessionData,
@@ -71,7 +68,6 @@ func NewTombstoneUpdater(
 ) *TombstoneUpdater {
 	return &TombstoneUpdater{
 		codec:    codec,
-		db:       db,
 		leaseMgr: leaseMgr,
 		descID:   descID,
 		sd:       sd,
@@ -82,7 +78,7 @@ func NewTombstoneUpdater(
 // UpdateTombstoneAny is an UpdateTombstone wrapper that accepts the []any
 // datum slice from the original sql writer's datum builder.
 func (tu *TombstoneUpdater) UpdateTombstoneAny(
-	ctx context.Context, txn isql.Txn, mvccTimestamp hlc.Timestamp, datums []any,
+	ctx context.Context, txn *kv.Txn, mvccTimestamp hlc.Timestamp, datums []any,
 ) (bool, error) {
 	tu.scratch = tu.scratch[:0]
 	for _, datum := range datums {
@@ -91,66 +87,25 @@ func (tu *TombstoneUpdater) UpdateTombstoneAny(
 	return tu.UpdateTombstone(ctx, txn, mvccTimestamp, tu.scratch)
 }
 
-// UpdateTombstone attempts to update the tombstone for the given row. This is
-// expected to always succeed. The delete will only return zero rows if the
-// operation loses LWW or the row does not exist. So if the cput fails on a
-// condition, it should also fail on LWW, which is treated as a success.
-//
-// It returns true if the update lost LWW (i.e. the local tombstone was already
-// newer).
+// UpdateTombstone attempts to update the tombstone for the given row. It
+// returns true if the update lost LWW (i.e. the local tombstone was already
+// newer). It returns ErrStalePreviousValue if a live row exists at the key
+// instead of a tombstone and the incoming origin timestamp is newer, meaning
+// the caller should refresh its local state and retry.
 func (tu *TombstoneUpdater) UpdateTombstone(
-	ctx context.Context, txn isql.Txn, mvccTimestamp hlc.Timestamp, afterRow []tree.Datum,
+	ctx context.Context, txn *kv.Txn, mvccTimestamp hlc.Timestamp, afterRow []tree.Datum,
 ) (bool, error) {
-	err := func() error {
-		if txn != nil {
-			// If UpdateTombstone is called in a transaction, create and run a
-			// batch in the transaction.
-			batch := txn.KV().NewBatch()
-			batch.Header.WriteOptions = OriginID1Options
-			if err := tu.AddToBatch(ctx, txn.KV(), batch, mvccTimestamp, afterRow); err != nil {
-				return err
-			}
-			return txn.KV().Run(ctx, batch)
-		}
-		// If UpdateTombstone is called outside of a transaction, create and
-		// run a 1pc transaction.
-		return tu.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-			batch := txn.NewBatch()
-			batch.Header.WriteOptions = OriginID1Options
-			if err := tu.AddToBatch(ctx, txn, batch, mvccTimestamp, afterRow); err != nil {
-				return err
-			}
-			return txn.CommitInBatch(ctx, batch)
-		})
-	}()
-	if err != nil {
-		if IsLwwLoser(err) {
-			return true, nil
-		}
-		return false, err
-	}
-	return false, nil
-}
-
-// AddToBatch adds a tombstone delete operation to the given KV batch. The
-// caller is responsible for setting the batch's WriteOptions and running the
-// batch.
-func (tu *TombstoneUpdater) AddToBatch(
-	ctx context.Context,
-	txn *kv.Txn,
-	batch *kv.Batch,
-	mvccTimestamp hlc.Timestamp,
-	afterRow []tree.Datum,
-) error {
 	deleter, err := tu.getDeleter(ctx, txn)
 	if err != nil {
-		return err
+		return false, err
 	}
+
+	batch := txn.NewBatch()
+	batch.Header.WriteOptions = OriginID1Options
 
 	var ph row.PartialIndexUpdateHelper
 	var vh row.VectorIndexUpdateHelper
-
-	return deleter.DeleteRow(
+	if err := deleter.DeleteRow(
 		ctx,
 		batch,
 		afterRow,
@@ -162,7 +117,20 @@ func (tu *TombstoneUpdater) AddToBatch(
 		},
 		false, /* mustValidateOldPKValues */
 		false, /* traceKV */
-	)
+	); err != nil {
+		return false, err
+	}
+
+	if err := txn.Run(ctx, batch); err != nil {
+		if IsLwwLoser(err) {
+			return true, nil
+		}
+		if HasStalePreviousValue(err) {
+			return false, ErrStalePreviousValue
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 func (tu *TombstoneUpdater) hasValidLease(ctx context.Context, now hlc.Timestamp) bool {

--- a/pkg/crosscluster/logical/sqlwriter/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/sqlwriter/tombstone_updater_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/ldrrandgen"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
@@ -63,7 +63,7 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
 	tu := NewTombstoneUpdater(
-		s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager),
+		s.Codec(), s.LeaseManager().(*lease.Manager),
 		desc.GetID(), sd, s.ClusterSettings())
 	defer tu.ReleaseLeases(ctx)
 
@@ -84,14 +84,18 @@ func TestTombstoneUpdaterRandomTables(t *testing.T) {
 		before := s.Clock().Now()
 		after := s.Clock().Now()
 
-		err := s.InternalDB().(isql.DB).Txn(ctx,
-			func(ctx context.Context, txn isql.Txn) error {
-				_, err := tu.UpdateTombstone(ctx, txn, after, row)
-				return err
-			})
+		err := s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			_, err := tu.UpdateTombstone(ctx, txn, after, row)
+			return err
+		})
 		require.NoError(t, err)
 
-		lwwLoss, err := tu.UpdateTombstone(ctx, nil, before, row)
+		var lwwLoss bool
+		err = s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			var err error
+			lwwLoss, err = tu.UpdateTombstone(ctx, txn, before, row)
+			return err
+		})
 		require.NoError(t, err)
 		require.True(t, lwwLoss, "expected LWW loss for tombstone update")
 
@@ -118,6 +122,58 @@ func generateRandomRow(rng *rand.Rand, cols []catalog.Column) []tree.Datum {
 		row = append(row, datum)
 	}
 	return row
+}
+
+func TestTombstoneUpdaterStalePreviousValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartSlimServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE tombstone_stale_test (
+		id INT PRIMARY KEY,
+		name STRING,
+		extra STRING
+	)`)
+
+	desc := cdctest.GetHydratedTableDescriptor(
+		t, s.ExecutorConfig(), tree.Name("tombstone_stale_test"))
+
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	tu := NewTombstoneUpdater(
+		s.Codec(), s.LeaseManager().(*lease.Manager),
+		desc.GetID(), sd, s.ClusterSettings())
+	defer tu.ReleaseLeases(ctx)
+
+	session := newInternalSession(t, s)
+	defer session.Close(ctx)
+
+	writer, err := NewRowWriter(ctx, desc, session)
+	require.NoError(t, err)
+
+	row := tree.Datums{
+		tree.NewDInt(1),
+		tree.NewDString("live"),
+		tree.DNull,
+	}
+
+	insertTS := s.Clock().Now()
+	err = session.Txn(ctx, func(ctx context.Context) error {
+		return writer.InsertRow(ctx, insertTS, row)
+	})
+	require.NoError(t, err)
+
+	// UpdateTombstone on a live row should return ErrStalePreviousValue because
+	// the CPut expects a tombstone but finds a live value.
+	tombstoneTS := s.Clock().Now()
+	err = s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := tu.UpdateTombstone(ctx, txn, tombstoneTS, row)
+		return err
+	})
+	require.ErrorIs(t, err, ErrStalePreviousValue)
 }
 
 func TestTombstoneDescriptorLease(t *testing.T) {

--- a/pkg/crosscluster/logical/table_batch_handler.go
+++ b/pkg/crosscluster/logical/table_batch_handler.go
@@ -133,7 +133,7 @@ func newTableHandler(
 		return nil, err
 	}
 
-	tombstoneUpdater := sqlwriter.NewTombstoneUpdater(codec, db.KV(), leaseMgr, tableID, sd, settings)
+	tombstoneUpdater := sqlwriter.NewTombstoneUpdater(codec, leaseMgr, tableID, sd, settings)
 
 	return &tableHandler{
 		sqlReader:        reader,
@@ -186,22 +186,20 @@ func (t *tableHandler) attemptBatch(
 				}
 			case event.IsTombstoneUpdate():
 				stats.tombstoneUpdates++
-				// Use a KV savepoint so that a LWW-loser ConditionFailedError
-				// on one tombstone does not abort the surrounding transaction.
+				// Use a KV savepoint so that a ConditionFailedError on one
+				// tombstone does not abort the surrounding transaction.
+				var lwwLoss bool
 				err := t.session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
-					batch := txn.NewBatch()
-					batch.Header.WriteOptions = sqlwriter.OriginID1Options
-					if err := t.tombstoneUpdater.AddToBatch(ctx, txn, batch, event.RowTimestamp, event.Row); err != nil {
-						return err
-					}
-					return txn.Run(ctx, batch)
+					var err error
+					lwwLoss, err = t.tombstoneUpdater.UpdateTombstone(ctx, txn, event.RowTimestamp, event.Row)
+					return err
 				})
 				if err != nil {
-					if isLwwLoser(err) {
-						stats.kvLwwLosers++
-						continue
-					}
 					return err
+				}
+				if lwwLoss {
+					stats.kvLwwLosers++
+					continue
 				}
 			case event.IsInsertRow():
 				stats.inserts++

--- a/pkg/crosscluster/logical/tombstone_updater_test.go
+++ b/pkg/crosscluster/logical/tombstone_updater_test.go
@@ -11,11 +11,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/logical/sqlwriter"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -45,7 +44,7 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 	desc := desctestutils.TestingGetMutableExistingTableDescriptor(
 		s.DB(), s.Codec(), dbNames[0], "tab")
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
-	tu := sqlwriter.NewTombstoneUpdater(s.Codec(), s.DB(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
+	tu := sqlwriter.NewTombstoneUpdater(s.Codec(), s.LeaseManager().(*lease.Manager), desc.GetID(), sd, s.ClusterSettings())
 	defer tu.ReleaseLeases(ctx)
 
 	// Set up 1 way logical replication. The replication stream is used to ensure
@@ -63,14 +62,14 @@ func TestTombstoneUpdaterSetsOriginID(t *testing.T) {
 		tree.DNull,                 // v (deleted)
 	}
 
-	_, err := tu.UpdateTombstone(ctx, nil, s.Clock().Now(), row)
+	err := s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := tu.UpdateTombstone(ctx, txn, s.Clock().Now(), row)
+		return err
+	})
 	require.NoError(t, err)
 
-	config := s.ExecutorConfig().(sql.ExecutorConfig)
-	err = sql.DescsTxn(ctx, &config, func(
-		ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
-	) error {
-		_, err = tu.UpdateTombstone(ctx, txn, s.Clock().Now(), row)
+	err = s.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		_, err := tu.UpdateTombstone(ctx, txn, s.Clock().Now(), row)
 		return err
 	})
 	require.NoError(t, err)

--- a/pkg/crosscluster/logical/txnmode/txnmode_test.go
+++ b/pkg/crosscluster/logical/txnmode/txnmode_test.go
@@ -85,6 +85,10 @@ func (s *cpuHandleAssertingSession) Txn(ctx context.Context, do func(context.Con
 	return s.Session.Txn(ctx, do)
 }
 
+// TestTxnModeSmoketest exercises basic transactional LDR and is the preferred
+// place to add non-invasive assertions about internal job state (e.g. partition
+// URIs, CPU handles). Extend this test rather than spinning up a new cluster
+// for each trivial assertion.
 func TestTxnModeSmoketest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderDeadlock(t)
@@ -135,6 +139,17 @@ func TestTxnModeSmoketest(t *testing.T) {
 
 	destDB.CheckQueryResults(t, "SELECT * FROM parent ORDER BY id", [][]string{})
 	destDB.CheckQueryResults(t, "SELECT * FROM child ORDER BY id", [][]string{})
+
+	// Verify partition URIs are checkpointed in job progress. In gateway
+	// routing mode (set by the stream-use-gateway-routing-mode metamorphic
+	// constant), checkpointPartitionURIs intentionally skips saving URIs.
+	progress := jobutils.GetJobProgress(t, destDB, jobID)
+	ldrProgress := progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
+	if replicationtestutils.IsGatewayRoutingMode() {
+		require.Empty(t, ldrProgress.PartitionConnUris)
+	} else {
+		require.NotEmpty(t, ldrProgress.PartitionConnUris)
+	}
 
 	// Verify that at least one session had its CPU handle checked, confirming
 	// that the writer goroutines are running with per-goroutine handles.

--- a/pkg/crosscluster/logical/txnwriter/apply_batch.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch.go
@@ -105,24 +105,22 @@ func (tw *transactionWriter) tryApplyTransaction(
 				return ApplyResult{}, err
 			}
 		case row.IsTombstoneUpdate():
-			// Use a KV savepoint so that a LWW-loser ConditionFailedError
-			// on one tombstone does not abort the surrounding transaction.
+			// Use a KV savepoint so that a ConditionFailedError on one
+			// tombstone does not abort the surrounding transaction.
+			var lwwLoss bool
 			err := tw.session.KVSavepoint(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				batch := txn.NewBatch()
-				batch.Header.WriteOptions = sqlwriter.OriginID1Options
-				if err := tw.tombstoneUpdaters[row.TableID].AddToBatch(
-					ctx, txn, batch, transaction.TxnID.Timestamp, row.Row,
-				); err != nil {
-					return err
-				}
-				return txn.Run(ctx, batch)
+				var err error
+				lwwLoss, err = tw.tombstoneUpdaters[row.TableID].UpdateTombstone(
+					ctx, txn, transaction.TxnID.Timestamp, row.Row,
+				)
+				return err
 			})
-			if sqlwriter.IsLwwLoser(err) {
-				lwwLosers++
-				continue
-			}
 			if err != nil {
 				return ApplyResult{}, err
+			}
+			if lwwLoss {
+				lwwLosers++
+				continue
 			}
 		case row.IsInsertRow():
 			err := tableWriter.InsertRow(ctx, transaction.TxnID.Timestamp, row.Row)

--- a/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
+++ b/pkg/crosscluster/logical/txnwriter/apply_batch_test.go
@@ -484,6 +484,36 @@ func TestTransactionWriter_ApplyBatch(t *testing.T) {
 			)
 		},
 	}, {
+		// Regression test for #171194 (uncovered by the
+		// ldr/transactional/conflict roachtest): a tombstone update that
+		// encounters a live row triggers a ConditionFailedError with
+		// HadNewerOriginTimestamp. The applier must convert this to
+		// ErrStalePreviousValue so the refresh path reads the live row
+		// and converts the tombstone update into a delete.
+		name: "refresh_converts_tombstone_update_to_delete",
+		setup: func(t *testing.T, baseID int) {
+			sqlDB.Exec(t, fmt.Sprintf(
+				`INSERT INTO parent (id, payload) VALUES (%d, 'live')`, baseID+1))
+		},
+		buildTxn: func(t *testing.T, baseID int, _ hlc.Timestamp) ldrdecoder.Transaction {
+			return ldrdecoder.Transaction{
+				TxnID: ldrdecoder.TxnID{Timestamp: s.Clock().Now()},
+				WriteSet: []ldrdecoder.DecodedRow{{
+					Row:      tree.Datums{tree.NewDInt(tree.DInt(baseID + 1)), tree.DNull},
+					PrevRow:  nil, // tombstone update: no previous row
+					IsDelete: true,
+					TableID:  parentID,
+				}},
+			}
+		},
+		validate: func(t *testing.T, baseID int, result ApplyResult) {
+			require.Equal(t, ApplyResult{AppliedRows: 1}, result)
+			sqlDB.CheckQueryResults(t,
+				fmt.Sprintf(`SELECT count(*) FROM parent WHERE id = %d`, baseID+1),
+				[][]string{{"0"}},
+			)
+		},
+	}, {
 		name: "refresh_converts_delete_to_tombstone_update",
 		setup: func(t *testing.T, baseID int) {
 		},

--- a/pkg/crosscluster/logical/txnwriter/writer.go
+++ b/pkg/crosscluster/logical/txnwriter/writer.go
@@ -119,7 +119,7 @@ func (tw *transactionWriter) initTable(ctx context.Context, tableID descpb.ID) e
 	tw.tableWriters[tableID] = writer
 	tw.tableReaders[tableID] = reader
 	tw.tombstoneUpdaters[tableID] = sqlwriter.NewTombstoneUpdater(
-		tw.codec, tw.db.KV(), tw.leaseMgr, tableID, tw.sd, tw.settings,
+		tw.codec, tw.leaseMgr, tableID, tw.sd, tw.settings,
 	)
 	return nil
 }

--- a/pkg/crosscluster/replicationtestutils/uri_util.go
+++ b/pkg/crosscluster/replicationtestutils/uri_util.go
@@ -21,6 +21,12 @@ import (
 var useGatewayRoutingMode = metamorphic.ConstantWithTestBool("stream-use-gateway-routing-mode", false)
 var useExternalConnection = metamorphic.ConstantWithTestBool("stream-use-external-connection", true)
 
+// IsGatewayRoutingMode returns true if the metamorphic constant selects
+// gateway routing mode for the current test binary invocation.
+func IsGatewayRoutingMode() bool {
+	return useGatewayRoutingMode
+}
+
 func GetExternalConnectionURI(
 	t *testing.T,
 	sourceCluster serverutils.ApplicationLayerInterface,


### PR DESCRIPTION
Transactional LDR cannot safely perform initial scans because the
initial scan does not preserve MVCC history, which transactional mode
needs to guarantee constraints are replicated correctly (https://github.com/cockroachdb/cockroach/issues/169338).

Adjust the LDR roachtest infrastructure so tests can skip the initial
scan by seeding both clusters with identical data and using a cursor.

Key changes:
- Add `initWithSeed` to `ldrConfig`: initializes both clusters with a
  random seed, then grabs a cursor via `getMinCursor` to skip the
  initial scan.
- Add `expectBacklog` to `latencyVerifier`: tests that skip the initial
  scan start with no lag, so the verifier uses a simpler path that
  checks lag stays below the threshold on every poll rather than waiting
  for convergence.
- Add `skipDLQCheck` to `LDRWorkload`: transactional mode does not
  create DLQ tables.
- Rewrite `getLogicalDataReplicationJobInfo` to read from
  `crdb_internal.jobs` instead of deserializing the progress proto.
- Register transactional variants of kv0/basic, kv0/update_heavy,
  kv0/shutdown_node, kv0/network_partition, kv0/schema_change, tpcc,
  conflict, and create/tpcc.

Informs: https://github.com/cockroachdb/cockroach/issues/169338
Epic: [CRDB-60163](https://cockroachlabs.atlassian.net/browse/CRDB-60163)
Release note: none