### PR TITLE
sql: reimplement pg_*_is_visible as Go builtins

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -176,6 +176,7 @@ go_library(
         "partition_utils.go",
         "pg_catalog.go",
         "pg_extension.go",
+        "pg_is_visible.go",
         "pg_metadata_diff.go",
         "plan.go",
         "plan_columns.go",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -456,6 +456,25 @@ func (ep *DummyEvalPlanner) GetTypeFromValidSQLSyntax(
 	return nil, errors.WithStack(errEvalPlanner)
 }
 
+// PGFunctionIsVisible is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) PGFunctionIsVisible(
+	ctx context.Context, oid oid.Oid,
+) (*tree.DBool, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// PGTableIsVisible is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) PGTableIsVisible(
+	ctx context.Context, oid oid.Oid,
+) (*tree.DBool, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
+// PGTypeIsVisible is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) PGTypeIsVisible(ctx context.Context, oid oid.Oid) (*tree.DBool, error) {
+	return nil, errors.WithStack(errEvalPlanner)
+}
+
 // EvalSubquery is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
 	return nil, errors.WithStack(errEvalPlanner)

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -885,7 +885,9 @@ RESET search_path
 # in reg_qual_sc whose name is also defined in public must be qualified.
 statement ok
 CREATE TABLE public.shadow (id INT);
-CREATE TABLE reg_qual_sc.shadow (id INT)
+CREATE TABLE reg_qual_sc.shadow (id INT);
+CREATE TYPE public.shadow_ty AS ENUM ('a');
+CREATE TYPE reg_qual_sc.shadow_ty AS ENUM ('b')
 
 statement ok
 SET search_path = public, reg_qual_sc
@@ -914,6 +916,18 @@ SELECT pg_table_is_visible(
 ----
 true  false
 
+# Types shadow the same way: with public earlier than reg_qual_sc, only the
+# public type with a shared name is visible.
+query BB
+SELECT pg_type_is_visible(
+         (SELECT t.oid FROM pg_type t JOIN pg_namespace n ON t.typnamespace = n.oid
+          WHERE t.typname = 'shadow_ty' AND n.nspname = 'public')),
+       pg_type_is_visible(
+         (SELECT t.oid FROM pg_type t JOIN pg_namespace n ON t.typnamespace = n.oid
+          WHERE t.typname = 'shadow_ty' AND n.nspname = 'reg_qual_sc'))
+----
+true  false
+
 statement ok
 RESET search_path
 
@@ -932,10 +946,12 @@ statement ok
 DROP TABLE "Mixed Case"."Weird Name";
 DROP SCHEMA "Mixed Case";
 DROP TABLE public.shadow;
+DROP TYPE public.shadow_ty;
 DROP TYPE reg_qual_sc.color;
 DROP FUNCTION reg_qual_sc.f;
 DROP TABLE reg_qual_sc.t;
 DROP TABLE reg_qual_sc.shadow;
+DROP TYPE reg_qual_sc.shadow_ty;
 DROP SCHEMA reg_qual_sc
 
 subtest end

--- a/pkg/sql/pg_is_visible.go
+++ b/pkg/sql/pg_is_visible.go
@@ -1,0 +1,350 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+	"github.com/lib/pq/oid"
+)
+
+// These builtins (pg_function_is_visible, pg_table_is_visible,
+// pg_type_is_visible) answer "would the unqualified name of this object resolve
+// back to this OID through the current search_path?" — Postgres's notion of
+// visibility, where an object is hidden if an earlier schema on the path defines
+// the same name (the same name *and* argument types, for functions).
+//
+// They are invoked once per row by ORM and psql `\d` introspection queries, so
+// the implementation walks the (short) search path doing leased-cache-backed
+// lookups rather than scanning the pg_catalog virtual tables, which would be
+// O(catalog size) per call.
+
+// PGFunctionIsVisible is part of the eval.Planner interface.
+func (p *planner) PGFunctionIsVisible(ctx context.Context, o oid.Oid) (*tree.DBool, error) {
+	name, target, err := p.ResolveFunctionByOID(ctx, o)
+	if err != nil {
+		if errors.Is(err, tree.ErrRoutineUndefined) {
+			return nil, nil //nolint:returnerrcheck
+		}
+		return nil, err
+	}
+	// The virtual pg_proc only exposes the current database's UDFs (plus
+	// builtins, which resolve to the current database). A UDF in another
+	// database has no pg_proc row, so report NULL.
+	if name.Catalog() != p.CurrentDatabase() {
+		return nil, nil
+	}
+
+	// Resolve the bare function name through the search path to obtain every
+	// candidate overload (builtins + UDFs) that the name could refer to.
+	searchPath := p.CurrentSearchPath()
+	unresolved := tree.MakeUnresolvedName(name.Object())
+	resolved, err := p.ResolveFunction(
+		ctx, tree.MakeUnresolvedFunctionName(&unresolved), &searchPath,
+	)
+	if err != nil {
+		if errors.Is(err, tree.ErrRoutineUndefined) {
+			return tree.DBoolFalse, nil
+		}
+		return nil, err
+	}
+
+	// Among the overloads whose argument types match the target's signature,
+	// find the one in the earliest schema on the search path. The function is
+	// visible iff that overload is the target. This mirrors Postgres's
+	// signature-aware FunctionIsVisible.
+	targetArgs := target.Types.Types()
+	bestPos := -1
+	var bestOid oid.Oid
+	for i := range resolved.Overloads {
+		ov := &resolved.Overloads[i]
+		if !argTypesEqual(ov.Types.Types(), targetArgs) {
+			continue
+		}
+		pos := searchPathPosition(searchPath, ov.Schema)
+		if pos < 0 {
+			continue
+		}
+		if bestPos < 0 || pos < bestPos {
+			bestPos, bestOid = pos, ov.Oid
+		}
+	}
+	if bestPos < 0 {
+		return tree.DBoolFalse, nil
+	}
+	return tree.MakeDBool(tree.DBool(bestOid == o)), nil
+}
+
+// PGTableIsVisible is part of the eval.Planner interface.
+func (p *planner) PGTableIsVisible(ctx context.Context, o oid.Oid) (*tree.DBool, error) {
+	relName, scName, ok, err := p.relNameAndSchemaForVisibility(ctx, o)
+	if err != nil || !ok {
+		return nil, err
+	}
+	visible, err := p.objectVisibleInSearchPath(ctx, scName,
+		func(ctx context.Context, candidateSchema string) (bool, error) {
+			return p.relationExistsInSchema(ctx, candidateSchema, relName)
+		})
+	if err != nil {
+		return nil, err
+	}
+	return tree.MakeDBool(tree.DBool(visible)), nil
+}
+
+// PGTypeIsVisible is part of the eval.Planner interface.
+func (p *planner) PGTypeIsVisible(ctx context.Context, o oid.Oid) (*tree.DBool, error) {
+	typName, scName, ok, err := p.typeNameAndSchemaForVisibility(ctx, o)
+	if err != nil || !ok {
+		return nil, err
+	}
+	visible, err := p.objectVisibleInSearchPath(ctx, scName,
+		func(ctx context.Context, candidateSchema string) (bool, error) {
+			return p.typeExistsInSchema(ctx, candidateSchema, typName)
+		})
+	if err != nil {
+		return nil, err
+	}
+	return tree.MakeDBool(tree.DBool(visible)), nil
+}
+
+// objectVisibleInSearchPath implements Postgres's *IsVisible walk: scanning the
+// current search path in order, the object is visible iff we reach its own
+// schema (targetSchema) before any other schema that also defines the name (per
+// existsInSchema). Returns false if targetSchema is not on the path at all.
+func (p *planner) objectVisibleInSearchPath(
+	ctx context.Context,
+	targetSchema string,
+	existsInSchema func(ctx context.Context, candidateSchema string) (bool, error),
+) (bool, error) {
+	iter := p.CurrentSearchPath().Iter()
+	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
+		if scName == targetSchema {
+			return true, nil
+		}
+		exists, err := existsInSchema(ctx, scName)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+// relNameAndSchemaForVisibility resolves a pg_class OID to its relation name and
+// schema name. ok is false (with no error) when no relation has the OID.
+func (p *planner) relNameAndSchemaForVisibility(
+	ctx context.Context, o oid.Oid,
+) (relName, scName string, ok bool, err error) {
+	// Tables, views, and sequences have a pg_class OID equal to their descriptor
+	// ID, so they can be resolved directly and cheaply.
+	desc, err := p.byIDGetterBuilder().WithoutNonPublic().Get().Table(ctx, descpb.ID(o))
+	if err != nil {
+		if !errors.Is(err, catalog.ErrDescriptorNotFound) && !sqlerrors.IsUndefinedRelationError(err) {
+			return "", "", false, err
+		}
+		// The OID did not resolve to a table descriptor; fall back to pg_class.
+		return p.relNameAndSchemaFromPGClass(ctx, o)
+	}
+
+	// Virtual tables (e.g. pg_catalog.pg_class) appear in every database's
+	// pg_class and are not owned by a real database, so the current-database
+	// check below does not apply. Resolve them through pg_class, which reports
+	// their schema correctly.
+	if desc.IsVirtualTable() {
+		return p.relNameAndSchemaFromPGClass(ctx, o)
+	}
+
+	// The virtual pg_class only contains the current database's relations, so a
+	// relation in another database has no row and is reported as NULL.
+	curDBID, err := p.currentDatabaseID(ctx)
+	if err != nil {
+		return "", "", false, err
+	}
+	if desc.GetParentID() != curDBID {
+		return "", "", false, nil
+	}
+	sc, err := p.byIDGetterBuilder().WithoutNonPublic().Get().Schema(ctx, desc.GetParentSchemaID())
+	if err != nil {
+		return "", "", false, err
+	}
+	return desc.GetName(), sc.GetName(), true, nil
+}
+
+// relNameAndSchemaFromPGClass resolves a pg_class OID that is not a directly
+// resolvable table descriptor — a composite type or an index entry, both of
+// which have hashed OIDs — by reading pg_class. Any other OID has no pg_class
+// row. This path is rarely exercised (e.g. \di over indexes) and is allowed to
+// fall back to the slower virtual-table scan.
+func (p *planner) relNameAndSchemaFromPGClass(
+	ctx context.Context, o oid.Oid,
+) (relName, scName string, ok bool, err error) {
+	if !oidext.IsMaybeHashedOid(o) {
+		return "", "", false, nil
+	}
+	row, err := p.QueryRowEx(ctx, "pg_table_is_visible", sessiondata.NoSessionDataOverride,
+		`SELECT c.relname, n.nspname
+		 FROM pg_catalog.pg_class c
+		 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+		 WHERE c.oid = $1`,
+		tree.NewDOid(o))
+	if err != nil {
+		return "", "", false, err
+	}
+	if row == nil {
+		return "", "", false, nil
+	}
+	return string(tree.MustBeDString(row[0])), string(tree.MustBeDString(row[1])), true, nil
+}
+
+// relationExistsInSchema reports whether a relation named relName exists in the
+// given schema. It uses the object resolver so that both physical and virtual
+// (e.g. pg_catalog) schemas are handled.
+func (p *planner) relationExistsInSchema(
+	ctx context.Context, schemaName, relName string,
+) (bool, error) {
+	tn := tree.MakeTableNameWithSchema(
+		tree.Name(p.CurrentDatabase()), tree.Name(schemaName), tree.Name(relName),
+	)
+	_, desc, err := resolver.ResolveExistingTableObject(ctx, p, &tn,
+		tree.ObjectLookupFlags{Required: false, DesiredObjectKind: tree.TableObject})
+	if err != nil {
+		return false, err
+	}
+	return desc != nil, nil
+}
+
+// typeNameAndSchemaForVisibility resolves a pg_type OID to its type name and
+// schema name. ok is false (with no error) when no type has the OID.
+func (p *planner) typeNameAndSchemaForVisibility(
+	ctx context.Context, o oid.Oid,
+) (typName, scName string, ok bool, err error) {
+	if _, found := types.OidToType[o]; found {
+		// Predefined types live in pg_catalog.
+		name, nameOK := oidext.TypeName(o)
+		if !nameOK {
+			name = types.OidToType[o].PGName()
+		}
+		return name, catconstants.PgCatalogName, true, nil
+	}
+	if !types.IsOIDUserDefinedType(o) {
+		return "", "", false, nil
+	}
+	curDBID, err := p.currentDatabaseID(ctx)
+	if err != nil {
+		return "", "", false, err
+	}
+	id := typedesc.UserDefinedTypeOIDToID(o)
+	sc, typDesc, err := getSchemaAndTypeByTypeID(ctx, p, id, false /* includeMetaData */)
+	if err != nil {
+		if errors.Is(err, catalog.ErrDescriptorNotFound) {
+			return "", "", false, nil //nolint:returnerrcheck
+		}
+		return "", "", false, err
+	}
+	if typDesc != nil {
+		if typDesc.Dropped() || typDesc.GetParentID() != curDBID {
+			return "", "", false, nil
+		}
+		return typDesc.GetName(), sc.GetName(), true, nil
+	}
+
+	// The OID was not a type descriptor; it may be the implicit record type of a
+	// table, whose pg_type name and schema are the table's. (getSchemaAndTypeByTypeID
+	// returns no descriptor for these.)
+	tbl, err := p.byIDGetterBuilder().WithoutNonPublic().Get().Table(ctx, id)
+	if err != nil {
+		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
+			sqlerrors.IsUndefinedRelationError(err) {
+			return "", "", false, nil //nolint:returnerrcheck
+		}
+		return "", "", false, err
+	}
+	if tbl.GetParentID() != curDBID {
+		return "", "", false, nil
+	}
+	scDesc, err := p.byIDGetterBuilder().WithoutNonPublic().Get().Schema(ctx, tbl.GetParentSchemaID())
+	if err != nil {
+		return "", "", false, err
+	}
+	return tbl.GetName(), scDesc.GetName(), true, nil
+}
+
+// typeExistsInSchema reports whether a type named typName exists in the given
+// schema. pg_type contains predefined types (pg_catalog), user-defined types,
+// and the implicit record type of every table; the latter two share
+// system.namespace with their schema's objects.
+func (p *planner) typeExistsInSchema(
+	ctx context.Context, schemaName, typName string,
+) (bool, error) {
+	if schemaName == catconstants.PgCatalogName {
+		if _, found, _ := types.TypeForNonKeywordTypeName(typName); found {
+			return true, nil
+		}
+	}
+	found, prefix, err := p.LookupSchema(ctx, p.CurrentDatabase(), schemaName)
+	if err != nil || !found {
+		return false, err
+	}
+	id, err := p.Descriptors().LookupObjectID(
+		ctx, p.txn, prefix.Database.GetID(), prefix.Schema.GetID(), typName,
+	)
+	if err != nil {
+		return false, err
+	}
+	return id != descpb.InvalidID, nil
+}
+
+// currentDatabaseID returns the descriptor ID of the session's current
+// database, used to scope visibility checks to objects the per-database virtual
+// catalogs (pg_class, pg_type, pg_proc) actually expose.
+func (p *planner) currentDatabaseID(ctx context.Context) (descpb.ID, error) {
+	db, err := p.Descriptors().ByName(p.txn).Get().Database(ctx, p.CurrentDatabase())
+	if err != nil {
+		return descpb.InvalidID, err
+	}
+	return db.GetID(), nil
+}
+
+// searchPathPosition returns the position of schemaName in the current search
+// path (with implicit schemas included), or -1 if it is not present.
+func searchPathPosition(path sessiondata.SearchPath, schemaName string) int {
+	iter := path.Iter()
+	pos := 0
+	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
+		if scName == schemaName {
+			return pos
+		}
+		pos++
+	}
+	return -1
+}
+
+// argTypesEqual reports whether two argument type lists are identical by OID,
+// matching Postgres's proargtypes equality used to distinguish overloads.
+func argTypesEqual(a, b []*types.T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Oid() != b[i].Oid() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1757,22 +1757,22 @@ FROM defaults_parsed
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Body: `SELECT (SELECT n2.nspname
-                       FROM pg_catalog.pg_proc p2
-                       JOIN pg_catalog.pg_namespace n2 ON p2.pronamespace = n2.oid
-                       WHERE p2.proname = p.proname
-                         AND p2.proargtypes = p.proargtypes
-                         AND n2.nspname = ANY current_schemas(true)
-                       ORDER BY array_position(current_schemas(true), n2.nspname)
-                       LIMIT 1) IS NOT DISTINCT FROM
-                    (SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.oid = p.pronamespace)
-             FROM pg_catalog.pg_proc p
-             WHERE p.oid = $1
-             LIMIT 1`,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
+				res, err := evalCtx.Planner.PGFunctionIsVisible(ctx, tree.MustBeDOid(args[0]).Oid)
+				if err != nil {
+					return nil, err
+				}
+				if res == nil {
+					return tree.DNull, nil
+				}
+				return res, nil
+			},
 			CalledOnNullInput: true,
 			Info:              "Returns whether the function with the given OID is visible in the search path (its schema is on the search path and no function with the same name and signature shadows it from an earlier schema).",
 			Volatility:        volatility.Stable,
-			Language:          tree.RoutineLangSQL,
 		},
 	),
 	// pg_table_is_visible returns true iff the table with the given OID is
@@ -1784,21 +1784,22 @@ FROM defaults_parsed
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Body: `SELECT (SELECT n2.nspname
-                       FROM pg_catalog.pg_class c2
-                       JOIN pg_catalog.pg_namespace n2 ON c2.relnamespace = n2.oid
-                       WHERE c2.relname = c.relname
-                         AND n2.nspname = ANY current_schemas(true)
-                       ORDER BY array_position(current_schemas(true), n2.nspname)
-                       LIMIT 1) IS NOT DISTINCT FROM
-                    (SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.oid = c.relnamespace)
-             FROM pg_catalog.pg_class c
-             WHERE c.oid = $1
-             LIMIT 1`,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
+				res, err := evalCtx.Planner.PGTableIsVisible(ctx, tree.MustBeDOid(args[0]).Oid)
+				if err != nil {
+					return nil, err
+				}
+				if res == nil {
+					return tree.DNull, nil
+				}
+				return res, nil
+			},
 			CalledOnNullInput: true,
 			Info:              "Returns whether the table with the given OID is visible in the search path (its schema is on the search path and no table with the same name shadows it from an earlier schema).",
 			Volatility:        volatility.Stable,
-			Language:          tree.RoutineLangSQL,
 		},
 	),
 
@@ -1811,21 +1812,22 @@ FROM defaults_parsed
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Body: `SELECT (SELECT n2.nspname
-                       FROM pg_catalog.pg_type t2
-                       JOIN pg_catalog.pg_namespace n2 ON t2.typnamespace = n2.oid
-                       WHERE t2.typname = t.typname
-                         AND n2.nspname = ANY current_schemas(true)
-                       ORDER BY array_position(current_schemas(true), n2.nspname)
-                       LIMIT 1) IS NOT DISTINCT FROM
-                    (SELECT n.nspname FROM pg_catalog.pg_namespace n WHERE n.oid = t.typnamespace)
-             FROM pg_catalog.pg_type t
-             WHERE t.oid = $1
-             LIMIT 1`,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
+				res, err := evalCtx.Planner.PGTypeIsVisible(ctx, tree.MustBeDOid(args[0]).Oid)
+				if err != nil {
+					return nil, err
+				}
+				if res == nil {
+					return tree.DNull, nil
+				}
+				return res, nil
+			},
 			CalledOnNullInput: true,
 			Info:              "Returns whether the type with the given OID is visible in the search path (its schema is on the search path and no type with the same name shadows it from an earlier schema).",
 			Volatility:        volatility.Stable,
-			Language:          tree.RoutineLangSQL,
 		},
 	),
 

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -240,6 +240,26 @@ type Planner interface {
 	// `INT(13)`, `mytype`, `"mytype"`, `pg_catalog.int4` or `"public".mytype`.
 	GetTypeFromValidSQLSyntax(ctx context.Context, sql string) (*types.T, error)
 
+	// PGFunctionIsVisible returns whether the function with the given OID is
+	// visible in the current search path: its schema is on the path and no
+	// function with the same name and argument types shadows it from an earlier
+	// schema. Returns NULL if no function with the OID exists. Implements
+	// pg_catalog.pg_function_is_visible.
+	PGFunctionIsVisible(ctx context.Context, oid oid.Oid) (*tree.DBool, error)
+
+	// PGTableIsVisible returns whether the relation with the given OID is
+	// visible in the current search path: its schema is on the path and no
+	// relation with the same name shadows it from an earlier schema. Returns
+	// NULL if no relation with the OID exists. Implements
+	// pg_catalog.pg_table_is_visible.
+	PGTableIsVisible(ctx context.Context, oid oid.Oid) (*tree.DBool, error)
+
+	// PGTypeIsVisible returns whether the type with the given OID is visible in
+	// the current search path: its schema is on the path and no type with the
+	// same name shadows it from an earlier schema. Returns NULL if no type with
+	// the OID exists. Implements pg_catalog.pg_type_is_visible.
+	PGTypeIsVisible(ctx context.Context, oid oid.Oid) (*tree.DBool, error)
+
 	// EvalSubquery returns the Datum for the given subquery node.
 	EvalSubquery(expr *tree.Subquery) (tree.Datum, error)
 


### PR DESCRIPTION
pg_function_is_visible, pg_table_is_visible, and pg_type_is_visible are called
once per row by ORM and psql \d introspection queries. They were implemented as
SQL-body builtins whose Postgres-correct shadow check ("is this the first object
of its name on the search path?") scanned pg_proc / pg_class / pg_type. Because
those virtual tables are indexed only by OID, the shadow check forced a full
materialization of the catalog on every call: O(catalog) per call, and O(N^2)
under the per-row introspection pattern. This made catalog introspection very
slow and was the cause of the TestDescribe timeout in #171054.

This commit reimplements the three builtins in Go (pkg/sql/pg_is_visible.go),
exposed through new eval.Planner methods. Instead of scanning the virtual
catalogs, each builtin resolves the object's name and schema from its OID and
walks the current search path doing leased-cache-backed lookups, mirroring
Postgres's RelationIsVisible / TypeIsVisible / FunctionIsVisible:

* pg_function_is_visible resolves the OID's name and signature, then uses the
  normal function resolver to find the candidate overloads and checks that the
  first one (by search-path precedence) with matching argument types is the
  target. This preserves Postgres's signature-aware behavior: same-named
  functions with disjoint argument lists do not shadow each other.
* pg_table_is_visible and pg_type_is_visible walk the search path and check, per
  schema, whether an object of the same name exists, stopping at the first match.

The per-call cost drops from a full catalog populate to a handful of
descriptor/namespace lookups, eliminating the quadratic blow-up.

Behavior is unchanged from the SQL implementation: visibility, cross-schema
shadowing, signature-aware function visibility, NULL for a non-existent OID, and
NULL for objects in another database all match. A few cases are handled
explicitly: relations and types in other databases (which have no row in the
per-database virtual catalogs) return NULL; virtual tables (e.g.
pg_catalog.pg_class) are resolved through pg_class so they remain visible; and
index entries, whose hashed OIDs cannot be reversed to a descriptor, fall back
to a pg_class lookup.

This restores the Go-builtin approach used before acf5006af14, which had moved
these to SQL bodies for a performance win that later regressed once the bodies
were made shadow-aware.

## Performance

`BenchmarkORMQueries/django_table_introspection` calls `pg_table_is_visible`
once per row. Base master vs this PR (`./dev bench --count=6`, compared with
`benchstat`):

```
                                      │    master     │              this PR               │
                                      │    sec/op      │    sec/op     vs base              │
django_table_introspection_1_table      2737.5m ± 27%   287.0m ± 22%  -89.52% (p=0.002 n=6)
django_table_introspection_8_tables     2980.5m ± 17%   274.8m ±  5%  -90.78% (p=0.002 n=6)
geomean                                   2.856         280.8m        -90.17%

                                      │    master     │              this PR               │
                                      │     B/op       │     B/op      vs base              │
django_table_introspection_1_table      1425.9Mi ± 0%   106.2Mi ± 6%  -92.55% (p=0.002 n=6)
django_table_introspection_8_tables     1501.9Mi ± 0%   104.1Mi ± 0%  -93.07% (p=0.002 n=6)

                                      │    master     │              this PR               │
                                      │  allocs/op     │  allocs/op    vs base             │
django_table_introspection_1_table      8714.5k ± 0%   639.3k ± 7%   -92.66% (p=0.002 n=6)
django_table_introspection_8_tables     9569.0k ± 0%   624.3k ± 1%   -93.48% (p=0.002 n=6)
```

`TestDescribe` (psql `\d`/`\df`/`\dT` over the full catalog) drops from ~75s on
master to ~10.6s with this PR.

Resolves: #171054
Informs: #108334
Epic: none

Release note: None
