### PR TITLE
restore: persist descriptor refs in job_info, not RestoreDetails

### DIFF
--- a/pkg/backup/BUILD.bazel
+++ b/pkg/backup/BUILD.bazel
@@ -206,6 +206,7 @@ go_test(
         "main_test.go",
         "partitioned_backup_test.go",
         "restore_data_processor_test.go",
+        "restore_desc_refs_test.go",
         "restore_multiregion_rbr_test.go",
         "restore_online_distflow_test.go",
         "restore_online_test.go",

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -9716,6 +9716,24 @@ func TestProtectRestoreTargets(t *testing.T) {
 			restoreDetails := jobutils.GetJobPayload(t, sqlDB, jobId).GetRestore()
 			require.NotNil(t, restoreDetails.ProtectedTimestampRecord)
 
+			// Resolve the descriptor IDs the restore is materializing via
+			// the new info-key rows in system.job_info; the legacy
+			// RestoreDetails.{Database,Table}Descs slices are only
+			// populated under mixed-version clusters and the helpers
+			// transparently fall back to them.
+			s := tc.ApplicationLayer(0)
+			idb := s.InternalDB().(isql.DB)
+			var dbRefs, tableRefs []backuppb.RestoreDescRef
+			require.NoError(t, idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				var err error
+				dbRefs, err = databaseDescRefs(ctx, txn, jobId, *restoreDetails)
+				if err != nil {
+					return err
+				}
+				tableRefs, err = tableDescRefs(ctx, txn, jobId, *restoreDetails)
+				return err
+			}))
+
 			target := ptutil.GetPTSTarget(t, sqlDB, restoreDetails.ProtectedTimestampRecord)
 			switch subtest.name {
 			case "cluster":
@@ -9730,10 +9748,10 @@ func TestProtectRestoreTargets(t *testing.T) {
 				require.Equal(t, roachpb.TenantID{InternalValue: 20}, targetIDs.IDs[0])
 			case "database":
 				targetIDs := target.GetSchemaObjects()
-				require.Equal(t, restoreDetails.DatabaseDescs[0].GetID(), targetIDs.IDs[0])
+				require.Equal(t, dbRefs[0].ID, targetIDs.IDs[0])
 			case "table":
 				targetIDs := target.GetSchemaObjects()
-				require.Equal(t, restoreDetails.TableDescs[0].GetID(), targetIDs.IDs[0])
+				require.Equal(t, tableRefs[0].ID, targetIDs.IDs[0])
 			}
 			// Finish the restore and ensure the PTS record was removed
 			sqlDB.Exec(t, `SET CLUSTER SETTING jobs.debug.pausepoints = ''`)

--- a/pkg/backup/backuppb/backup.proto
+++ b/pkg/backup/backuppb/backup.proto
@@ -243,6 +243,25 @@ message BackupProgressTraceEvent {
   util.hlc.Timestamp revision_start_time = 3 [(gogoproto.nullable) = false];
 }
 
+// RestoreDescRef is an (ID, Version) tuple identifying a descriptor that a
+// RESTORE job has materialized in OFFLINE state. The descriptor body is
+// fetched from KV when needed; persisting only the reference avoids
+// embedding the full descriptor in the job's RestoreDetails payload, which
+// can exceed the per-row raft command size limit at large descriptor counts.
+message RestoreDescRef {
+  uint32 id      = 1 [(gogoproto.customname) = "ID",
+                      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"];
+  uint32 version = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.DescriptorVersion"];
+}
+
+// RestoreDescRefs is the value stored under each per-type info-key
+// (restoreTableDescRefsKey, etc.) in system.job_info during a RESTORE.
+// One row per descriptor type keeps individual rows well under the raft
+// command size limit even at multi-million-descriptor scale.
+message RestoreDescRefs {
+  repeated RestoreDescRef refs = 1 [(gogoproto.nullable) = false];
+}
+
 // ExportStats is a message containing information about each
 // Export{Request,Response}.
 message ExportStats {

--- a/pkg/backup/restore_desc_refs_test.go
+++ b/pkg/backup/restore_desc_refs_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestoreDescriptorRefsGate validates the dual-write/single-write
+// behavior of the RESTORE job around the
+// V26_3_DescriptorIDsInRestoreDetails cluster version gate:
+//
+//   - Below the gate, the job must populate both the legacy
+//     RestoreDetails.{Database,Table,Type,Schema,Function}Descs slices
+//     and the dedicated per-type info-key rows in system.job_info, so
+//     that an older binary resuming the job can still drive it from the
+//     payload.
+//   - At or above the gate, the legacy slices must be empty and only
+//     the info-key rows must be populated; this is what bounds the
+//     RestoreDetails payload size so that the job's SetDetails write
+//     no longer hits the raft command size limit at multi-million
+//     descriptor scale.
+//
+// The test also exercises the reader fallback in tableDescRefs by
+// inspecting the info-key rows directly via the package-private helper.
+func TestRestoreDescriptorRefsGate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// The below-gate subtest requires the gate version to still be above
+	// MinSupported so that we can override the cluster version to one
+	// step below it.
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(
+		t, clusterversion.V26_3_DescriptorIDsInRestoreDetails,
+	)
+
+	ctx := context.Background()
+
+	type expectedCounts struct {
+		databases, tables, types, schemas, functions int
+	}
+
+	// seedAndBackup populates a fresh database with one of each
+	// descriptor type and returns the expected ref counts for a
+	// subsequent DATABASE-level restore.
+	seedAndBackup := func(t *testing.T, sqlDB *sqlutils.SQLRunner, dbName, backupURI string) expectedCounts {
+		sqlDB.Exec(t, fmt.Sprintf("CREATE DATABASE %s", dbName))
+		sqlDB.Exec(t, fmt.Sprintf("USE %s", dbName))
+		sqlDB.Exec(t, "CREATE SCHEMA sc")
+		sqlDB.Exec(t, "CREATE TYPE sc.color AS ENUM ('red', 'green', 'blue')")
+		sqlDB.Exec(t, "CREATE TABLE sc.t (k INT PRIMARY KEY, c sc.color)")
+		sqlDB.Exec(t, "CREATE FUNCTION sc.f() RETURNS INT LANGUAGE SQL AS 'SELECT 1'")
+		sqlDB.Exec(t, fmt.Sprintf("BACKUP DATABASE %s INTO '%s'", dbName, backupURI))
+		// Drop the source so the restore creates fresh descriptors.
+		sqlDB.Exec(t, "USE defaultdb")
+		sqlDB.Exec(t, fmt.Sprintf("DROP DATABASE %s CASCADE", dbName))
+		return expectedCounts{
+			databases: 1,
+			tables:    1,
+			types:     2, // enum + array type
+			schemas:   2, // implicit public + user-created sc
+			functions: 1,
+		}
+	}
+
+	runCase := func(t *testing.T, name string, override roachpb.Version, expectLegacy bool) {
+		t.Run(name, func(t *testing.T) {
+			var params base.TestClusterArgs
+			// Run directly on the system tenant: a CV override on the
+			// host cluster does not propagate to an auto-injected virtual
+			// cluster, which then refuses to start at a binary version
+			// newer than the host's logical version.
+			params.ServerArgs.DefaultTestTenant = base.TestIsSpecificToStorageLayerAndNeedsASystemTenant
+			if override != (roachpb.Version{}) {
+				params.ServerArgs.Knobs.Server = &server.TestingKnobs{
+					DisableAutomaticVersionUpgrade: make(chan struct{}),
+					ClusterVersionOverride:         override,
+				}
+			}
+			tc, sqlDB, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
+				t, singleNode, backuptestutils.WithParams(params),
+			)
+			defer cleanupFn()
+
+			backupURI := "nodelocal://1/" + name
+			counts := seedAndBackup(t, sqlDB, "src", backupURI)
+
+			// Pause the restore right before publishing so the descriptor
+			// references written by createImportingDescriptors are
+			// observable but the publish-time clobber has not yet run.
+			sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_publishing_descriptors'")
+			var jobID jobspb.JobID
+			sqlDB.QueryRow(t, fmt.Sprintf(
+				"RESTORE DATABASE src FROM LATEST IN '%s' WITH detached, new_db_name = 'dst'", backupURI,
+			)).Scan(&jobID)
+			jobutils.WaitForJobToPause(t, sqlDB, jobID)
+
+			// The info-key rows must always be present on the new code
+			// path, regardless of the cluster version.
+			s := tc.ApplicationLayer(0)
+			require.NoError(t, s.InternalDB().(isql.DB).Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+				assertRefsCount(t, ctx, txn, jobID, restoreDatabaseDescRefsKey, counts.databases)
+				assertRefsCount(t, ctx, txn, jobID, restoreTableDescRefsKey, counts.tables)
+				assertRefsCount(t, ctx, txn, jobID, restoreTypeDescRefsKey, counts.types)
+				assertRefsCount(t, ctx, txn, jobID, restoreSchemaDescRefsKey, counts.schemas)
+				assertRefsCount(t, ctx, txn, jobID, restoreFunctionDescRefsKey, counts.functions)
+				return nil
+			}))
+
+			// The legacy slices on RestoreDetails are populated when CV
+			// is below the gate (dual-write) and left nil otherwise.
+			registry := s.JobRegistry().(*jobs.Registry)
+			job, err := registry.LoadJob(ctx, jobID)
+			require.NoError(t, err)
+			details := job.Details().(jobspb.RestoreDetails)
+			if expectLegacy {
+				require.Len(t, details.DatabaseDescs, counts.databases, "legacy DatabaseDescs")
+				require.Len(t, details.TableDescs, counts.tables, "legacy TableDescs")
+				require.Len(t, details.TypeDescs, counts.types, "legacy TypeDescs")
+				require.Len(t, details.SchemaDescs, counts.schemas, "legacy SchemaDescs")
+				require.Len(t, details.FunctionDescs, counts.functions, "legacy FunctionDescs")
+			} else {
+				require.Empty(t, details.DatabaseDescs, "legacy DatabaseDescs should be empty above gate")
+				require.Empty(t, details.TableDescs, "legacy TableDescs should be empty above gate")
+				require.Empty(t, details.TypeDescs, "legacy TypeDescs should be empty above gate")
+				require.Empty(t, details.SchemaDescs, "legacy SchemaDescs should be empty above gate")
+				require.Empty(t, details.FunctionDescs, "legacy FunctionDescs should be empty above gate")
+			}
+
+			// Unblock and confirm the restore still completes.
+			sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
+			sqlDB.Exec(t, "RESUME JOB $1", jobID)
+			jobutils.WaitForJobToSucceed(t, sqlDB, jobID)
+		})
+	}
+
+	runCase(t, "below_gate",
+		(clusterversion.V26_3_DescriptorIDsInRestoreDetails - 1).Version(),
+		true /* expectLegacy */)
+	runCase(t, "at_gate",
+		roachpb.Version{} /* override: use the binary's latest version */, false /* expectLegacy */)
+}
+
+// TestRestoreDescriptorRefsReaderFallback validates that on the new
+// binary, restore readers fall back to the legacy RestoreDetails
+// descriptor slices when the info-key rows are absent. This is the
+// state of a job created by an older binary that never wrote info-key
+// rows (only possible during a mixed-version window).
+//
+// The test constructs the missing-info-key state by running a restore,
+// pausing it, deleting the info-key rows, and confirming the read
+// helpers still return the descriptor references via the legacy slices.
+func TestRestoreDescriptorRefsReaderFallback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(
+		t, clusterversion.V26_3_DescriptorIDsInRestoreDetails,
+	)
+
+	ctx := context.Background()
+
+	// Run under the below-gate override so that the legacy slices are
+	// populated and can serve the fallback path. The CV override does
+	// not propagate to an auto-injected virtual cluster, so pin the
+	// test to the system tenant.
+	var params base.TestClusterArgs
+	params.ServerArgs.DefaultTestTenant = base.TestIsSpecificToStorageLayerAndNeedsASystemTenant
+	params.ServerArgs.Knobs.Server = &server.TestingKnobs{
+		DisableAutomaticVersionUpgrade: make(chan struct{}),
+		ClusterVersionOverride:         (clusterversion.V26_3_DescriptorIDsInRestoreDetails - 1).Version(),
+	}
+	tc, sqlDB, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
+		t, singleNode, backuptestutils.WithParams(params),
+	)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, "CREATE DATABASE src")
+	sqlDB.Exec(t, "USE src")
+	sqlDB.Exec(t, "CREATE SCHEMA sc")
+	sqlDB.Exec(t, "CREATE TYPE sc.color AS ENUM ('red', 'green', 'blue')")
+	sqlDB.Exec(t, "CREATE TABLE sc.t (k INT PRIMARY KEY, c sc.color)")
+	sqlDB.Exec(t, "CREATE FUNCTION sc.f() RETURNS INT LANGUAGE SQL AS 'SELECT 1'")
+	sqlDB.Exec(t, "BACKUP DATABASE src INTO 'nodelocal://1/reader_fallback'")
+	sqlDB.Exec(t, "USE defaultdb")
+	sqlDB.Exec(t, "DROP DATABASE src CASCADE")
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_publishing_descriptors'")
+	var jobID jobspb.JobID
+	sqlDB.QueryRow(t,
+		"RESTORE DATABASE src FROM LATEST IN 'nodelocal://1/reader_fallback' WITH detached, new_db_name = 'dst'",
+	).Scan(&jobID)
+	jobutils.WaitForJobToPause(t, sqlDB, jobID)
+
+	s := tc.ApplicationLayer(0)
+	idb := s.InternalDB().(isql.DB)
+
+	// Snapshot the table-ref count via the info-key row, then delete the
+	// row and confirm the read helper returns the same count via the
+	// legacy slice fallback.
+	var tableCount, dbCount, typeCount, schemaCount, fnCount int
+	require.NoError(t, idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		refs, ok, err := getDescRefs(ctx, txn, jobID, restoreTableDescRefsKey)
+		require.NoError(t, err)
+		require.True(t, ok, "info-key row should exist before deletion")
+		tableCount = len(refs)
+		// Similarly capture the other types so we can assert fallback
+		// parity across all five descriptor kinds.
+		refs, _, err = getDescRefs(ctx, txn, jobID, restoreDatabaseDescRefsKey)
+		require.NoError(t, err)
+		dbCount = len(refs)
+		refs, _, err = getDescRefs(ctx, txn, jobID, restoreTypeDescRefsKey)
+		require.NoError(t, err)
+		typeCount = len(refs)
+		refs, _, err = getDescRefs(ctx, txn, jobID, restoreSchemaDescRefsKey)
+		require.NoError(t, err)
+		schemaCount = len(refs)
+		refs, _, err = getDescRefs(ctx, txn, jobID, restoreFunctionDescRefsKey)
+		require.NoError(t, err)
+		fnCount = len(refs)
+		return nil
+	}))
+
+	deleteInfoRow := func(t *testing.T, key string) {
+		sqlDB.Exec(t,
+			"DELETE FROM system.job_info WHERE job_id = $1 AND info_key = $2", jobID, key,
+		)
+	}
+	deleteInfoRow(t, restoreTableDescRefsKey)
+	deleteInfoRow(t, restoreDatabaseDescRefsKey)
+	deleteInfoRow(t, restoreTypeDescRefsKey)
+	deleteInfoRow(t, restoreSchemaDescRefsKey)
+	deleteInfoRow(t, restoreFunctionDescRefsKey)
+
+	// The info-key rows are gone; the helpers must now fall back to
+	// the legacy slices and return identical counts.
+	registry := s.JobRegistry().(*jobs.Registry)
+	job, err := registry.LoadJob(ctx, jobID)
+	require.NoError(t, err)
+	details := job.Details().(jobspb.RestoreDetails)
+	require.NoError(t, idb.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		// Confirm the info-key rows really are gone.
+		_, ok, err := getDescRefs(ctx, txn, jobID, restoreTableDescRefsKey)
+		require.NoError(t, err)
+		require.False(t, ok, "info-key row should be deleted")
+
+		refs, err := tableDescRefs(ctx, txn, jobID, details)
+		require.NoError(t, err)
+		require.Len(t, refs, tableCount, "tableDescRefs fallback count")
+
+		refs, err = databaseDescRefs(ctx, txn, jobID, details)
+		require.NoError(t, err)
+		require.Len(t, refs, dbCount, "databaseDescRefs fallback count")
+
+		refs, err = typeDescRefs(ctx, txn, jobID, details)
+		require.NoError(t, err)
+		require.Len(t, refs, typeCount, "typeDescRefs fallback count")
+
+		refs, err = schemaDescRefs(ctx, txn, jobID, details)
+		require.NoError(t, err)
+		require.Len(t, refs, schemaCount, "schemaDescRefs fallback count")
+
+		refs, err = functionDescRefs(ctx, txn, jobID, details)
+		require.NoError(t, err)
+		require.Len(t, refs, fnCount, "functionDescRefs fallback count")
+		return nil
+	}))
+
+	// Cancel the job to keep the test cluster clean for shutdown.
+	sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = ''")
+	sqlDB.Exec(t, "CANCEL JOB $1", jobID)
+	jobutils.WaitForJobToCancel(t, sqlDB, jobID)
+}
+
+// assertRefsCount reads the info-key row for a restore job and asserts
+// the contained slice has the expected length.
+func assertRefsCount(
+	t *testing.T, ctx context.Context, txn isql.Txn, jobID jobspb.JobID, key string, expected int,
+) {
+	t.Helper()
+	raw, ok, err := jobs.InfoStorageForJob(txn, jobID).Get(ctx, "test-restore-refs", key)
+	require.NoError(t, err, key)
+	require.True(t, ok, "%s row missing", key)
+	var msg backuppb.RestoreDescRefs
+	require.NoError(t, protoutil.Unmarshal(raw, &msg), key)
+	require.Len(t, msg.Refs, expected, key)
+	// Sanity-check the ref payload shape: every entry must carry a
+	// non-zero ID and Version (descriptors are never persisted at v0).
+	for i, r := range msg.Refs {
+		require.NotZero(t, r.ID, "%s[%d].ID", key, i)
+		require.NotZero(t, r.Version, "%s[%d].Version", key, i)
+	}
+}

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2367,49 +2367,59 @@ func createImportingDescriptors(
 		}
 
 		details.PrepareCompleted = true
-		details.DatabaseDescs = databaseDescs
-		details.TableDescs = tableDescs
-		details.TypeDescs = make([]*descpb.TypeDescriptor, len(typesToWrite))
+
+		newTypeDescs := make([]*descpb.TypeDescriptor, len(typesToWrite))
 		for i := range typesToWrite {
-			details.TypeDescs[i] = typesToWrite[i].TypeDesc()
+			newTypeDescs[i] = typesToWrite[i].TypeDesc()
 		}
-		details.SchemaDescs = make([]*descpb.SchemaDescriptor, len(schemasToWrite))
+		newSchemaDescs := make([]*descpb.SchemaDescriptor, len(schemasToWrite))
 		for i := range schemasToWrite {
-			details.SchemaDescs[i] = schemasToWrite[i].SchemaDesc()
+			newSchemaDescs[i] = schemasToWrite[i].SchemaDesc()
 		}
-		details.FunctionDescs = make([]*descpb.FunctionDescriptor, len(functionsToWrite))
+		newFunctionDescs := make([]*descpb.FunctionDescriptor, len(functionsToWrite))
 		for i, fn := range functionsToWrite {
-			details.FunctionDescs[i] = fn.FuncDesc()
+			newFunctionDescs[i] = fn.FuncDesc()
 		}
 
-		// Dual-write each descriptor type's (ID, Version) tuples to a
-		// dedicated system.job_info row alongside the legacy slice
-		// population above. The info-key rows are the long-term source of
-		// truth — later phases of the restore fetch descriptor bodies from
-		// KV by ID rather than relying on the full payloads on
-		// RestoreDetails — but the legacy slices remain populated here for
-		// mixed-version compatibility. A later commit gates the legacy
-		// writes off once the cluster has crossed the corresponding
-		// cluster version.
+		// Write each descriptor type's (ID, Version) tuples to a dedicated
+		// system.job_info row. The info-key rows are the source of truth
+		// for the restore's descriptor set; subsequent phases fetch
+		// descriptor bodies from KV by ID. Below, the legacy slices on
+		// RestoreDetails are dual-written when the cluster has not yet
+		// crossed the gate, so that nodes still running the prior binary
+		// can drive the job.
 		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTableDescRefsKey,
-			descRefsFromTableDescs(details.TableDescs)); err != nil {
+			descRefsFromTableDescs(tableDescs)); err != nil {
 			return err
 		}
 		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTypeDescRefsKey,
-			descRefsFromTypeDescs(details.TypeDescs)); err != nil {
+			descRefsFromTypeDescs(newTypeDescs)); err != nil {
 			return err
 		}
 		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreSchemaDescRefsKey,
-			descRefsFromSchemaDescs(details.SchemaDescs)); err != nil {
+			descRefsFromSchemaDescs(newSchemaDescs)); err != nil {
 			return err
 		}
 		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreDatabaseDescRefsKey,
-			descRefsFromDatabaseDescs(details.DatabaseDescs)); err != nil {
+			descRefsFromDatabaseDescs(databaseDescs)); err != nil {
 			return err
 		}
 		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreFunctionDescRefsKey,
-			descRefsFromFunctionDescs(details.FunctionDescs)); err != nil {
+			descRefsFromFunctionDescs(newFunctionDescs)); err != nil {
 			return err
+		}
+
+		// TODO (kev-cao): drop this dual-write in 27.1+ once
+		// V26_3_DescriptorIDsInRestoreDetails is the minimum supported
+		// version.
+		if !p.ExecCfg().Settings.Version.ActiveVersion(ctx).AtLeast(
+			clusterversion.V26_3_DescriptorIDsInRestoreDetails.Version(),
+		) {
+			details.DatabaseDescs = databaseDescs
+			details.TableDescs = tableDescs
+			details.TypeDescs = newTypeDescs
+			details.SchemaDescs = newSchemaDescs
+			details.FunctionDescs = newFunctionDescs
 		}
 
 		// Update the job once all descs have been prepared for ingestion.
@@ -3699,19 +3709,24 @@ func (r *restoreResumer) publishDescriptors(
 
 	// Update and persist the state of the job.
 	details.DescriptorsPublished = true
-	details.TableDescs = newTables
-	details.TypeDescs = newTypes
-	details.SchemaDescs = newSchemas
-	details.DatabaseDescs = newDBs
-	details.FunctionDescs = newFunctions
+	// Always write the (ID, Version) tuples to the dedicated info-key rows;
+	// these are the source of truth on the new code path. The legacy
+	// descriptor slices on RestoreDetails are only populated for mixed-version
+	// clusters where an older binary might still drive the job.
+	// TODO (kev-cao): drop this dual-write in 27.1+ once
+	// V26_3_DescriptorIDsInRestoreDetails is the minimum supported version.
+	if !r.execCfg.Settings.Version.ActiveVersion(ctx).AtLeast(
+		clusterversion.V26_3_DescriptorIDsInRestoreDetails.Version(),
+	) {
+		details.TableDescs = newTables
+		details.TypeDescs = newTypes
+		details.SchemaDescs = newSchemas
+		details.DatabaseDescs = newDBs
+		details.FunctionDescs = newFunctions
+	}
 	if details.OnlineImpl() {
 		details.PostDownloadTableAutoStatsSettings = tableAutoStatsSettings
 	}
-	// Dual-write the published (ID, Version) tuples to the dedicated
-	// info-key rows alongside the legacy slice updates above. See the
-	// matching block in createImportingDescriptors for the rationale; a
-	// later commit gates the legacy writes off once the cluster has
-	// crossed the corresponding cluster version.
 	if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTableDescRefsKey,
 		descRefsFromTableDescs(newTables)); err != nil {
 		return err

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -138,6 +138,17 @@ const (
 	// restoreTempSystemDBPrefix is the prefix used for the temporary system
 	// database created during restore.
 	restoreTempSystemDBPrefix = "crdb_temp_system"
+
+	// Per-type info-keys used by RESTORE to persist (ID, Version) tuples for
+	// every descriptor materialized in OFFLINE state. The descriptor body is
+	// fetched from KV when needed; persisting only references keeps the
+	// per-row size well under the raft command size limit at multi-million
+	// descriptor scale. See backuppb.RestoreDescRefs for the value shape.
+	restoreTableDescRefsKey    = "restore_table_desc_refs"
+	restoreTypeDescRefsKey     = "restore_type_desc_refs"
+	restoreSchemaDescRefsKey   = "restore_schema_desc_refs"
+	restoreDatabaseDescRefsKey = "restore_database_desc_refs"
+	restoreFunctionDescRefsKey = "restore_function_desc_refs"
 )
 
 var restoreStatsInsertionConcurrency = settings.RegisterIntSetting(
@@ -167,6 +178,182 @@ func restoreTempSystemName(
 }
 
 var laggingRestoreProcErr = errors.New("try re-planning due to lagging restore processors")
+
+// getDescRefs reads the RestoreDescRefs proto stored at the given info-key for
+// the given restore job. Returns (nil, false, nil) when the key is absent.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func getDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, infoKey string,
+) ([]backuppb.RestoreDescRef, bool, error) {
+	raw, ok, err := jobs.InfoStorageForJob(txn, jobID).Get(ctx, "restore-desc-refs", infoKey)
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	var msg backuppb.RestoreDescRefs
+	if err := protoutil.Unmarshal(raw, &msg); err != nil {
+		return nil, false, errors.Wrap(err, "decoding restore desc refs")
+	}
+	return msg.Refs, true, nil
+}
+
+// writeDescRefs marshals refs as a RestoreDescRefs proto and writes it to the
+// given info-key for the restore job.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func writeDescRefs(
+	ctx context.Context,
+	txn isql.Txn,
+	jobID jobspb.JobID,
+	infoKey string,
+	refs []backuppb.RestoreDescRef,
+) error {
+	bytes, err := protoutil.Marshal(&backuppb.RestoreDescRefs{Refs: refs})
+	if err != nil {
+		return errors.Wrap(err, "encoding restore desc refs")
+	}
+	return jobs.InfoStorageForJob(txn, jobID).Write(ctx, infoKey, bytes)
+}
+
+// tableDescRefs returns (ID, Version) tuples for tables this restore job is
+// materializing. Prefers the dedicated info-key row; falls back to the legacy
+// details.TableDescs slice for jobs created before info-key writes existed.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func tableDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
+) ([]backuppb.RestoreDescRef, error) {
+	refs, ok, err := getDescRefs(ctx, txn, jobID, restoreTableDescRefsKey)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return refs, nil
+	}
+	out := make([]backuppb.RestoreDescRef, len(details.TableDescs))
+	for i, d := range details.TableDescs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out, nil
+}
+
+// typeDescRefs is the type-descriptor analog of tableDescRefs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func typeDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
+) ([]backuppb.RestoreDescRef, error) {
+	refs, ok, err := getDescRefs(ctx, txn, jobID, restoreTypeDescRefsKey)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return refs, nil
+	}
+	out := make([]backuppb.RestoreDescRef, len(details.TypeDescs))
+	for i, d := range details.TypeDescs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out, nil
+}
+
+// schemaDescRefs is the schema-descriptor analog of tableDescRefs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func schemaDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
+) ([]backuppb.RestoreDescRef, error) {
+	refs, ok, err := getDescRefs(ctx, txn, jobID, restoreSchemaDescRefsKey)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return refs, nil
+	}
+	out := make([]backuppb.RestoreDescRef, len(details.SchemaDescs))
+	for i, d := range details.SchemaDescs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out, nil
+}
+
+// databaseDescRefs is the database-descriptor analog of tableDescRefs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func databaseDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
+) ([]backuppb.RestoreDescRef, error) {
+	refs, ok, err := getDescRefs(ctx, txn, jobID, restoreDatabaseDescRefsKey)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return refs, nil
+	}
+	out := make([]backuppb.RestoreDescRef, len(details.DatabaseDescs))
+	for i, d := range details.DatabaseDescs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out, nil
+}
+
+// functionDescRefs is the function-descriptor analog of tableDescRefs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func functionDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
+) ([]backuppb.RestoreDescRef, error) {
+	refs, ok, err := getDescRefs(ctx, txn, jobID, restoreFunctionDescRefsKey)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return refs, nil
+	}
+	out := make([]backuppb.RestoreDescRef, len(details.FunctionDescs))
+	for i, d := range details.FunctionDescs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out, nil
+}
+
+// allDescRefs returns (ID, Version) tuples for every descriptor this restore
+// job is materializing — tables, types, schemas, databases, and functions —
+// suitable for a single batched MutableByID().Descs fetch.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func allDescRefs(
+	ctx context.Context, txn isql.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
+) ([]backuppb.RestoreDescRef, error) {
+	tables, err := tableDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return nil, err
+	}
+	types, err := typeDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return nil, err
+	}
+	schemas, err := schemaDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return nil, err
+	}
+	databases, err := databaseDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return nil, err
+	}
+	functions, err := functionDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]backuppb.RestoreDescRef, 0,
+		len(tables)+len(types)+len(schemas)+len(databases)+len(functions))
+	out = append(out, tables...)
+	out = append(out, types...)
+	out = append(out, schemas...)
+	out = append(out, databases...)
+	out = append(out, functions...)
+	return out, nil
+}
 
 // rewriteBackupSpanKey rewrites a backup span start key for the purposes of
 // splitting up the target key-space to send out the actual work of restoring.

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -292,6 +292,42 @@ func restoredTableDescs(offlineDescs nstree.Catalog) []catalog.TableDescriptor {
 	return tables
 }
 
+// restoredTableIDs returns the IDs of all table descriptors in offlineDescs.
+func restoredTableIDs(offlineDescs nstree.Catalog) []descpb.ID {
+	tables := restoredTableDescs(offlineDescs)
+	ids := make([]descpb.ID, 0, len(tables))
+	for _, table := range tables {
+		ids = append(ids, table.GetID())
+	}
+	return ids
+}
+
+// restoredDatabaseIDs returns the IDs of all database descriptors in
+// offlineDescs.
+func restoredDatabaseIDs(offlineDescs nstree.Catalog) []descpb.ID {
+	all := offlineDescs.OrderedDescriptors()
+	ids := make([]descpb.ID, 0, len(all))
+	for _, desc := range all {
+		if _, ok := desc.(catalog.DatabaseDescriptor); ok {
+			ids = append(ids, desc.GetID())
+		}
+	}
+	return ids
+}
+
+// hasRestoredDatabases reports whether offlineDescs contains any database
+// descriptors.
+func hasRestoredDatabases(offlineDescs nstree.Catalog) bool {
+	found := false
+	_ = offlineDescs.ForEachDescriptor(func(desc catalog.Descriptor) error {
+		if _, ok := desc.(catalog.DatabaseDescriptor); ok {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
 // tableDescRefs returns (ID, Version) tuples for tables this restore job is
 // materializing. Prefers the dedicated info-key row; falls back to the legacy
 // details.TableDescs slice for jobs created before info-key writes existed.
@@ -2449,6 +2485,7 @@ func protectRestoreTargets(
 	execCfg *sql.ExecutorConfig,
 	job *jobs.Job,
 	details jobspb.RestoreDetails,
+	offlineDescs nstree.Catalog,
 	tenantRekeys []execinfrapb.TenantRekey,
 ) (jobsprotectedts.Cleaner, error) {
 	if details.ProtectedTimestampRecord != nil {
@@ -2473,20 +2510,12 @@ func protectRestoreTargets(
 			tenantIDs = append(tenantIDs, tenant.NewID)
 		}
 		target = ptpb.MakeTenantsTarget(tenantIDs)
-	case len(details.DatabaseDescs) > 0:
+	case hasRestoredDatabases(offlineDescs):
 		// During database restores, protect whole databases.
-		databaseIDs := make([]descpb.ID, 0, len(details.DatabaseDescs))
-		for i := range details.DatabaseDescs {
-			databaseIDs = append(databaseIDs, details.DatabaseDescs[i].GetID())
-		}
-		target = ptpb.MakeSchemaObjectsTarget(databaseIDs)
+		target = ptpb.MakeSchemaObjectsTarget(restoredDatabaseIDs(offlineDescs))
 	default:
 		// Else, protect individual tables.
-		tableIDs := make([]descpb.ID, 0, len(details.TableDescs))
-		for i := range details.TableDescs {
-			tableIDs = append(tableIDs, details.TableDescs[i].GetID())
-		}
-		target = ptpb.MakeSchemaObjectsTarget(tableIDs)
+		target = ptpb.MakeSchemaObjectsTarget(restoredTableIDs(offlineDescs))
 	}
 	// Set the PTS with a timestamp less than any upcoming batch request
 	// timestamps from future addSSTable requests. This ensures that a target's
@@ -2642,7 +2671,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		ctx context.Context, txn descs.Txn,
 	) error {
 		var err error
-		offlineDescs, err = prefetchDescriptors(ctx, txn.KV(), txn.Descriptors(), details)
+		offlineDescs, err = prefetchDescriptors(ctx, txn, r.job.ID(), details)
 		return err
 	}); err != nil {
 		return err
@@ -2692,7 +2721,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 			err.Error())
 	}
 
-	if len(details.TableDescs) == 0 && len(details.Tenants) == 0 {
+	if len(restoredTableDescs(offlineDescs)) == 0 && len(details.Tenants) == 0 {
 		// We have no tables to restore (we are restoring an empty DB).
 		// Since we have already created any new databases that we needed,
 		// we can return without importing any data.
@@ -2724,7 +2753,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		return nil
 	}
 
-	_, err = protectRestoreTargets(ctx, p.ExecCfg(), r.job, details, mainData.getTenantRekeys())
+	_, err = protectRestoreTargets(
+		ctx, p.ExecCfg(), r.job, details, offlineDescs, mainData.getTenantRekeys(),
+	)
 	if err != nil {
 		return err
 	}
@@ -2877,7 +2908,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 
 	if !build.IsRelease() && !details.RevisionLogTimestamp.IsEmpty() {
 		if err := restorerevlog.RestoreFromRevisionLog(
-			ctx, p, r.job, r.execCfg,
+			ctx, p, r.job, r.execCfg, restoredTableDescs(offlineDescs),
 		); err != nil {
 			return errors.Wrap(err, "restoring from revision log")
 		}
@@ -3052,15 +3083,28 @@ func isSystemUserRestore(details jobspb.RestoreDetails) bool {
 
 // ReportResults implements JobResultsReporter interface.
 func (r *restoreResumer) ReportResults(ctx context.Context, resultsCh chan<- tree.Datums) error {
+	details := r.job.Details().(jobspb.RestoreDetails)
+	var numTables int
+	if details.OnlineImpl() {
+		if err := r.execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			refs, err := tableDescRefs(ctx, txn, r.job.ID(), details)
+			if err != nil {
+				return err
+			}
+			numTables = len(refs)
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case resultsCh <- func() tree.Datums {
-		details := r.job.Details().(jobspb.RestoreDetails)
 		if details.OnlineImpl() {
 			return tree.Datums{
 				tree.NewDInt(tree.DInt(r.job.ID())),
-				tree.NewDInt(tree.DInt(len(details.TableDescs))),
+				tree.NewDInt(tree.DInt(numTables)),
 				tree.NewDInt(tree.DInt(r.restoreStats.Rows)),
 				tree.NewDInt(tree.DInt(r.restoreStats.DataSize)),
 				tree.NewDInt(tree.DInt(r.downloadJobID)),
@@ -3423,7 +3467,7 @@ func (r *restoreResumer) publishDescriptors(
 
 	// Pre-fetch all the descriptors into the collection to avoid doing
 	// round-trips per descriptor.
-	all, err := prefetchDescriptors(ctx, txn.KV(), txn.Descriptors(), details)
+	all, err := prefetchDescriptors(ctx, txn, r.job.ID(), details)
 	if err != nil {
 		return err
 	}
@@ -3436,12 +3480,33 @@ func (r *restoreResumer) publishDescriptors(
 		return err
 	}
 
+	tableRefs, err := tableDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	typeRefs, err := typeDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	schemaRefs, err := schemaDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	databaseRefs, err := databaseDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	functionRefs, err := functionDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+
 	// Create slices of raw descriptors for the restore job details.
-	newTables := make([]*descpb.TableDescriptor, 0, len(details.TableDescs))
-	newTypes := make([]*descpb.TypeDescriptor, 0, len(details.TypeDescs))
-	newSchemas := make([]*descpb.SchemaDescriptor, 0, len(details.SchemaDescs))
-	newDBs := make([]*descpb.DatabaseDescriptor, 0, len(details.DatabaseDescs))
-	newFunctions := make([]*descpb.FunctionDescriptor, 0, len(details.FunctionDescs))
+	newTables := make([]*descpb.TableDescriptor, 0, len(tableRefs))
+	newTypes := make([]*descpb.TypeDescriptor, 0, len(typeRefs))
+	newSchemas := make([]*descpb.SchemaDescriptor, 0, len(schemaRefs))
+	newDBs := make([]*descpb.DatabaseDescriptor, 0, len(databaseRefs))
+	newFunctions := make([]*descpb.FunctionDescriptor, 0, len(functionRefs))
 
 	// Go through the descriptors and find any declarative schema change jobs
 	// affecting them.
@@ -3453,23 +3518,24 @@ func (r *restoreResumer) publishDescriptors(
 
 	var tableAutoStatsSettings map[uint32]*catpb.AutoStatsSettings
 	if details.ExperimentalOnline {
-		tableAutoStatsSettings = make(map[uint32]*catpb.AutoStatsSettings, len(details.TableDescs))
+		tableAutoStatsSettings = make(map[uint32]*catpb.AutoStatsSettings, len(tableRefs))
 	}
 
 	// Write the new TableDescriptors and flip state over to public so they can be
 	// accessed.
-	for i := range details.TableDescs {
-		desc := all.LookupDescriptor(details.TableDescs[i].GetID())
+	for _, ref := range tableRefs {
+		desc := all.LookupDescriptor(ref.ID)
 		mutTable := desc.(*tabledesc.Mutable)
 
 		if details.ExperimentalOnline && mutTable.IsTable() {
+			// Preserve the backed up table stats so the download job re-enables
+			// them; do this before clobbering mutTable.AutoStatsSettings below.
+			tableAutoStatsSettings[uint32(ref.ID)] = mutTable.AutoStatsSettings
+
 			// We disable automatic stats refresh on all restored tables until the
 			// download job finishes.
 			boolean := false
 			mutTable.AutoStatsSettings = &catpb.AutoStatsSettings{Enabled: &boolean}
-
-			// Preserve the backed up table stats so the download job re-enables them
-			tableAutoStatsSettings[uint32(details.TableDescs[i].ID)] = details.TableDescs[i].AutoStatsSettings
 		}
 
 		// Note that we don't need to worry about the re-validated indexes for descriptors
@@ -3524,8 +3590,8 @@ func (r *restoreResumer) publishDescriptors(
 	}
 	// For all of the newly created types, make type schema change jobs for any
 	// type descriptors that were backed up in the middle of a type schema change.
-	for i := range details.TypeDescs {
-		typ := all.LookupDescriptor(details.TypeDescs[i].GetID()).(catalog.TypeDescriptor)
+	for _, ref := range typeRefs {
+		typ := all.LookupDescriptor(ref.ID).(catalog.TypeDescriptor)
 		newTypes = append(newTypes, typ.TypeDesc())
 		if typ.GetDeclarativeSchemaChangerState() == nil &&
 			typ.HasPendingSchemaChanges() {
@@ -3536,16 +3602,16 @@ func (r *restoreResumer) publishDescriptors(
 			}
 		}
 	}
-	for i := range details.SchemaDescs {
-		sc := all.LookupDescriptor(details.SchemaDescs[i].GetID()).(catalog.SchemaDescriptor)
+	for _, ref := range schemaRefs {
+		sc := all.LookupDescriptor(ref.ID).(catalog.SchemaDescriptor)
 		newSchemas = append(newSchemas, sc.SchemaDesc())
 	}
-	for i := range details.DatabaseDescs {
-		db := all.LookupDescriptor(details.DatabaseDescs[i].GetID()).(catalog.DatabaseDescriptor)
+	for _, ref := range databaseRefs {
+		db := all.LookupDescriptor(ref.ID).(catalog.DatabaseDescriptor)
 		newDBs = append(newDBs, db.DatabaseDesc())
 	}
-	for i := range details.FunctionDescs {
-		fn := all.LookupDescriptor(details.FunctionDescs[i].GetID()).(catalog.FunctionDescriptor)
+	for _, ref := range functionRefs {
+		fn := all.LookupDescriptor(ref.ID).(catalog.FunctionDescriptor)
 		newFunctions = append(newFunctions, fn.FuncDesc())
 	}
 
@@ -3682,38 +3748,25 @@ func (r *restoreResumer) publishDescriptors(
 // This function also takes care of asserting that the retrieved version
 // matches the expectation.
 func prefetchDescriptors(
-	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, details jobspb.RestoreDetails,
+	ctx context.Context, txn descs.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
 ) (_ nstree.Catalog, _ error) {
+	refs, err := allDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return nstree.Catalog{}, err
+	}
 	var all nstree.MutableCatalog
 	var allDescIDs catalog.DescriptorIDSet
 	expVersion := map[descpb.ID]descpb.DescriptorVersion{}
-	for i := range details.TableDescs {
-		expVersion[details.TableDescs[i].GetID()] = details.TableDescs[i].GetVersion()
-		allDescIDs.Add(details.TableDescs[i].GetID())
-	}
-	for i := range details.TypeDescs {
-		expVersion[details.TypeDescs[i].GetID()] = details.TypeDescs[i].GetVersion()
-		allDescIDs.Add(details.TypeDescs[i].GetID())
-	}
-	for i := range details.SchemaDescs {
-		expVersion[details.SchemaDescs[i].GetID()] = details.SchemaDescs[i].GetVersion()
-		allDescIDs.Add(details.SchemaDescs[i].GetID())
-	}
-	for i := range details.DatabaseDescs {
-		expVersion[details.DatabaseDescs[i].GetID()] = details.DatabaseDescs[i].GetVersion()
-		allDescIDs.Add(details.DatabaseDescs[i].GetID())
-	}
-	for i := range details.FunctionDescs {
-		expVersion[details.FunctionDescs[i].GetID()] = details.FunctionDescs[i].GetVersion()
-		allDescIDs.Add(details.FunctionDescs[i].GetID())
+	for _, ref := range refs {
+		expVersion[ref.ID] = ref.Version
+		allDescIDs.Add(ref.ID)
 	}
 	// Note that no maximum size is put on the batch here because,
-	// in general, we assume that we can fit all of the descriptors
-	// in RAM (we have them in RAM as part of the details object,
-	// and we're going to write them to KV very soon as part of a
-	// single batch).
+	// in general, we assume that we can fit all of the descriptors in
+	// RAM. We have them in RAM as part of building the catalog, and
+	// we're about to write them to KV in a single batch.
 	ids := allDescIDs.Ordered()
-	got, err := descsCol.MutableByID(txn).Descs(ctx, ids)
+	got, err := txn.Descriptors().MutableByID(txn.KV()).Descs(ctx, ids)
 	if err != nil {
 		return nstree.Catalog{}, errors.Wrap(err, "prefetch descriptors")
 	}
@@ -3937,11 +3990,36 @@ func (r *restoreResumer) dropDescriptors(
 		return nil
 	}
 
+	tableRefs, err := tableDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	typeRefs, err := typeDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	schemaRefs, err := schemaDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	databaseRefs, err := databaseDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	functionRefs, err := functionDescRefs(ctx, txn, r.job.ID(), details)
+	if err != nil {
+		return err
+	}
+	restoredTypeIDs := make(map[descpb.ID]struct{}, len(typeRefs))
+	for _, ref := range typeRefs {
+		restoredTypeIDs[ref.ID] = struct{}{}
+	}
+
 	b := txn.KV().NewBatch()
 	const kvTrace = false
 	// Collect the tables into mutable versions.
 	mutableTables, err := getUndroppedTablesFromRestore(
-		ctx, txn.KV(), details, descsCol,
+		ctx, txn.KV(), tableRefs, descsCol,
 	)
 	if err != nil {
 		return errors.Wrap(err, "getting mutable tables from restore")
@@ -3951,20 +4029,20 @@ func (r *restoreResumer) dropDescriptors(
 	// descriptors have already been published, then there's nothing to fuss
 	// about so we only do this check if they have not been published.
 	if !details.DescriptorsPublished {
-		if err := checkRestoredTableDescriptorVersions(details, mutableTables); err != nil {
+		if err := checkRestoredTableDescriptorVersions(tableRefs, mutableTables); err != nil {
 			log.Dev.Errorf(ctx, "table version mismatch during drop: %v", err)
 		}
 	}
 
 	// Remove any back references installed from existing types to tables being restored.
 	if err := r.removeExistingTypeBackReferences(
-		ctx, txn.KV(), descsCol, b, mutableTables, &details,
+		ctx, txn.KV(), descsCol, b, mutableTables, restoredTypeIDs,
 	); err != nil {
 		return err
 	}
 
 	// Drop the table descriptors that were created at the start of the restore.
-	tablesToGC := make([]descpb.ID, 0, len(details.TableDescs))
+	tablesToGC := make([]descpb.ID, 0, len(tableRefs))
 	// Set the drop time as 1 (ns in Unix time), so that the table gets GC'd
 	// immediately.
 	dropTime := int64(1)
@@ -4024,11 +4102,10 @@ func (r *restoreResumer) dropDescriptors(
 	}
 
 	// Drop the type descriptors that this restore created.
-	for i := range details.TypeDescs {
+	for _, ref := range typeRefs {
 		// TypeDescriptors don't have a GC job process, so we can just write them
 		// as dropped here.
-		typDesc := details.TypeDescs[i]
-		mutType, err := descsCol.MutableByID(txn.KV()).Desc(ctx, typDesc.ID)
+		mutType, err := descsCol.MutableByID(txn.KV()).Desc(ctx, ref.ID)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				continue
@@ -4044,21 +4121,20 @@ func (r *restoreResumer) dropDescriptors(
 			ctx,
 			kvTrace,
 			b,
-			catalogkeys.MakeCommentKey(uint32(typDesc.ID), 0, catalogkeys.TypeCommentType)); err != nil {
+			catalogkeys.MakeCommentKey(uint32(ref.ID), 0, catalogkeys.TypeCommentType)); err != nil {
 			return err
 		}
 
-		if err := descsCol.DeleteNamespaceEntryToBatch(ctx, kvTrace, typDesc, b); err != nil {
+		if err := descsCol.DeleteNamespaceEntryToBatch(ctx, kvTrace, mutType, b); err != nil {
 			return err
 		}
-		if err := descsCol.DeleteDescToBatch(ctx, kvTrace, typDesc.GetID(), b); err != nil {
+		if err := descsCol.DeleteDescToBatch(ctx, kvTrace, ref.ID, b); err != nil {
 			return err
 		}
 	}
 
-	for i := range details.FunctionDescs {
-		fnDesc := details.FunctionDescs[i]
-		mutFn, err := descsCol.MutableByID(txn.KV()).Desc(ctx, fnDesc.ID)
+	for _, ref := range functionRefs {
+		mutFn, err := descsCol.MutableByID(txn.KV()).Desc(ctx, ref.ID)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				continue
@@ -4069,7 +4145,7 @@ func (r *restoreResumer) dropDescriptors(
 			continue
 		}
 		mutFn.SetDropped()
-		if err := descsCol.DeleteDescToBatch(ctx, kvTrace, fnDesc.ID, b); err != nil {
+		if err := descsCol.DeleteDescToBatch(ctx, kvTrace, ref.ID, b); err != nil {
 			return err
 		}
 	}
@@ -4098,17 +4174,17 @@ func (r *restoreResumer) dropDescriptors(
 	// the restore if they are now empty (i.e. no user created a table, etc. in
 	// the database or schema during the restore).
 	ignoredChildDescIDs := make(map[descpb.ID]struct{})
-	for _, table := range details.TableDescs {
-		ignoredChildDescIDs[table.ID] = struct{}{}
+	for _, ref := range tableRefs {
+		ignoredChildDescIDs[ref.ID] = struct{}{}
 	}
-	for _, typ := range details.TypeDescs {
-		ignoredChildDescIDs[typ.ID] = struct{}{}
+	for _, ref := range typeRefs {
+		ignoredChildDescIDs[ref.ID] = struct{}{}
 	}
-	for _, schema := range details.SchemaDescs {
-		ignoredChildDescIDs[schema.ID] = struct{}{}
+	for _, ref := range schemaRefs {
+		ignoredChildDescIDs[ref.ID] = struct{}{}
 	}
-	for _, fn := range details.FunctionDescs {
-		ignoredChildDescIDs[fn.ID] = struct{}{}
+	for _, ref := range functionRefs {
+		ignoredChildDescIDs[ref.ID] = struct{}{}
 	}
 	all, err := descsCol.GetAllDescriptors(ctx, txn.KV())
 	if err != nil {
@@ -4124,19 +4200,19 @@ func (r *restoreResumer) dropDescriptors(
 	}
 
 	dbsWithDeletedSchemas := make(map[descpb.ID]dbWithDeletedSchemas)
-	for _, schemaDesc := range details.SchemaDescs {
+	for _, ref := range schemaRefs {
 		// We need to ignore descriptors we just added since we haven't committed the txn that deletes these.
-		isSchemaEmpty, err := isSchemaEmpty(ctx, txn.KV(), schemaDesc.GetID(), allDescs, ignoredChildDescIDs)
+		isSchemaEmpty, err := isSchemaEmpty(ctx, txn.KV(), ref.ID, allDescs, ignoredChildDescIDs)
 		if err != nil {
-			return errors.Wrapf(err, "checking if schema %s is empty during restore cleanup", schemaDesc.GetName())
+			return errors.Wrapf(err, "checking if schema %d is empty during restore cleanup", ref.ID)
 		}
 
 		if !isSchemaEmpty {
-			log.Dev.Warningf(ctx, "preserving schema %s on restore failure because it contains new child objects", schemaDesc.GetName())
+			log.Dev.Warningf(ctx, "preserving schema %d on restore failure because it contains new child objects", ref.ID)
 			continue
 		}
 
-		mutSchema, err := descsCol.MutableByID(txn.KV()).Desc(ctx, schemaDesc.GetID())
+		mutSchema, err := descsCol.MutableByID(txn.KV()).Desc(ctx, ref.ID)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				continue
@@ -4146,9 +4222,9 @@ func (r *restoreResumer) dropDescriptors(
 		if mutSchema.Dropped() {
 			continue
 		}
-		entry, hasEntry := dbsWithDeletedSchemas[schemaDesc.GetParentID()]
+		entry, hasEntry := dbsWithDeletedSchemas[mutSchema.GetParentID()]
 		if !hasEntry {
-			mutParent, err := descsCol.MutableByID(txn.KV()).Desc(ctx, schemaDesc.GetParentID())
+			mutParent, err := descsCol.MutableByID(txn.KV()).Desc(ctx, mutSchema.GetParentID())
 			if err != nil {
 				return err
 			}
@@ -4159,7 +4235,7 @@ func (r *restoreResumer) dropDescriptors(
 			ctx,
 			kvTrace,
 			b,
-			catalogkeys.MakeCommentKey(uint32(schemaDesc.GetID()), 0, catalogkeys.SchemaCommentType)); err != nil {
+			catalogkeys.MakeCommentKey(uint32(ref.ID), 0, catalogkeys.SchemaCommentType)); err != nil {
 			return err
 		}
 
@@ -4178,14 +4254,14 @@ func (r *restoreResumer) dropDescriptors(
 		}
 
 		// Remove the back-reference to the deleted schema in the parent database.
-		if schemaInfo, ok := entry.db.Schemas[schemaDesc.GetName()]; !ok {
+		if schemaInfo, ok := entry.db.Schemas[mutSchema.GetName()]; !ok {
 			log.Dev.Warningf(ctx, "unexpected missing schema entry for %s from db %d; skipping deletion",
-				schemaDesc.GetName(), entry.db.GetID())
-		} else if schemaInfo.ID != schemaDesc.GetID() {
+				mutSchema.GetName(), entry.db.GetID())
+		} else if schemaInfo.ID != mutSchema.GetID() {
 			log.Dev.Warningf(ctx, "unexpected schema entry %d for %s from db %d, expecting %d; skipping deletion",
-				schemaInfo.ID, schemaDesc.GetName(), entry.db.GetID(), schemaDesc.GetID())
+				schemaInfo.ID, mutSchema.GetName(), entry.db.GetID(), mutSchema.GetID())
 		} else {
-			delete(entry.db.Schemas, schemaDesc.GetName())
+			delete(entry.db.Schemas, mutSchema.GetName())
 		}
 
 		entry.schemas = append(entry.schemas, mutSchema)
@@ -4215,19 +4291,19 @@ func (r *restoreResumer) dropDescriptors(
 	// that no batch requests are queued after the `b.Del` to delete the dropped
 	// database descriptor.
 	deletedDBs := make(map[descpb.ID]struct{})
-	for _, dbDesc := range details.DatabaseDescs {
+	for _, ref := range databaseRefs {
 
 		// We need to ignore descriptors we just added since we haven't committed the txn that deletes these.
-		isDBEmpty, err := isDatabaseEmpty(ctx, txn.KV(), dbDesc.GetID(), allDescs, ignoredChildDescIDs)
+		isDBEmpty, err := isDatabaseEmpty(ctx, txn.KV(), ref.ID, allDescs, ignoredChildDescIDs)
 		if err != nil {
-			return errors.Wrapf(err, "checking if database %s is empty during restore cleanup", dbDesc.GetName())
+			return errors.Wrapf(err, "checking if database %d is empty during restore cleanup", ref.ID)
 		}
 		if !isDBEmpty {
-			log.Dev.Warningf(ctx, "preserving database %s on restore failure because it contains new child objects or schemas", dbDesc.GetName())
+			log.Dev.Warningf(ctx, "preserving database %d on restore failure because it contains new child objects or schemas", ref.ID)
 			continue
 		}
 
-		db, err := descsCol.MutableByID(txn.KV()).Desc(ctx, dbDesc.GetID())
+		db, err := descsCol.MutableByID(txn.KV()).Desc(ctx, ref.ID)
 		if err != nil {
 			if errors.Is(err, catalog.ErrDescriptorNotFound) {
 				continue
@@ -4256,7 +4332,7 @@ func (r *restoreResumer) dropDescriptors(
 			ctx,
 			kvTrace,
 			b,
-			catalogkeys.MakeCommentKey(uint32(dbDesc.GetID()), 0, catalogkeys.DatabaseCommentType)); err != nil {
+			catalogkeys.MakeCommentKey(uint32(ref.ID), 0, catalogkeys.DatabaseCommentType)); err != nil {
 			return err
 		}
 
@@ -4297,28 +4373,18 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 	descsCol *descs.Collection,
 	b *kv.Batch,
 	restoredTables []*tabledesc.Mutable,
-	details *jobspb.RestoreDetails,
+	restoredTypeIDs map[descpb.ID]struct{},
 ) error {
-	// We first collect the restored types to be addressable by ID.
-	restoredTypes := make(map[descpb.ID]catalog.TypeDescriptor)
 	existingTypes := make(map[descpb.ID]*typedesc.Mutable)
-	for i := range details.TypeDescs {
-		typ := details.TypeDescs[i]
-		restoredTypes[typ.ID] = typedesc.NewBuilder(typ).BuildImmutableType()
-	}
 	for _, tbl := range restoredTables {
 		lookup := func(id descpb.ID) (catalog.TypeDescriptor, error) {
-			// First see if the type was restored.
-			restored, ok := restoredTypes[id]
-			if ok {
-				return restored, nil
-			}
-			// Finally, look it up using the transaction.
 			typ, err := descsCol.MutableByID(txn).Type(ctx, id)
 			if err != nil {
 				return nil, err
 			}
-			existingTypes[typ.GetID()] = typ
+			if _, restored := restoredTypeIDs[id]; !restored {
+				existingTypes[typ.GetID()] = typ
+			}
 			return typ, nil
 		}
 
@@ -4335,16 +4401,16 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 
 		// For each type that is existing, remove the backreference from tbl.
 		for _, id := range referencedTypes {
-			_, restored := restoredTypes[id]
-			if !restored {
-				desc, err := lookup(id)
-				if err != nil {
-					return err
-				}
-				existing := desc.(*typedesc.Mutable)
-				existing.MaybeIncrementVersion()
-				_ = existing.RemoveReferencingDescriptorID(tbl.ID)
+			if _, restored := restoredTypeIDs[id]; restored {
+				continue
 			}
+			desc, err := lookup(id)
+			if err != nil {
+				return err
+			}
+			existing := desc.(*typedesc.Mutable)
+			existing.MaybeIncrementVersion()
+			_ = existing.RemoveReferencingDescriptorID(tbl.ID)
 		}
 	}
 
@@ -4625,11 +4691,11 @@ func (r *restoreResumer) maybeCleanupTempSystemDB(ctx context.Context) error {
 // database and dropped but attempting to load those temporary tables again
 // would result in an error.
 func getUndroppedTablesFromRestore(
-	ctx context.Context, txn *kv.Txn, details jobspb.RestoreDetails, descCol *descs.Collection,
+	ctx context.Context, txn *kv.Txn, tableRefs []backuppb.RestoreDescRef, descCol *descs.Collection,
 ) ([]*tabledesc.Mutable, error) {
 	var tables []*tabledesc.Mutable
-	for _, desc := range details.TableDescs {
-		mutableTable, err := descCol.MutableByID(txn).Table(ctx, desc.ID)
+	for _, ref := range tableRefs {
+		mutableTable, err := descCol.MutableByID(txn).Table(ctx, ref.ID)
 		if err != nil {
 			if pgerror.GetPGCode(err) == pgcode.UndefinedTable {
 				continue
@@ -4649,11 +4715,11 @@ func getUndroppedTablesFromRestore(
 // error if any of the restored tables have a version that does not match the
 // version that was recorded at the time of restore in the job details.
 func checkRestoredTableDescriptorVersions(
-	details jobspb.RestoreDetails, restoredTables []*tabledesc.Mutable,
+	tableRefs []backuppb.RestoreDescRef, restoredTables []*tabledesc.Mutable,
 ) error {
 	versionsAtRestoreTime := make(map[descpb.ID]descpb.DescriptorVersion)
-	for _, desc := range details.TableDescs {
-		versionsAtRestoreTime[desc.ID] = desc.Version
+	for _, ref := range tableRefs {
+		versionsAtRestoreTime[ref.ID] = ref.Version
 	}
 	for _, table := range restoredTables {
 		if expVersion, ok := versionsAtRestoreTime[table.GetID()]; ok {

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -215,6 +215,66 @@ func writeDescRefs(
 	return jobs.InfoStorageForJob(txn, jobID).Write(ctx, infoKey, bytes)
 }
 
+// descRefsFromTableDescs extracts (ID, Version) tuples from a table-descriptor
+// slice for persisting via writeDescRefs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func descRefsFromTableDescs(descs []*descpb.TableDescriptor) []backuppb.RestoreDescRef {
+	out := make([]backuppb.RestoreDescRef, len(descs))
+	for i, d := range descs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out
+}
+
+// descRefsFromTypeDescs is the type-descriptor analog of
+// descRefsFromTableDescs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func descRefsFromTypeDescs(descs []*descpb.TypeDescriptor) []backuppb.RestoreDescRef {
+	out := make([]backuppb.RestoreDescRef, len(descs))
+	for i, d := range descs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out
+}
+
+// descRefsFromSchemaDescs is the schema-descriptor analog of
+// descRefsFromTableDescs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func descRefsFromSchemaDescs(descs []*descpb.SchemaDescriptor) []backuppb.RestoreDescRef {
+	out := make([]backuppb.RestoreDescRef, len(descs))
+	for i, d := range descs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out
+}
+
+// descRefsFromDatabaseDescs is the database-descriptor analog of
+// descRefsFromTableDescs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func descRefsFromDatabaseDescs(descs []*descpb.DatabaseDescriptor) []backuppb.RestoreDescRef {
+	out := make([]backuppb.RestoreDescRef, len(descs))
+	for i, d := range descs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out
+}
+
+// descRefsFromFunctionDescs is the function-descriptor analog of
+// descRefsFromTableDescs.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func descRefsFromFunctionDescs(descs []*descpb.FunctionDescriptor) []backuppb.RestoreDescRef {
+	out := make([]backuppb.RestoreDescRef, len(descs))
+	for i, d := range descs {
+		out[i] = backuppb.RestoreDescRef{ID: d.ID, Version: d.Version}
+	}
+	return out
+}
+
 // tableDescRefs returns (ID, Version) tuples for tables this restore job is
 // materializing. Prefers the dedicated info-key row; falls back to the legacy
 // details.TableDescs slice for jobs created before info-key writes existed.
@@ -2266,6 +2326,36 @@ func createImportingDescriptors(
 			details.FunctionDescs[i] = fn.FuncDesc()
 		}
 
+		// Dual-write each descriptor type's (ID, Version) tuples to a
+		// dedicated system.job_info row alongside the legacy slice
+		// population above. The info-key rows are the long-term source of
+		// truth — later phases of the restore fetch descriptor bodies from
+		// KV by ID rather than relying on the full payloads on
+		// RestoreDetails — but the legacy slices remain populated here for
+		// mixed-version compatibility. A later commit gates the legacy
+		// writes off once the cluster has crossed the corresponding
+		// cluster version.
+		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTableDescRefsKey,
+			descRefsFromTableDescs(details.TableDescs)); err != nil {
+			return err
+		}
+		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTypeDescRefsKey,
+			descRefsFromTypeDescs(details.TypeDescs)); err != nil {
+			return err
+		}
+		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreSchemaDescRefsKey,
+			descRefsFromSchemaDescs(details.SchemaDescs)); err != nil {
+			return err
+		}
+		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreDatabaseDescRefsKey,
+			descRefsFromDatabaseDescs(details.DatabaseDescs)); err != nil {
+			return err
+		}
+		if err := writeDescRefs(ctx, txn, r.job.ID(), restoreFunctionDescRefsKey,
+			descRefsFromFunctionDescs(details.FunctionDescs)); err != nil {
+			return err
+		}
+
 		// Update the job once all descs have been prepared for ingestion.
 		//
 		//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
@@ -3504,6 +3594,31 @@ func (r *restoreResumer) publishDescriptors(
 	details.FunctionDescs = newFunctions
 	if details.OnlineImpl() {
 		details.PostDownloadTableAutoStatsSettings = tableAutoStatsSettings
+	}
+	// Dual-write the published (ID, Version) tuples to the dedicated
+	// info-key rows alongside the legacy slice updates above. See the
+	// matching block in createImportingDescriptors for the rationale; a
+	// later commit gates the legacy writes off once the cluster has
+	// crossed the corresponding cluster version.
+	if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTableDescRefsKey,
+		descRefsFromTableDescs(newTables)); err != nil {
+		return err
+	}
+	if err := writeDescRefs(ctx, txn, r.job.ID(), restoreTypeDescRefsKey,
+		descRefsFromTypeDescs(newTypes)); err != nil {
+		return err
+	}
+	if err := writeDescRefs(ctx, txn, r.job.ID(), restoreSchemaDescRefsKey,
+		descRefsFromSchemaDescs(newSchemas)); err != nil {
+		return err
+	}
+	if err := writeDescRefs(ctx, txn, r.job.ID(), restoreDatabaseDescRefsKey,
+		descRefsFromDatabaseDescs(newDBs)); err != nil {
+		return err
+	}
+	if err := writeDescRefs(ctx, txn, r.job.ID(), restoreFunctionDescRefsKey,
+		descRefsFromFunctionDescs(newFunctions)); err != nil {
+		return err
 	}
 	//lint:ignore SA1019 TODO: migrate to job_info_storage.go API
 	if err := r.job.DeprecatedWithTxn(txn).SetDetails(ctx, details); err != nil {

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -275,6 +275,23 @@ func descRefsFromFunctionDescs(descs []*descpb.FunctionDescriptor) []backuppb.Re
 	return out
 }
 
+// restoredTableDescs returns the table descriptors from offlineDescs, the
+// catalog hoisted into doResume right after createImportingDescriptors, in
+// stable ID order. The order matches the historical iteration over
+// details.TableDescs closely enough for the consumers that walk the result
+// today (rekey list, pkIDs, missing-stats warning), none of which rely on
+// a specific order.
+func restoredTableDescs(offlineDescs nstree.Catalog) []catalog.TableDescriptor {
+	all := offlineDescs.OrderedDescriptors()
+	tables := make([]catalog.TableDescriptor, 0, len(all))
+	for _, desc := range all {
+		if table, ok := desc.(catalog.TableDescriptor); ok {
+			tables = append(tables, table)
+		}
+	}
+	return tables
+}
+
 // tableDescRefs returns (ID, Version) tuples for tables this restore job is
 // materializing. Prefers the dedicated info-key row; falls back to the legacy
 // details.TableDescs slice for jobs created before info-key writes existed.
@@ -1188,7 +1205,7 @@ func remapAndFilterRelevantStatistics(
 	ctx context.Context,
 	tableStatistics []*stats.TableStatisticProto,
 	descriptorRewrites jobspb.DescRewriteMap,
-	tableDescs []*descpb.TableDescriptor,
+	tables []catalog.TableDescriptor,
 ) []*stats.TableStatisticProto {
 	relevantTableStatistics := make([]*stats.TableStatisticProto, 0, len(tableStatistics))
 
@@ -1218,11 +1235,11 @@ func remapAndFilterRelevantStatistics(
 	// Check if we are missing stats for any table that is being restored. This
 	// could be because we ran into an error when computing stats during the
 	// backup.
-	for _, desc := range tableDescs {
-		if _, ok := tableHasStatsInBackup[desc.GetID()]; !ok {
+	for _, table := range tables {
+		if _, ok := tableHasStatsInBackup[table.GetID()]; !ok {
 			log.Dev.Warningf(ctx, "statistics for table: %s, table ID: %d not found in the backup. "+
 				"Query performance on this table could suffer until statistics are recomputed.",
-				desc.GetName(), desc.GetID())
+				table.GetName(), table.GetID())
 		}
 	}
 
@@ -1638,7 +1655,11 @@ func synthesizeZoneConfigsForPartialRestore(
 //     restore targets. This flow should get executed last and should contain the
 //     bulk of the work, as it is used for job progress tracking.
 func createRestoreFlows(
-	ctx context.Context, r *restoreResumer, backupCodec keys.SQLCodec, sqlDescs []catalog.Descriptor,
+	ctx context.Context,
+	r *restoreResumer,
+	backupCodec keys.SQLCodec,
+	sqlDescs []catalog.Descriptor,
+	offlineDescs nstree.Catalog,
 ) (preRestore restorationData, preValid restorationData, mainRestore restorationData, err error) {
 
 	details := r.job.Details().(jobspb.RestoreDetails)
@@ -1726,23 +1747,22 @@ func createRestoreFlows(
 
 	var rekeys []execinfrapb.TableRekey
 	var systemTables []catalog.TableDescriptor
-	for i := range details.TableDescs {
-		desc := tabledesc.NewBuilder(details.TableDescs[i]).BuildImmutableTable()
+	for _, table := range restoredTableDescs(offlineDescs) {
 		// Skip rekeys for revlog-added tables — no backup data to rekey.
-		if _, ok := revlogNewPostIDs[desc.GetID()]; ok {
+		if _, ok := revlogNewPostIDs[table.GetID()]; ok {
 			continue
 		}
-		newDescBytes, err := protoutil.Marshal(desc.DescriptorProto())
+		newDescBytes, err := protoutil.Marshal(table.DescriptorProto())
 		if err != nil {
 			return nil, nil, nil, errors.NewAssertionErrorWithWrappedErrf(err,
 				"marshaling descriptor")
 		}
 		rekeys = append(rekeys, execinfrapb.TableRekey{
-			OldID:   uint32(newIDToOldID[desc.GetID()]),
+			OldID:   uint32(newIDToOldID[table.GetID()]),
 			NewDesc: newDescBytes,
 		})
-		if desc.GetParentID() == tempSystemDBID {
-			systemTables = append(systemTables, desc)
+		if table.GetParentID() == tempSystemDBID {
+			systemTables = append(systemTables, table)
 		}
 	}
 
@@ -1781,8 +1801,8 @@ func createRestoreFlows(
 	}
 
 	pkIDs := make(map[uint64]bool)
-	for _, tbl := range details.TableDescs {
-		pkIDs[kvpb.BulkOpSummaryID(uint64(tbl.GetID()), uint64(tbl.GetPrimaryIndex().ID))] = true
+	for _, table := range restoredTableDescs(offlineDescs) {
+		pkIDs[kvpb.BulkOpSummaryID(uint64(table.GetID()), uint64(table.GetPrimaryIndex().GetID()))] = true
 	}
 
 	dataToPreRestore := &restorationDataBase{
@@ -2606,7 +2626,31 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err := createImportingDescriptors(ctx, p, backupDescs, r); err != nil {
 		return err
 	}
-	preData, preValidateData, mainData, err := createRestoreFlows(ctx, r, backupCodec, backupDescs)
+
+	// Refresh the job details since createImportingDescriptors may have
+	// updated them.
+	details = r.job.Details().(jobspb.RestoreDetails)
+
+	// Fetch the freshly written OFFLINE descriptors once and reuse the
+	// resulting catalog across the readers that follow. This avoids each
+	// reader having to round-trip its own KV fetch, and is the source of
+	// descriptor bodies after we stop persisting the full descriptors
+	// onto RestoreDetails. publishDescriptors keeps its own fresh fetch
+	// because it needs txn-bound mutable copies to write back.
+	var offlineDescs nstree.Catalog
+	if err := p.ExecCfg().InternalDB.DescsTxn(ctx, func(
+		ctx context.Context, txn descs.Txn,
+	) error {
+		var err error
+		offlineDescs, err = prefetchDescriptors(ctx, txn.KV(), txn.Descriptors(), details)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	preData, preValidateData, mainData, err := createRestoreFlows(
+		ctx, r, backupCodec, backupDescs, offlineDescs,
+	)
 	if err != nil {
 		return err
 	}
@@ -2624,11 +2668,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := r.job.DeprecatedNoTxn().SetDetails(ctx, details); err != nil {
 			return errors.Wrap(err, "updating job details with download spans")
 		}
+		// Refresh the local copy again after the in-band SetDetails write.
+		details = r.job.Details().(jobspb.RestoreDetails)
 	}
-
-	// Refresh the job details since they may have been updated when creating the
-	// importing descriptors.
-	details = r.job.Details().(jobspb.RestoreDetails)
 
 	if fn := r.testingKnobs.afterOfflineTableCreation; fn != nil {
 		if err := fn(); err != nil {
@@ -2639,8 +2681,9 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	backupStats, err := backupinfo.GetStatisticsFromBackup(ctx, defaultStore, details.Encryption,
 		&kmsEnv, latestBackupManifest)
 	if err == nil {
-		remappedStats = remapAndFilterRelevantStatistics(ctx, backupStats, details.DescriptorRewrites,
-			details.TableDescs)
+		remappedStats = remapAndFilterRelevantStatistics(
+			ctx, backupStats, details.DescriptorRewrites, restoredTableDescs(offlineDescs),
+		)
 	} else {
 		// We don't want to fail the restore if we are unable to resolve statistics
 		// from the backup, since they can be recomputed after the restore has
@@ -2918,7 +2961,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		log.Dev.Errorf(ctx, "failed to release protected timestamp: %v", err)
 	}
 	if !details.OnlineImpl() {
-		r.notifyStatsRefresherOfNewTables(ctx)
+		r.notifyStatsRefresherOfNewTables(ctx, offlineDescs)
 	}
 
 	r.restoreStats = resTotal
@@ -3038,12 +3081,15 @@ func (r *restoreResumer) ReportResults(ctx context.Context, resultsCh chan<- tre
 // Initiate a run of CREATE STATISTICS. We don't know the actual number of
 // rows affected per table, so we use a large number because we want to make
 // sure that stats always get created/refreshed here.
-func (r *restoreResumer) notifyStatsRefresherOfNewTables(ctx context.Context) {
-	details := r.job.Details().(jobspb.RestoreDetails)
-	for i := range details.TableDescs {
-		desc := tabledesc.NewBuilder(details.TableDescs[i]).BuildImmutableTable()
-		r.execCfg.StatsRefresher.NotifyMutation(ctx, desc, math.MaxInt32 /* rowsAffected */)
-	}
+func (r *restoreResumer) notifyStatsRefresherOfNewTables(
+	ctx context.Context, offlineDescs nstree.Catalog,
+) {
+	_ = offlineDescs.ForEachDescriptor(func(desc catalog.Descriptor) error {
+		if table, ok := desc.(catalog.TableDescriptor); ok {
+			r.execCfg.StatsRefresher.NotifyMutation(ctx, table, math.MaxInt32 /* rowsAffected */)
+		}
+		return nil
+	})
 }
 
 func waitForSpanConfigReconciliationCheckpoint(

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -777,9 +777,50 @@ func (r *restoreResumer) maybeWriteDownloadJob(
 		if _, err := execConfig.JobRegistry.CreateJobWithTxn(ctx, downloadJobRecord, downloadJobID, txn); err != nil {
 			return err
 		}
+		// Copy the descriptor-ref info-key rows from the link job to the
+		// download job so that OnFailOrCancel cleanup on the download job can
+		// resolve the descriptor set without depending on the legacy
+		// RestoreDetails.{Type,Table,Schema,Database,Function}Descs slices,
+		// which are not populated once the cluster has crossed the
+		// V26_3_DescriptorIDsInRestoreDetails gate.
+		//
+		// TODO (kev-cao): remove this copy and rely on the link job's
+		// info-key rows directly in 27.1+.
+		if err := copyRestoreDescRefs(ctx, txn, r.job.ID(), downloadJobID); err != nil {
+			return errors.Wrap(err, "copying restore desc refs to download job")
+		}
 		r.downloadJobID = downloadJobID
 		return nil
 	})
+}
+
+// copyRestoreDescRefs copies the five restore_*_desc_refs info-key rows from
+// srcJobID to dstJobID.
+//
+// TODO (kev-cao): remove this helper and flatten call-sites in 27.1+.
+func copyRestoreDescRefs(ctx context.Context, txn isql.Txn, srcJobID, dstJobID jobspb.JobID) error {
+	keys := []string{
+		restoreTableDescRefsKey,
+		restoreTypeDescRefsKey,
+		restoreSchemaDescRefsKey,
+		restoreDatabaseDescRefsKey,
+		restoreFunctionDescRefsKey,
+	}
+	src := jobs.InfoStorageForJob(txn, srcJobID)
+	dst := jobs.InfoStorageForJob(txn, dstJobID)
+	for _, k := range keys {
+		raw, ok, err := src.Get(ctx, "restore-desc-refs", k)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if err := dst.Write(ctx, k, raw); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // waitForDownloadToComplete polls until there are no more ExternalFileBytes

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -860,7 +860,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 			) error {
 				var err error
 				publishedDescs, err = prefetchDescriptors(
-					ctx, txn.KV(), txn.Descriptors(),
+					ctx, txn, r.job.ID(),
 					r.job.Details().(jobspb.RestoreDetails),
 				)
 				return err
@@ -1048,7 +1048,7 @@ func createImportRollbackJob(
 
 // setDescriptorsOffline sets the state of all online descriptors in the details to offline.
 func setDescriptorsOffline(
-	ctx context.Context, txn descs.Txn, details jobspb.RestoreDetails,
+	ctx context.Context, txn descs.Txn, jobID jobspb.JobID, details jobspb.RestoreDetails,
 ) error {
 	descCol := txn.Descriptors()
 	b := txn.KV().NewBatch()
@@ -1065,24 +1065,13 @@ func setDescriptorsOffline(
 		return nil
 	}
 
-	var descIDs []descpb.ID
-	for _, desc := range details.TableDescs {
-		descIDs = append(descIDs, desc.ID)
-	}
-	for i := range details.FunctionDescs {
-		descIDs = append(descIDs, details.FunctionDescs[i].ID)
-	}
-	for i := range details.DatabaseDescs {
-		descIDs = append(descIDs, details.DatabaseDescs[i].ID)
-	}
-	for i := range details.TypeDescs {
-		descIDs = append(descIDs, details.TypeDescs[i].ID)
-	}
-	for i := range details.SchemaDescs {
-		descIDs = append(descIDs, details.SchemaDescs[i].ID)
+	refs, err := allDescRefs(ctx, txn, jobID, details)
+	if err != nil {
+		return err
 	}
 
-	for _, id := range descIDs {
+	for _, ref := range refs {
+		id := ref.ID
 		// We use Desc over the type-specific lookups because the latter replaces
 		// the shared catalog.ErrDescriptorNotFound with a more specific pgcode.
 		// Uinsg the former allows us to match on one error type for all
@@ -1125,7 +1114,7 @@ func (r *restoreResumer) maybeCleanupFailedOnlineRestore(
 	// If the descriptors are online, flip them off before excising to ensure no
 	// foreground workload can run when we clobber the key space.
 	if err := r.execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
-		return setDescriptorsOffline(ctx, txn, details)
+		return setDescriptorsOffline(ctx, txn, r.job.ID(), details)
 	}); err != nil {
 		return err
 	}

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -853,7 +854,20 @@ func (r *restoreResumer) waitForDownloadToComplete(
 		r.downloadJobProg = fractionComplete
 
 		if remaining == 0 {
-			r.notifyStatsRefresherOfNewTables(ctx)
+			var publishedDescs nstree.Catalog
+			if err := execCtx.ExecCfg().InternalDB.DescsTxn(ctx, func(
+				ctx context.Context, txn descs.Txn,
+			) error {
+				var err error
+				publishedDescs, err = prefetchDescriptors(
+					ctx, txn.KV(), txn.Descriptors(),
+					r.job.Details().(jobspb.RestoreDetails),
+				)
+				return err
+			}); err != nil {
+				return err
+			}
+			r.notifyStatsRefresherOfNewTables(ctx, publishedDescs)
 			close(done)
 			return nil
 		}

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -2386,10 +2386,14 @@ func doRestorePlan(
 
 	// Validate that revision log rekeys can be built from the
 	// restore details. This catches errors during planning rather
-	// than during job execution.
+	// than during job execution. Planning does not have access to
+	// the materialized table descriptors (those are created during
+	// job execution), so this validation only exercises rekey
+	// construction with no tables; it remains useful as a sanity
+	// check on details.DescriptorRewrites and execCfg.
 	if !revisionLogTimestamp.IsEmpty() {
 		if _, _, err := restorerevlog.BuildRekeys(
-			restoreDetails, p.ExecCfg(),
+			nil /* tables */, restoreDetails, p.ExecCfg(),
 		); err != nil {
 			return errors.Wrap(err, "validating revision log rekeys")
 		}

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -300,6 +300,13 @@ const (
 	// to requiring REFERENCES on both the origin and referenced tables.
 	V26_3_GrantReferencesToUsersWithCreate
 
+	// V26_3_DescriptorIDsInRestoreDetails gates RESTORE's transition from
+	// embedding full descriptor payloads in RestoreDetails to persisting
+	// (ID, Version) tuples in dedicated system.job_info rows. Once a cluster
+	// is at this version, new RESTORE jobs only write the info-key rows and
+	// leave the legacy descriptor slices on RestoreDetails empty.
+	V26_3_DescriptorIDsInRestoreDetails
+
 	// *************************************************
 	// Step (1) Add new versions above this comment.
 	// Do not add new versions to a patch release.
@@ -394,6 +401,8 @@ var versionTable = [numKeys]roachpb.Version{
 	V26_3_CrdbInternalTSDB: {Major: 26, Minor: 2, Internal: 12},
 
 	V26_3_GrantReferencesToUsersWithCreate: {Major: 26, Minor: 2, Internal: 14},
+
+	V26_3_DescriptorIDsInRestoreDetails: {Major: 26, Minor: 2, Internal: 16},
 	// *************************************************
 	// Step (2): Add new versions above this comment.
 	// *************************************************

--- a/pkg/revlog/restorerevlog/BUILD.bazel
+++ b/pkg/revlog/restorerevlog/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/sql/bulkutil",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/physicalplan",

--- a/pkg/revlog/restorerevlog/restore.go
+++ b/pkg/revlog/restorerevlog/restore.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/bulkutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -149,7 +148,11 @@ func AssignTicksToNodes(ticks []revlogpb.Manifest, numNodes int) [][]revlogpb.Ma
 // can resume after a transient failure without replaying all ticks
 // from scratch.
 func RestoreFromRevisionLog(
-	ctx context.Context, execCtx sql.JobExecContext, job *jobs.Job, execCfg *sql.ExecutorConfig,
+	ctx context.Context,
+	execCtx sql.JobExecContext,
+	job *jobs.Job,
+	execCfg *sql.ExecutorConfig,
+	tables []catalog.TableDescriptor,
 ) error {
 	details := job.Details().(jobspb.RestoreDetails)
 
@@ -201,7 +204,7 @@ func RestoreFromRevisionLog(
 	assignments := AssignTicksToNodes(manifests, len(sqlInstanceIDs))
 
 	// Build table rekeys from the restore details.
-	tableRekeys, tenantRekeys, err := BuildRekeys(details, execCfg)
+	tableRekeys, tenantRekeys, err := BuildRekeys(tables, details, execCfg)
 	if err != nil {
 		return errors.Wrap(err, "building rekeys for revlog restore")
 	}
@@ -294,7 +297,7 @@ func RestoreFromRevisionLog(
 
 	// Split/scatter spans for new tables.
 	if err := SplitAndScatterRevlogSpans(
-		ctx, execCtx, details, allManifests,
+		ctx, execCtx, tables, details, allManifests,
 	); err != nil {
 		return errors.Wrap(err, "split/scatter for revlog new tables")
 	}
@@ -303,7 +306,7 @@ func RestoreFromRevisionLog(
 
 	// Ingest via bulkmerge.Merge.
 	if err := RunRevlogFinalMerge(
-		ctx, execCtx, jobID, details, allManifests,
+		ctx, execCtx, jobID, tables, allManifests,
 	); err != nil {
 		return errors.Wrap(err, "revlog final merge")
 	}
@@ -432,11 +435,13 @@ func ApplyDescriptorChanges(
 	return result, newDescIDs, nil
 }
 
-// BuildRekeys constructs table and tenant rekeys from the restore
-// details. This mirrors the rekey construction in createRestoreFlows
-// (restore_job.go).
+// BuildRekeys constructs table and tenant rekeys from the supplied
+// table descriptors and the restore details. This mirrors the rekey
+// construction in createRestoreFlows (restore_job.go). The descriptors
+// are sourced from the catalog the restore job has already fetched
+// from KV after createImportingDescriptors commits.
 func BuildRekeys(
-	details jobspb.RestoreDetails, execCfg *sql.ExecutorConfig,
+	tables []catalog.TableDescriptor, details jobspb.RestoreDetails, execCfg *sql.ExecutorConfig,
 ) ([]execinfrapb.TableRekey, []execinfrapb.TenantRekey, error) {
 	newIDToOldID := make(map[descpb.ID]descpb.ID)
 	for oldID, rewrite := range details.DescriptorRewrites {
@@ -444,9 +449,7 @@ func BuildRekeys(
 	}
 
 	var tableRekeys []execinfrapb.TableRekey
-	for i := range details.TableDescs {
-		desc := tabledesc.NewBuilder(details.TableDescs[i]).
-			BuildImmutableTable()
+	for _, desc := range tables {
 		newDescBytes, err := protoutil.Marshal(desc.DescriptorProto())
 		if err != nil {
 			return nil, nil, errors.NewAssertionErrorWithWrappedErrf(
@@ -479,6 +482,7 @@ func BuildRekeys(
 func SplitAndScatterRevlogSpans(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
+	tables []catalog.TableDescriptor,
 	details jobspb.RestoreDetails,
 	allManifests []jobspb.BulkSSTManifest,
 ) error {
@@ -496,9 +500,7 @@ func SplitAndScatterRevlogSpans(
 
 	// Compute spans for new tables.
 	var newSpans []roachpb.Span
-	for i := range details.TableDescs {
-		td := tabledesc.NewBuilder(details.TableDescs[i]).
-			BuildImmutableTable()
+	for _, td := range tables {
 		if _, ok := newIDSet[td.GetID()]; !ok {
 			continue
 		}
@@ -583,7 +585,7 @@ func RunRevlogFinalMerge(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
 	jobID jobspb.JobID,
-	details jobspb.RestoreDetails,
+	tables []catalog.TableDescriptor,
 	allManifests []jobspb.BulkSSTManifest,
 ) error {
 	codec := execCtx.ExecCfg().Codec
@@ -594,9 +596,7 @@ func RunRevlogFinalMerge(
 	// Compute sorted, non-overlapping schema spans from all table
 	// descriptors in the restore.
 	var schemaSpans []roachpb.Span
-	for i := range details.TableDescs {
-		td := tabledesc.NewBuilder(details.TableDescs[i]).
-			BuildImmutableTable()
+	for _, td := range tables {
 		schemaSpans = append(schemaSpans, td.TableSpan(codec))
 	}
 	slices.SortFunc(schemaSpans, func(a, b roachpb.Span) int {


### PR DESCRIPTION
At ~1M descriptors, persisting full marshaled descriptor protos into
`RestoreDetails.{Table,Type,Schema,Database,Function}Descs` (and from
there into the `system.job_info` payload row) pushes the row past the
64 MiB raft command size limit, so execution can't even start
ingesting. #170974 already removed planning-side population of these
fields; this PR removes execution-side population too.

Each restored descriptor's `(ID, Version)` tuple is persisted to a
dedicated `system.job_info` row keyed by descriptor type
(`restore_table_desc_refs`, `restore_type_desc_refs`, ...). Per-row
size is bounded by `kv.raft.command.max_size` independently of the
payload, so at 1M descs each row is on the order of ~16 MiB — well
under the limit. Descriptor bodies are read from KV at Resume time
via the batched `descsCol.MutableByID().Descs(ctx, ids)` pattern that
`prefetchDescriptors` already uses.

A new cluster version `V26_3_DescriptorIDsInRestoreDetails` gates the
behavior change. Below the gate the new info-key rows are written
*and* the legacy slices are populated, so a restore job created on a
new binary can still be driven by a node on the old binary during a
mixed-version window. Once the gate is active only the info-key rows
are written. Readers always prefer the info-key rows and fall back to
the legacy slices, which covers jobs created before any new code ran.

The early commits scaffold protos, helpers, and the gate; the middle
commits hoist a single descriptor fetch in `doResume` and migrate
each reader (the rekey list, stats notification, `dropDescriptors`,
`setDescriptorsOffline`, etc.); the last three commits flip the gate
on and fix two paths the gate broke (the revlog pipeline, which read
descriptors from the now-nil slice, and the download job's
`OnFailOrCancel`, which looked up info-key rows under the wrong job
ID).

Informs: #170974

Epic: none

Release note: None