### PR TITLE
sql: keep feature detail in plpgsql unimplemented telemetry

### DIFF
--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -8,7 +8,6 @@ package parser
 import (
 	"strings"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parserutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -621,15 +620,17 @@ func (l *lexer) Error(e string) {
 	l.lastError = parserutils.PopulateErrorDetails(lastTok.id, ERROR, lastTok.str, lastTok.pos, err, l.in)
 }
 
-// UnimplementedWithIssue records a syntax-level "unimplemented" error
-// annotated with a tracking issue.
-func (l *lexer) UnimplementedWithIssue(issue int) {
-	l.lastError = unimp.NewWithIssue(issue, "this syntax")
+// UnimplementedWithIssueDetail records a syntax-level "unimplemented" error
+// annotated with a tracking issue. The detail is a short, stable identifier for
+// the specific unimplemented feature; it is recorded in telemetry as
+// "#<issue>.<detail>" so that usage can be drilled down per feature.
+func (l *lexer) UnimplementedWithIssueDetail(issue int, detail string) {
+	l.lastError = unimp.NewWithIssueDetail(issue, detail, "this syntax")
 	lastTok := l.lastToken()
 	l.lastError = parserutils.PopulateErrorDetails(lastTok.id, ERROR, lastTok.str, lastTok.pos, l.lastError, l.in)
 	l.lastError = &tree.UnsupportedError{
 		Err:         l.lastError,
-		FeatureName: build.MakeIssueURL(issue),
+		FeatureName: detail,
 	}
 }
 

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -26,8 +26,8 @@ func setErrNoDetails(plpgsqllex plpgsqlLexer, err error) int {
     return 1
 }
 
-func unimplementedWithIssue(plpgsqllex plpgsqlLexer, issue int) int {
-    plpgsqllex.(*lexer).UnimplementedWithIssue(issue)
+func unimplementedWithIssueDetail(plpgsqllex plpgsqlLexer, issue int, detail string) int {
+    plpgsqllex.(*lexer).UnimplementedWithIssueDetail(issue, detail)
     return 1
 }
 
@@ -475,7 +475,7 @@ decl_statement: decl_varname decl_const decl_datatype decl_collate decl_notnull 
   }
 | decl_varname ALIAS FOR decl_aliasitem ';'
   {
-    return unimplementedWithIssue(plpgsqllex, 169572)
+    return unimplementedWithIssueDetail(plpgsqllex, 169572, "alias for")
   }
 | decl_varname opt_scrollable CURSOR decl_cursor_args decl_is_for decl_cursor_query
   {
@@ -516,7 +516,7 @@ decl_cursor_query: stmt_until_semi ';'
 
 decl_cursor_args: '('
   {
-    return unimplementedWithIssue(plpgsqllex, 117746)
+    return unimplementedWithIssueDetail(plpgsqllex, 117746, "cursor arguments")
   }
 | /* EMPTY */
   {
@@ -771,7 +771,7 @@ proc_stmt:pl_block ';'
 
 stmt_perform: PERFORM stmt_until_semi ';'
   {
-    return unimplementedWithIssue(plpgsqllex, 108416)
+    return unimplementedWithIssueDetail(plpgsqllex, 108416, "perform")
   }
 ;
 
@@ -1106,7 +1106,7 @@ for_control:
 	    }
 	    $$.val = forLoopControl
 	  case LOOP:
-	    return unimplementedWithIssue(plpgsqllex, 105246)
+	    return unimplementedWithIssueDetail(plpgsqllex, 105246, "for loop over query or cursor")
 	  default:
 	    return setErr(plpgsqllex, errors.New("unterminated FOR loop definition"))
 	  }
@@ -1125,7 +1125,7 @@ for_target:
 
 stmt_foreach_a: opt_loop_label FOREACH
   {
-    return unimplementedWithIssue(plpgsqllex, 163147)
+    return unimplementedWithIssueDetail(plpgsqllex, 163147, "for each loop")
   }
 ;
 
@@ -1185,7 +1185,7 @@ return_query:
       // Advance the lexer by one token so that the error correctly points to
       // the EXECUTE keyword.
       plpgsqllex.(*lexer).Advance(1)
-      return unimplementedWithIssue(plpgsqllex, 169571)
+      return unimplementedWithIssueDetail(plpgsqllex, 169571, "return dynamic sql query")
     }
     retQuery, err := plpgsqllex.(*lexer).ParseReturnQuery()
     if err != nil {
@@ -1198,7 +1198,7 @@ return_query:
 stmt_raise:
   RAISE ';'
   {
-    return unimplementedWithIssue(plpgsqllex, 169573)
+    return unimplementedWithIssueDetail(plpgsqllex, 169573, "empty RAISE statement")
   }
 | RAISE opt_error_level SCONST opt_format_exprs opt_option_exprs ';'
   {
@@ -1400,7 +1400,7 @@ stmt_open: OPEN IDENT ';'
   }
 | OPEN IDENT opt_scrollable FOR EXECUTE
   {
-    return unimplementedWithIssue(plpgsqllex, 169574)
+    return unimplementedWithIssueDetail(plpgsqllex, 169574, "cursor for execute")
   }
 | OPEN IDENT opt_scrollable FOR stmt_until_semi ';'
   {


### PR DESCRIPTION
The plpgsql parser reports syntax-level "unimplemented" errors via the lexer's UnimplementedWithIssue helper, which keys telemetry on the tracking issue number alone (e.g. "#169572"). This drops the per-feature breakdown, so a single issue's hits can no longer be attributed to the specific syntax that produced them.

Switch to unimp.NewWithIssueDetail, mirroring the main SQL parser's UnimplementedWithIssueDetail helper. Each call site passes a short, stable feature identifier as the telemetry detail, so the key becomes "#<issue>.<detail>" (e.g. "#169572.alias for") while still linking to the issue. The rendered error message is unchanged.

Epic: CRDB-63280

Release note: None