### PR TITLE
sql/opt/xform: add costing for the Lock operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update_read_committed
@@ -640,3 +640,56 @@ RESET optimizer_use_lock_op_for_serializable
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+subtest skip_locked_ordered_limit
+
+# Regression test: the optimizer used to pick TopK (or Sort) directly above a Lock
+# for "ORDER BY <unindexed col> LIMIT k FOR UPDATE SKIP LOCKED" queries. That
+# shape locks every input row only to discard all but k, which under SKIP
+# LOCKED starves concurrent sessions: with N eligible rows the first session
+# locks all N, and subsequent sessions skip all N and return zero rows. Costing
+# the Lock operator (proportional to the rows it locks, respecting the limit
+# hint) makes the optimizer push the Sort below the Lock so only ~k rows are
+# locked.
+
+statement ok
+CREATE TABLE skl (k INT PRIMARY KEY, v INT, FAMILY (k, v))
+
+statement ok
+GRANT ALL ON skl TO testuser
+
+statement ok
+INSERT INTO skl VALUES (1, 1), (2, 2), (3, 3), (4, 4)
+
+user testuser
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+# Session A locks the smallest-v row. If the planner had picked Sort/TopK
+# above Lock, all four rows would be locked here, starving session B.
+query I
+SELECT k FROM skl WHERE v > 0 ORDER BY v LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+1
+
+user root
+
+# Session B runs concurrently (session A's txn is still open). It must see
+# the next row, not zero rows.
+query I
+BEGIN ISOLATION LEVEL READ COMMITTED;
+SELECT k FROM skl WHERE v > 0 ORDER BY v LIMIT 1 FOR UPDATE SKIP LOCKED;
+COMMIT;
+----
+2
+
+user testuser
+
+statement ok
+COMMIT
+
+user root
+
+statement ok
+DROP TABLE skl

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -588,6 +588,9 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	case opt.LimitOp:
 		cost = c.computeLimitCost(candidate.(*memo.LimitExpr))
 
+	case opt.LockOp:
+		cost = c.computeLockCost(candidate.(*memo.LockExpr), required)
+
 	case opt.OffsetOp:
 		cost = c.computeOffsetCost(candidate.(*memo.OffsetExpr))
 
@@ -1579,6 +1582,28 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 func (c *coster) computeLimitCost(limit *memo.LimitExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
 	cost := memo.Cost{C: limit.Relational().Statistics().RowCount * cpuCostFactor}
+	return cost
+}
+
+func (c *coster) computeLockCost(lock *memo.LockExpr, required *physical.Required) memo.Cost {
+	// The Lock operator is implemented as a lookup join into the primary index,
+	// so its cost resembles that of an index lookup join: a per-lookup cost to
+	// seek into the primary index plus a per-row cost to retrieve the locked
+	// columns. The Lock passes through its input rows, so it locks (and is
+	// costed over) as many rows as flow into it. Crucially, when a limit hint
+	// flows down from above, the Lock only needs to lock that many rows. This
+	// makes plans that push the Lock below a row-reducing operation (so it only
+	// locks ~K rows) cheaper than plans that lock every input row before
+	// discarding all but K above the Lock.
+	rowCount := lock.Relational().Statistics().RowCount
+	if required.LimitHint != 0 {
+		rowCount = math.Min(rowCount, required.LimitHint)
+	}
+
+	cost := memo.Cost{C: rowCount * randIOCostFactor}
+	perRowCost := lookupJoinRetrieveRowCost +
+		c.rowScanCost(lock.Table, cat.PrimaryIndex, lock.LockCols).C
+	cost.C += rowCount * perRowCost
 	return cost
 }
 

--- a/pkg/sql/opt/xform/testdata/physprops/plangram
+++ b/pkg/sql/opt/xform/testdata/physprops/plangram
@@ -1727,7 +1727,7 @@ lock xy
  ├── locking: for-update
  ├── cardinality: [0 - 1]
  ├── volatile
- ├── cost: 9.06
+ ├── cost: 15.1
  ├── key: ()
  ├── fd: ()-->(1,2)
  └── scan xy
@@ -1750,7 +1750,7 @@ lock xy
  ├── locking: for-update
  ├── cardinality: [0 - 1]
  ├── volatile
- ├── cost: 9.06
+ ├── cost: 15.1
  ├── cost-flags: plangram-mismatch
  ├── key: ()
  ├── fd: ()-->(1,2)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -579,6 +579,61 @@ limit
  │         └── limit hint: 5.00
  └── 5
 
+# Regression test: when SKIP LOCKED is combined with ORDER BY on a non-indexed
+# column, the optimizer must not pick a TopK (or Sort) above the Lock. Either
+# shape locks every row produced by the Lock's input only to discard all but
+# K, which under SKIP LOCKED also starves concurrent sessions (they see the
+# discarded rows as locked and skip them, returning fewer rows than they
+# should). The preferred plan places the Sort below the Lock with a Limit
+# above, so only ~K rows are locked. Costing the Lock operator (proportional to
+# the rows it locks, respecting the limit hint) steers the optimizer away from
+# the bad shape: locking N rows above the Sort costs more than locking ~K below.
+exec-ddl
+CREATE TABLE skl (k INT PRIMARY KEY, v INT)
+----
+
+opt set=optimizer_use_lock_op_for_serializable=true
+SELECT k FROM skl WHERE v > 0 ORDER BY v LIMIT 1 FOR UPDATE SKIP LOCKED
+----
+limit
+ ├── columns: k:1!null  [hidden: v:2!null]
+ ├── internal-ordering: +2
+ ├── cardinality: [0 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── lock skl
+ │    ├── columns: k:1!null v:2!null
+ │    ├── key columns: k:1
+ │    ├── lock columns: (5,6)
+ │    ├── locking: for-update,skip-locked
+ │    ├── volatile
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── ordering: +2
+ │    ├── limit hint: 1.00
+ │    └── sort
+ │         ├── columns: k:1!null v:2!null
+ │         ├── volatile
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2)
+ │         ├── ordering: +2
+ │         ├── limit hint: 1.00
+ │         └── select
+ │              ├── columns: k:1!null v:2!null
+ │              ├── volatile
+ │              ├── key: (1)
+ │              ├── fd: (1)-->(2)
+ │              ├── scan skl
+ │              │    ├── columns: k:1!null v:2
+ │              │    ├── locking: none,skip-locked
+ │              │    ├── volatile
+ │              │    ├── key: (1)
+ │              │    └── fd: (1)-->(2)
+ │              └── filters
+ │                   └── v:2 > 0 [outer=(2), constraints=(/2: [/1 - ]; tight)]
+ └── 1
+
 exec-ddl
 CREATE TABLE abcd (
   a INT PRIMARY KEY,


### PR DESCRIPTION
The Lock operator had no entry in the coster, so it was effectively free regardless of how many rows it locked. Add computeLockCost, which costs the Lock like the primary-index lookup join it executes as, proportional to the rows it locks and respecting the limit hint flowing down from above.

This alone fixes "ORDER BY <unindexed col> LIMIT k FOR UPDATE SKIP LOCKED": locking every input row above a Sort now costs more than locking ~k rows below it, so the optimizer places the Sort below the Lock. Under SKIP LOCKED the old shape starved concurrent sessions, which skipped the needlessly locked rows and returned fewer rows than they should.

Informs #121917

Release note (bug fix): Fixed a planner issue where "ORDER BY <unindexed col> LIMIT k FOR UPDATE SKIP LOCKED" could lock all input rows and cause concurrent sessions to return fewer rows than expected. The optimizer now places the sort below the lock so only ~k rows are locked.