### PR TITLE
sql: link plpgsql unimplemented features to corresponding issues

### DIFF
--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -8,6 +8,7 @@ package parser
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -620,14 +621,15 @@ func (l *lexer) Error(e string) {
 	l.lastError = parserutils.PopulateErrorDetails(lastTok.id, ERROR, lastTok.str, lastTok.pos, err, l.in)
 }
 
-// Unimplemented wraps Error, setting lastUnimplementedError.
-func (l *lexer) Unimplemented(feature string) {
-	l.lastError = unimp.New(feature, "this syntax")
+// UnimplementedWithIssue records a syntax-level "unimplemented" error
+// annotated with a tracking issue.
+func (l *lexer) UnimplementedWithIssue(issue int) {
+	l.lastError = unimp.NewWithIssue(issue, "this syntax")
 	lastTok := l.lastToken()
 	l.lastError = parserutils.PopulateErrorDetails(lastTok.id, ERROR, lastTok.str, lastTok.pos, l.lastError, l.in)
 	l.lastError = &tree.UnsupportedError{
 		Err:         l.lastError,
-		FeatureName: feature,
+		FeatureName: build.MakeIssueURL(issue),
 	}
 }
 

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -26,8 +26,8 @@ func setErrNoDetails(plpgsqllex plpgsqlLexer, err error) int {
     return 1
 }
 
-func unimplemented(plpgsqllex plpgsqlLexer, feature string) int {
-    plpgsqllex.(*lexer).Unimplemented(feature)
+func unimplementedWithIssue(plpgsqllex plpgsqlLexer, issue int) int {
+    plpgsqllex.(*lexer).UnimplementedWithIssue(issue)
     return 1
 }
 
@@ -475,7 +475,7 @@ decl_statement: decl_varname decl_const decl_datatype decl_collate decl_notnull 
   }
 | decl_varname ALIAS FOR decl_aliasitem ';'
   {
-    return unimplemented(plpgsqllex, "alias for")
+    return unimplementedWithIssue(plpgsqllex, 169572)
   }
 | decl_varname opt_scrollable CURSOR decl_cursor_args decl_is_for decl_cursor_query
   {
@@ -516,7 +516,7 @@ decl_cursor_query: stmt_until_semi ';'
 
 decl_cursor_args: '('
   {
-    return unimplemented(plpgsqllex, "cursor arguments")
+    return unimplementedWithIssue(plpgsqllex, 117746)
   }
 | /* EMPTY */
   {
@@ -771,7 +771,7 @@ proc_stmt:pl_block ';'
 
 stmt_perform: PERFORM stmt_until_semi ';'
   {
-    return unimplemented(plpgsqllex, "perform")
+    return unimplementedWithIssue(plpgsqllex, 108416)
   }
 ;
 
@@ -1106,7 +1106,7 @@ for_control:
 	    }
 	    $$.val = forLoopControl
 	  case LOOP:
-	    return unimplemented(plpgsqllex, "for loop over query or cursor")
+	    return unimplementedWithIssue(plpgsqllex, 105246)
 	  default:
 	    return setErr(plpgsqllex, errors.New("unterminated FOR loop definition"))
 	  }
@@ -1125,7 +1125,7 @@ for_target:
 
 stmt_foreach_a: opt_loop_label FOREACH
   {
-    return unimplemented(plpgsqllex, "for each loop")
+    return unimplementedWithIssue(plpgsqllex, 163147)
   }
 ;
 
@@ -1185,7 +1185,7 @@ return_query:
       // Advance the lexer by one token so that the error correctly points to
       // the EXECUTE keyword.
       plpgsqllex.(*lexer).Advance(1)
-      return unimplemented (plpgsqllex, "return dynamic sql query")
+      return unimplementedWithIssue(plpgsqllex, 169571)
     }
     retQuery, err := plpgsqllex.(*lexer).ParseReturnQuery()
     if err != nil {
@@ -1198,7 +1198,7 @@ return_query:
 stmt_raise:
   RAISE ';'
   {
-    return unimplemented(plpgsqllex, "empty RAISE statement")
+    return unimplementedWithIssue(plpgsqllex, 169573)
   }
 | RAISE opt_error_level SCONST opt_format_exprs opt_option_exprs ';'
   {
@@ -1398,9 +1398,9 @@ stmt_open: OPEN IDENT ';'
   {
     $$.val = &plpgsqltree.Open{CurVar: plpgsqltree.Variable($2)}
   }
-| OPEN IDENT opt_scrollable FOR EXECUTE 
+| OPEN IDENT opt_scrollable FOR EXECUTE
   {
-    return unimplemented(plpgsqllex, "cursor for execute")
+    return unimplementedWithIssue(plpgsqllex, 169574)
   }
 | OPEN IDENT opt_scrollable FOR stmt_until_semi ';'
   {

--- a/pkg/sql/plpgsql/parser/testdata/decl_header
+++ b/pkg/sql/plpgsql/parser/testdata/decl_header
@@ -123,7 +123,6 @@ DECLARE
 BEGIN
 END
 ----
-----
 at or near ";": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -131,17 +130,7 @@ DECLARE
   var2 ALIAS FOR quantity;
                          ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/169572/
 
 parse
 DECLARE
@@ -176,24 +165,13 @@ DECLARE
 BEGIN
 END
 ----
-----
 at or near "(": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
   var1 NO SCROLL CURSOR (arg1 INTEGER) FOR SELECT * FROM t1 WHERE id = arg1;
                         ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/117746/
 
 # Correctly handle parsing errors for variable types.
 error

--- a/pkg/sql/plpgsql/parser/testdata/stmt_for
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_for
@@ -285,7 +285,6 @@ FOR counter IN 1.5 LOOP
 END LOOP;
 END
 ----
-----
 at or near "in": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -293,17 +292,7 @@ BEGIN
 FOR counter IN 1.5 LOOP
             ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/105246/
 
 # Nesting the dots should cause the parser to expect a cursor or query loop
 # instead.
@@ -315,7 +304,6 @@ FOR counter IN SELECT (1...5) LOOP
 END LOOP;
 END
 ----
-----
 at or near "in": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -323,17 +311,7 @@ BEGIN
 FOR counter IN SELECT (1...5) LOOP
             ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/105246/
 
 error
 DECLARE
@@ -344,7 +322,6 @@ LOOP
 END LOOP;
 RETURN;
 ----
-----
 at or near "in": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -352,17 +329,7 @@ BEGIN
 FOR yr IN SELECT * FROM generate_series(1,10,1) AS y_(y)
        ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/105246/
 
 pretty
 DECLARE

--- a/pkg/sql/plpgsql/parser/testdata/stmt_foreach_a
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_foreach_a
@@ -10,7 +10,6 @@ BEGIN
   RETURN s;
 END
 ----
-----
 at or near "foreach": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -20,14 +19,4 @@ BEGIN
   FOREACH x IN ARRAY $1
   ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/163147/

--- a/pkg/sql/plpgsql/parser/testdata/stmt_open
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_open
@@ -112,7 +112,6 @@ BEGIN
 OPEN curs2 SCROLL FOR EXECUTE SELECT $1, $2 FROM foo WHERE key = mykey USING hello, jojo;
 END
 ----
-----
 at or near "execute": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -120,17 +119,7 @@ BEGIN
 OPEN curs2 SCROLL FOR EXECUTE SELECT $1, $2 FROM foo WHERE key = mykey USING hello, jojo;
                       ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/169574/
 
 error
 DECLARE

--- a/pkg/sql/plpgsql/parser/testdata/stmt_perform
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_perform
@@ -4,7 +4,6 @@ BEGIN
   PERFORM 1+1;
 END
 ----
-----
 at or near ";": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -12,24 +11,13 @@ BEGIN
   PERFORM 1+1;
              ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/108416/
 
 error
 DECLARE
 BEGIN
   PERFORM SELECT * FROM generate_series(1,10,1) AS y_(y);
 END
-----
 ----
 at or near ";": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
@@ -38,14 +26,4 @@ BEGIN
   PERFORM SELECT * FROM generate_series(1,10,1) AS y_(y);
                                                         ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/108416/

--- a/pkg/sql/plpgsql/parser/testdata/stmt_raise
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_raise
@@ -4,7 +4,6 @@ BEGIN
   RAISE;
 END
 ----
-----
 at or near ";": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -12,17 +11,7 @@ BEGIN
   RAISE;
        ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/169573/
 
 parse
 DECLARE

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return_query
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return_query
@@ -155,7 +155,6 @@ BEGIN
   RETURN QUERY EXECUTE a dynamic command;
 END
 ----
-----
 at or near "execute": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
@@ -163,14 +162,4 @@ BEGIN
   RETURN QUERY EXECUTE a dynamic command;
                ^
 HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
+See: https://go.crdb.dev/issue-v/169571/


### PR DESCRIPTION
The deprecated `unimplemented()` helper produces
telemetry of limited value. This commit moves to a
new helper to link unimplemented features to
corresponding issues.

Epic: CRDB-63280
Fixes: #169577

Release note (sql change): Unimplemented PL/pgSQL
syntax errors now include a link to the GitHub
issue tracking the missing feature.
