### PR TITLE
drtprod: tag scale-test cluster VMs with usage=scale_test

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -33,6 +33,7 @@ targets:
           os-volume-size: 100
           username: drt
           lifetime: 8760h
+          label: usage=scale_test
           gce-image: "ubuntu-2204-jammy-v20240319"
       - command: sync
         flags:
@@ -89,6 +90,7 @@ targets:
           os-volume-size: 100
           username: workload
           lifetime: 8760h
+          label: usage=scale_test
         on_rollback:
           - command: destroy
             args:

--- a/pkg/cmd/drtprod/configs/drt_scale_300.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_300.yaml
@@ -51,6 +51,7 @@ targets:
           os-volume-size: 100
           username: drt
           lifetime: 8760h
+          label: usage=scale_test
           gce-image: "ubuntu-2204-jammy-v20250112"
       - command: sync
         skip_notification: true
@@ -108,6 +109,7 @@ targets:
           os-volume-size: 100
           username: workload
           lifetime: 8760h
+          label: usage=scale_test
           gce-image: "ubuntu-2204-jammy-v20250112"
         on_rollback:
           - command: destroy

--- a/pkg/cmd/drtprod/configs/drt_scale_pcr.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_pcr.yaml
@@ -31,6 +31,7 @@ targets:
           os-volume-size: 100
           username: drt
           lifetime: 8760h
+          label: usage=scale_test
           gce-image: "ubuntu-2204-jammy-v20240319"
       - command: sync
         flags:

--- a/pkg/cmd/drtprod/configs/drt_scale_restore.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_restore.yaml
@@ -33,6 +33,7 @@ targets:
           os-volume-size: 100
           username: drt
           lifetime: 8760h
+          label: usage=scale_test
           gce-image: "ubuntu-2204-jammy-v20240319"
       - command: sync
         flags:
@@ -89,6 +90,7 @@ targets:
           os-volume-size: 100
           username: workload
           lifetime: 8760h
+          label: usage=scale_test
         on_rollback:
           - command: destroy
             args:


### PR DESCRIPTION
Pass `--label=usage=scale_test` through to roachprod when creating the cluster and workload VMs for every DRT scale-test config. The label is applied at VM-provisioning time and is used to attribute cloud spend to the scale-test program (which dominates the DRT fleet's cost due to its large, long-lived clusters).

Configs touched (CRDB and workload create steps in each): `drt_scale.yaml`, `drt_scale_300.yaml`, `drt_scale_pcr.yaml`, `drt_scale_restore.yaml`.

Other DRT configs (chaos, large, pua, upgrade, multi-cloud, remote) are not part of the scale-test program and retain the default `usage=roachprod` label.

Resolves: #160194
Epic: none

Release note: None