### PR TITLE
sql: index pg_proc by proname to speed up pg_function_is_visible

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
@@ -807,9 +807,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 +  440301044 | pg_namespace_oid_idx
 + 4215795806 | pg_policy_polrelid_idx
 +  225076140 | pg_proc_oid_idx
++  225076141 | pg_proc_proname_idx
 + 2989383775 | pg_timezone_names_name_idx
 +  818702295 | pg_type_oid_idx
-+(30 rows)
++(31 rows)
  
  -- Cross-check against pg_type entry
  -- NOTE: we allow attstorage to be 'plain' even when typstorage is not;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3786,6 +3786,81 @@ https://www.postgresql.org/docs/16/catalog-pg-proc.html`,
 				}
 			},
 		},
+		{
+			// Index on proname. This reproduces exactly the rows that the full
+			// populate above would emit for a single proname value, so that
+			// correlated lookups by name — most notably the shadow check in
+			// pg_function_is_visible's `WHERE p2.proname = p.proname` — become a
+			// single-key index scan instead of a full populate of pg_proc.
+			incomplete: false,
+			populate: func(ctx context.Context, unwrappedConstraint tree.Datum, p *planner, dbContext catalog.DatabaseDescriptor,
+				addRow func(...tree.Datum) error) (bool, error) {
+				h := makeOidHasher()
+				name := string(tree.MustBeDString(unwrappedConstraint))
+				var matched bool
+
+				// Builtins. The proname column always holds the bare name, but a
+				// builtin's registry key may be schema-qualified (e.g.
+				// "crdb_internal.foo"). addPgProcBuiltinRow strips the prefix to
+				// derive proname and the namespace, so to find every builtin whose
+				// proname equals name we must probe all three schemas it knows how
+				// to attribute. The uppercase-name and pg_dump_compatibility skips
+				// mirror the filters the full populate applies.
+				var first rune
+				for _, c := range name {
+					first = c
+					break
+				}
+				if !unicode.IsUpper(first) {
+					pgDumpCompat := sessiondatapb.IsPgDumpCompatibilityEnabled(p.SessionData().PgDumpCompatibility)
+					for _, key := range []string{
+						name,
+						catconstants.CRDBInternalSchemaName + "." + name,
+						catconstants.InformationSchemaName + "." + name,
+					} {
+						if pgDumpCompat &&
+							(strings.HasPrefix(key, catconstants.CRDBInternalSchemaName+".") ||
+								strings.HasPrefix(key, catconstants.InformationSchemaName+".")) {
+							continue
+						}
+						if _, overloads := builtinsregistry.GetBuiltinProperties(key); len(overloads) == 0 {
+							continue
+						}
+						if err := addPgProcBuiltinRow(key, addRow); err != nil {
+							return false, err
+						}
+						matched = true
+					}
+				}
+
+				// User-defined functions named name, looked up per schema in the
+				// current database.
+				if err := forEachSchema(ctx, p, dbContext, true /* requiresPrivileges */, false, /* includeMetadata */
+					func(ctx context.Context, scDesc catalog.SchemaDescriptor) error {
+						fn, found := scDesc.GetFunction(name)
+						if !found {
+							return nil
+						}
+						for _, sig := range fn.Signatures {
+							fnDesc, err := descs.GetCatalogDescriptorGetter(
+								ctx, p.Descriptors(), p.Txn(), p.EvalContext().Settings,
+							).WithoutNonPublic().Get().Function(ctx, sig.ID)
+							if err != nil {
+								return err
+							}
+							if err := addPgProcUDFRow(h, scDesc, fnDesc, addRow); err != nil {
+								return err
+							}
+							matched = true
+						}
+						return nil
+					}); err != nil {
+					return false, err
+				}
+
+				return matched, nil
+			},
+		},
 	},
 }
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1753,22 +1753,36 @@ FROM defaults_parsed
 	// same-named functions in different schemas with disjoint argument
 	// lists do not shadow each other.
 	// https://www.postgresql.org/docs/current/functions-info.html
+	//
+	// The shadow check must match p2 by name against a scalar value, not by
+	// correlating with an outer pg_proc relation (e.g. p2.proname = p.proname).
+	// A correlated equality gets decorrelated into a hash join that fully
+	// populates pg_proc on every call; comparing p2.proname against a scalar
+	// instead lets the optimizer drive a lookup join into
+	// pg_proc@pg_proc_proname_idx. The target row's proname/proargtypes/
+	// pronamespace are read once into the `target` CTE via the oid index. The
+	// CASE guard makes the function return NULL (not true) for an OID that does
+	// not exist, since a CTE-only query would otherwise always return one row.
 	"pg_function_is_visible": makeBuiltin(defProps(),
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Body: `SELECT (SELECT n2.nspname
-                       FROM pg_catalog.pg_proc p2
-                       JOIN pg_catalog.pg_namespace n2 ON p2.pronamespace = n2.oid
-                       WHERE p2.proname = p.proname
-                         AND p2.proargtypes = p.proargtypes
-                         AND n2.nspname = ANY current_schemas(true)
-                       ORDER BY array_position(current_schemas(true), n2.nspname)
-                       LIMIT 1) IS NOT DISTINCT FROM
-                    (SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.oid = p.pronamespace)
-             FROM pg_catalog.pg_proc p
-             WHERE p.oid = $1
-             LIMIT 1`,
+			Body: `WITH target AS (
+               SELECT proname, proargtypes, pronamespace
+               FROM pg_catalog.pg_proc WHERE oid = $1
+             )
+             SELECT CASE WHEN (SELECT proname FROM target) IS NOT NULL THEN
+                 (SELECT n2.nspname
+                  FROM pg_catalog.pg_proc p2
+                  JOIN pg_catalog.pg_namespace n2 ON p2.pronamespace = n2.oid
+                  WHERE p2.proname = (SELECT proname FROM target)
+                    AND p2.proargtypes = (SELECT proargtypes FROM target)
+                    AND n2.nspname = ANY current_schemas(true)
+                  ORDER BY array_position(current_schemas(true), n2.nspname)
+                  LIMIT 1) IS NOT DISTINCT FROM
+                 (SELECT n.nspname FROM pg_catalog.pg_namespace n
+                  WHERE n.oid = (SELECT pronamespace FROM target))
+             END`,
 			CalledOnNullInput: true,
 			Info:              "Returns whether the function with the given OID is visible in the search path (its schema is on the search path and no function with the same name and signature shadows it from an earlier schema).",
 			Volatility:        volatility.Stable,

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -646,7 +646,8 @@ CREATE TABLE pg_catalog.pg_proc (
 	prosqlbody STRING,
 	proconfig STRING[],
 	proacl STRING[],
-	INDEX(oid)
+	INDEX(oid),
+	INDEX(proname)
 )`
 
 // PGCatalogRange describes the schema of the pg_catalog.pg_range table.


### PR DESCRIPTION
pg_function_is_visible was rewritten to be signature-aware by shadow-checking pg_proc for same-named functions on the search path. Because pg_proc, a virtual table, was only indexed by oid, the shadow check forced a full materialization of pg_proc (every builtin plus every UDF) on every call. Under the per-row introspection pattern that ORMs and psql's \d-style describe commands use (SELECT ..., pg_function_is_visible(p.oid) FROM pg_proc p), this is quadratic in the number of functions and makes catalog introspection very slow.

This commit makes the shadow check an indexed lookup:

* pkg/sql/vtable/pg_catalog.go and pkg/sql/pg_catalog.go add a second virtual index on pg_proc.proname. Its populate reproduces exactly the rows the full scan emits for one name: it probes the three registry keys a builtin name can carry (bare, crdb_internal., information_schema.) and looks up UDFs per schema via SchemaDescriptor.GetFunction, replicating the uppercase and pg_dump_compatibility filters of the full populate so the index is complete.

* pkg/sql/sem/builtins/pg_builtins.go rewrites the pg_function_is_visible body. The index alone is not enough: a correlated predicate (p2.proname = p.proname) is decorrelated into a hash join that still fully populates pg_proc. Comparing p2.proname against a scalar instead lets the optimizer drive a lookup join into the new index. The target row's proname, proargtypes, and pronamespace are read once through a target CTE (via the oid index), and a CASE guard preserves the existing behavior of returning NULL for an OID that does not exist.

After the change, each call performs one oid-index lookup plus one proname-index lookup join, with no full pg_proc populate. Behavior is unchanged: visibility, shadowing across the search path, and the NULL-for-missing-OID result all match the previous implementation.

The sibling pg_table_is_visible and pg_type_is_visible functions have the same regression and need analogous relname/typname indexes on pg_class/pg_type; they are left for follow-up.

Informs: #171054
Epic: CRDB-62230

Release note: None