### PR TITLE
build: tweak docker and kernel settings for cc integration tests

### DIFF
--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -195,6 +195,37 @@ fi
 EOF
 write_teamcity_config
 
+# By default docker and containerd uses the system default LimitNOFile of 1024.
+# This causes issues in the managed-service tests because Cockroach Cloud
+# configurs the CRDB container to explicitly set the soft limit to 1048576
+cat > /etc/docker/daemon.json <<EOF
+{
+  "default-ulimits": {
+    "nofile": {
+      "Name": "nofile",
+      "Hard": 1048576,
+      "Soft": 1048576
+    }
+  }
+}
+EOF
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+cat > /etc/systemd/system/docker.service.d/override.conf <<EOF
+[Service]
+LimitNOFILE=1048576
+LimitNPROC=infinity
+EOF
+
+# This is normally set to 128, which have been observed to cause issues with
+# the k3d integration test not being able to start containers due to cAdvisor
+# exausting the open file limit
+cat > /etc/sysctl.d/99-k3d-inotify.conf <<EOF
+fs.inotify.max_user_instances = 256
+EOF
+
+sudo sysctl --system
+
 # Configure the Teamcity agent to start when the server starts.
 #
 # systemd will nuke the auto-upgrade process unless we mark the service as


### PR DESCRIPTION
The current build of the runners is unable to run the cc integration tests. More specifically, all of the k3d tests are failing. This commit tweaks the docker daemon and system settings to partially fix the tests. This will need to be paired with changes in the managed-service repo to fully unblock the Ubuntu 24.04 runner migration

The docker `LimitNOFILE` changes are returning to old behaviour, where the old runners have a limit of at least 1048576 (probably infinity, but I didn't dig too deeply)

The `inotify.max_user_instances` is new, the old runners have it set to the default 128. For reasons I'm not sure of, k3d is now requiring more instances and will fail to start. Note that the max is still way higher than the proposed value of 256


Informs: CC-35466