### PR TITLE
roachtest: update to Django 6.0.x

### DIFF
--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -24,8 +24,8 @@ var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<
 
 // WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
 // This is used by docs automation to produce a list of supported versions for ORM's.
-var djangoSupportedTag = "cockroach-4.1.x"
-var djangoCockroachDBSupportedTag = "4.1.*"
+var djangoSupportedTag = "cockroach-6.0.x"
+var djangoCockroachDBSupportedTag = "6.0.*"
 
 func registerDjango(r registry.Registry) {
 	runDjango := func(
@@ -65,22 +65,22 @@ func registerDjango(r registry.Registry) {
 			c,
 			node,
 			"install dependencies",
-			`sudo apt-get -qq install make python3.10 libpq-dev python3.10-dev gcc python3-virtualenv python3-setuptools python-setuptools build-essential python3.10-distutils python3-apt libmemcached-dev`,
+			`sudo apt-get -qq install make python3.12 libpq-dev python3.12-dev gcc python3-virtualenv python3-setuptools python-setuptools build-essential python3.12-distutils python3-apt libmemcached-dev`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
-			ctx, t, c, node, "set python3.10 as default", `
-    		sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
-    		sudo update-alternatives --config python3`,
+			ctx, t, c, node, "set python3.12 as default", `
+			sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+			sudo update-alternatives --config python3`,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if err := repeatRunE(
 			ctx, t, c, node, "install pip",
-			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.10`,
+			`curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.12`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -263,7 +263,6 @@ PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]
 TEST_RUNNER = '.cockroach_settings.NonDescribingDiscoverRunner'
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 class NonDescribingDiscoverRunner(DiscoverRunner):
     def get_test_runner_kwargs(self):

--- a/pkg/cmd/roachtest/tests/django_blocklist.go
+++ b/pkg/cmd/roachtest/tests/django_blocklist.go
@@ -157,11 +157,7 @@ var enabledDjangoTests = []string{
 }
 
 // Maintain that this list is alphabetized.
-var djangoBlocklist = blocklist{
-	`schema.tests.SchemaTests.test_alter_text_field_to_date_field`:     "alter type requires USING",
-	`schema.tests.SchemaTests.test_alter_text_field_to_datetime_field`: "alter type requires USING",
-	`schema.tests.SchemaTests.test_alter_text_field_to_time_field`:     "alter type requires USING",
-}
+var djangoBlocklist = blocklist{}
 
 var djangoIgnoreList = blocklist{
 	`select_for_update.tests.SelectForUpdateTests.test_nowait_raises_error_on_block`: "flaky; see #120196",


### PR DESCRIPTION
Fixes #170036
Release note: None

I cherry-picked https://github.com/django/django/commit/906a51e125c3007f86d42b81072a1dad7149af05 into the Django branch used for testing (timgraham/cockroach-6.0.x) in order to resolve the test failure reported in #170036.