### PR TITLE
sql: fix FETCH FIRST on empty WITH HOLD cursor

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -943,3 +943,20 @@ statement ok
 CLOSE foo;
 
 subtest end
+
+# Regression test for FETCH FIRST on a persisted WITH HOLD cursor over an
+# empty result set returning an internal error instead of zero rows (#171238).
+subtest regression_171238
+
+statement ok
+BEGIN;
+DECLARE foo_first CURSOR WITH HOLD FOR SELECT * FROM empty;
+COMMIT;
+
+query empty
+FETCH FIRST FROM foo_first;
+
+statement ok
+CLOSE foo_first;
+
+subtest end

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -288,8 +288,8 @@ func (b *fetchMoveNodeBase) nextInternal(ctx context.Context) (bool, error) {
 		case tree.FetchFirst:
 			switch b.cursor.curRow {
 			case 0:
-				_, err := b.cursor.Next(ctx)
-				return true, err
+				more, err := b.cursor.Next(ctx)
+				return more, err
 			case 1:
 				return true, nil
 			}


### PR DESCRIPTION
Fixes #171238

`FETCH FIRST` on a persisted `WITH HOLD` cursor over an empty result set returned an internal error (`decoding unset EncDatum`) instead of zero rows. In `fetchMoveNodeBase.nextInternal`, the `FetchFirst` branch for `curRow == 0` discarded the bool returned by `sqlCursor.Next` and unconditionally reported a row, so the caller tried to decode an unset EncDatum. 

This propagates `Next`'s `(more, err)` directly from the `case 0` branch, matching the `FetchAbsolute` path just below.

Related to #145362 / #145391 (prior fix for `FETCH ABSOLUTE`), but the asymmetric `FetchFirst` path was not reached by that change.

Epic: none

Release note (bug fix): FETCH FIRST on an empty WITH HOLD cursor no longer returns an internal error.