### PR TITLE
sql: reject WITHIN GROUP on non-ordered-set aggregates

### DIFF
--- a/pkg/sql/delegate/show_enums.go
+++ b/pkg/sql/delegate/show_enums.go
@@ -39,7 +39,7 @@ func (d *delegator) delegateShowEnums(n *tree.ShowEnums) (tree.Statement, error)
 WITH enums(enumtypid, values) AS (
 	SELECT
 		enums.enumtypid AS enumtypid,
-		array_agg(enums.enumlabel) WITHIN GROUP (ORDER BY (enumsortorder)) AS values
+		array_agg(enums.enumlabel ORDER BY enums.enumsortorder) AS values
 	FROM %[1]s.pg_catalog.pg_enum AS enums
 	GROUP BY enumtypid
 )

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -3567,6 +3567,18 @@ SELECT percentile_disc(0.50) FROM osagg
 statement error ordered-set aggregations must have a WITHIN GROUP clause containing one ORDER BY column
 SELECT percentile_cont(0.50) FROM osagg
 
+# Test that WITHIN GROUP is rejected on functions that are not ordered-set
+# aggregates (#171236). Covers non-aggregate scalar builtins and general
+# aggregates.
+statement error pgcode 42809 function concat_ws is not an ordered set aggregate
+SELECT concat_ws(',', 'a', 'b') WITHIN GROUP (ORDER BY 1)
+
+statement error pgcode 42809 function abs is not an ordered set aggregate
+SELECT abs(-5) WITHIN GROUP (ORDER BY 1)
+
+statement error pgcode 42809 function sum is not an ordered set aggregate
+SELECT sum(f) WITHIN GROUP (ORDER BY f) FROM osagg
+
 # Tests for min/max on collated strings.
 statement ok
 CREATE TABLE t_collate (x STRING COLLATE en_us);

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1162,6 +1162,17 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 			panic(err)
 		}
 
+		// WITHIN GROUP is only valid on ordered-set aggregate functions.
+		if t.AggType == tree.OrderedSetAgg {
+			if _, found := isOrderedSetAggregate(def); !found {
+				panic(pgerror.Newf(
+					pgcode.WrongObjectType,
+					"function %s is not an ordered set aggregate",
+					def.Name,
+				))
+			}
+		}
+
 		if isGenerator(def) && s.replaceSRFs {
 			expr = s.replaceSRF(t, def)
 			break


### PR DESCRIPTION
Fixes #171236

`WITHIN GROUP (ORDER BY ...)` is only valid on ordered-set aggregate functions (`percentile_disc`, `percentile_cont`). CockroachDB silently ignored the clause on general aggregates (`sum`, `avg`, ...) and non-aggregate scalar functions (`concat_ws`, `abs`, ...), diverging from PostgreSQL's behavior.
  
This rejects the misuse in `scope.VisitPre` against the `isOrderedSetAggregate` allowlist, using `pgcode.WrongObjectType` (SQLSTATE 42809) to match PostgreSQL.

Epic: none

Release note (bug fix): WITHIN GROUP on a function that is not an ordered-set aggregate now returns an error matching PostgreSQL.