### PR TITLE
sql: restore verbose plan output in statement diagnostics bundles

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -416,7 +416,7 @@ func (b *stmtBundleBuilder) addOptPlans(ctx context.Context) {
 	b.z.AddFile("opt-vv.txt", formatOptPlan(memo.ExprFmtHideQualifications|memo.ExprFmtHideNotVisibleIndexInfo))
 }
 
-// addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.
+// addExecPlan adds the EXPLAIN ANALYZE (VERBOSE, TYPES) plan as file plan.txt.
 func (b *stmtBundleBuilder) addExecPlan(plan string) {
 	if plan == "" {
 		plan = noPlan

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -496,6 +496,10 @@ func (ih *instrumentationHelper) Setup(
 				stmtDiagnosticsRecorder.ShouldCollectDiagnostics(ctx, stmt.StmtNoConstants, "" /* planGist */)
 			// IsRedacted will be false when ih.collectBundle is false.
 			ih.explainFlags.RedactValues = ih.explainFlags.RedactValues || ih.diagRequest.IsRedacted()
+			if ih.collectBundle {
+				ih.explainFlags.Verbose = true
+				ih.explainFlags.ShowTypes = true
+			}
 		}
 	}
 
@@ -583,6 +587,8 @@ func (ih *instrumentationHelper) setupWithPlanGist(
 		return ctx
 	}
 	ih.explainFlags.RedactValues = ih.explainFlags.RedactValues || ih.diagRequest.IsRedacted()
+	ih.explainFlags.Verbose = true
+	ih.explainFlags.ShowTypes = true
 	ih.needFinish = true
 	ih.collectExecStats = true
 	if ih.sp == nil || !ih.sp.IsVerbose() {
@@ -1311,6 +1317,8 @@ func (ih *instrumentationHelper) handleTransactionDiagnostics(
 		ih.diagRequestID = 0
 		ih.diagRequest = stmtdiagnostics.Request{}
 		ih.explainFlags.RedactValues = txnState.txnInstrumentationHelper.ShouldRedact()
+		ih.explainFlags.Verbose = true
+		ih.explainFlags.ShowTypes = true
 		ih.shouldFinishSpan = true
 		ih.needFinish = true
 		ih.sp = stmtSp


### PR DESCRIPTION
Commit a1007075db4 replaced hardcoded `explain.Flags{Verbose: true, ShowTypes: true}` with `ih.explainFlags` when generating plan.txt in bundles. While `ih.explainFlags` is correctly populated for explicit `EXPLAIN ANALYZE (DEBUG)` statements, it remains zero-valued for bundles collected via statement diagnostics requests, plan-gist matching, and transaction-level diagnostics. This caused plan.txt to show a non-verbose plan instead of the expected verbose plan with types.

Fix by setting `Verbose` and `ShowTypes` on `ih.explainFlags` in all three diagnostics collection paths, matching what `EXPLAIN ANALYZE (DEBUG)` does via `SetOutputMode`.

Epic: none

Release note: None