### PR TITLE
ci: read the code repository from configuration in investigate and autosolve

### DIFF
--- a/.github/prompts/investigate-smoke.md
+++ b/.github/prompts/investigate-smoke.md
@@ -30,8 +30,8 @@ mkdir -p artifacts
     pick one of the older commits from the list, and run `git show <sha> -- pkg/kv/kvserver/replica.go | head -40`.
     This verifies that the blobless clone can transparently fetch old diffs.
 8. **Bash(gh issue view)**: `gh issue view <ISSUE_NUMBER> --json title -q .title`
-   (use the issue number from the variables below)
-9. **Bash(gh search)**: `gh search issues "test" --repo <REPO> --limit 1 --json number`
+   (use the issue number from the variables below; gh defaults to ISSUE_REPO)
+9. **Bash(gh search)**: `gh search issues "test" --repo <ISSUE_REPO> --limit 1 --json number`
 10. **Bash(fetch-url)**: `fetch-url "https://teamcity.cockroachdb.com/guestAuth/app/rest/server" /dev/null`
 11. **Bash(unzip)**: download any small zip and list it, or just run `unzip -l` on a nonexistent file to confirm the command runs
 12. **Read tool**: Read `pkg/BUILD.bazel` (first 10 lines)

--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -7,7 +7,12 @@ and write your findings to `artifacts/findings.md` (a later workflow
 step posts it as a comment on the issue). Create the directory first
 with `mkdir -p artifacts`.
 
-You are inside a blobless clone of the CockroachDB repository with
+The issue and your findings comment live in `ISSUE_REPO` (passed in the
+prompt); `gh` defaults to it, so use plain `gh issue`/`gh pr`/`gh search`
+commands. The working tree is checked out from `CODE_REPO`; use that
+when building source links (blob/permalink URLs).
+
+You are inside a blobless clone of the `CODE_REPO` repository with
 full commit history. `git log`, `git blame`, `git diff`, etc. work
 normally — no need to deepen or unshallow. File contents (blobs) are
 fetched transparently on demand when you check out a commit or read
@@ -339,10 +344,10 @@ top-level error is just "command failed" or similarly uninformative,
 dig into the artifact logs to find the actual underlying failure
 from the command's output.>
 
-<When referencing file:line(s) in code, make it a link specific to this repo and
-SHA. Example:
-[server.go:251](https://github.com/cockroachdb/cockroach/blob/<sha>/pkg/server/server.go#L251).
-For multi-line sections, e.g. [server.go:251-300], use suffix like #L251-L300>
+<When referencing file:line(s) in code, make it a link specific to the
+CODE_REPO repo and SHA. Example (substitute CODE_REPO for the owner/repo):
+[server.go:251](https://github.com/<CODE_REPO>/blob/<sha>/pkg/server/server.go#L251).
+For multi-line sections, e.g. [server.go:251-300], use suffix like #L251-L300.>
 
 ### Analysis
 

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -90,6 +90,8 @@ jobs:
       ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
       COMMENT_BODY: ${{ inputs.comment_body || github.event.comment.body }}
       HAS_API_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+      # Repository to check out the code from. Issues and comments use github.repository.
+      CODE_REPO: ${{ secrets.CODE_REPO }}
     steps:
       - name: Acknowledge trigger
         if: github.event_name == 'issue_comment'
@@ -104,9 +106,15 @@ jobs:
       # contents until they're actually accessed. Much faster than a
       # full clone of the cockroach repo while still giving the agent
       # full history without manual deepening.
+      #
+      # Check out CODE_REPO using the autosolver fork PAT. On a personal
+      # fork (HAS_API_KEY set) CODE_REPO is unset, so fall back to the
+      # fork itself with the default token.
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          repository: ${{ env.HAS_API_KEY == 'true' && github.repository || env.CODE_REPO }}
+          token: ${{ env.HAS_API_KEY == 'true' && secrets.GITHUB_TOKEN || secrets.AUTOSOLVER_PUSH_TO_FORK_PAT }}
           filter: blob:none
           fetch-depth: 0
 
@@ -156,6 +164,9 @@ jobs:
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ env.HAS_API_KEY != 'true' && 'vertex-model-runners' || '' }}
           CLOUD_ML_REGION: ${{ env.HAS_API_KEY != 'true' && 'global' || '' }}
+          # The checkout is a different repo than this one; point the
+          # agent's gh commands at this repo's issue tracker.
+          GH_REPO: ${{ github.repository }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -173,10 +184,14 @@ jobs:
             Read and follow the instructions in the prompt file
             `.github/prompts/${{ inputs.smoke_test == true && 'investigate-smoke' || 'investigate' }}.md`.
 
-            REPO: ${{ github.repository }}
+            ISSUE_REPO: ${{ github.repository }}
+            CODE_REPO: ${{ env.HAS_API_KEY == 'true' && github.repository || env.CODE_REPO }}
             ISSUE NUMBER: ${{ env.ISSUE_NUMBER }}
             TRIGGER COMMENT: ${{ env.COMMENT_BODY }}
             WORKFLOW RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Use ISSUE_REPO for all gh issue/pr/search commands. Use
+            CODE_REPO when building source links (blob/permalink URLs).
 
       - name: Upload findings
         if: always()

--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -10,9 +10,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Autosolver fork configuration - update these if the bot account changes
+  # Owner of the bot fork the branch is pushed to. The fork repo name is
+  # derived from CODE_REPO (see the validate step).
   AUTOSOLVER_FORK_OWNER: cockroach-teamcity
-  AUTOSOLVER_FORK_REPO: cockroach
 
 jobs:
   auto-solve-issue:
@@ -24,6 +24,9 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+    env:
+      # Repository the code and the resulting PR target. Issues stay in github.repository.
+      CODE_REPO: ${{ secrets.CODE_REPO }}
 
     steps:
       - name: Check that labeler is not the issue author
@@ -34,37 +37,34 @@ jobs:
         run: |
           if [ "$LABELER" = "$ISSUE_AUTHOR" ]; then
             echo "::notice::Skipping auto-solver: labeler ($LABELER) is the issue author"
-            gh issue comment ${{ github.event.issue.number }} --body \
+            gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body \
               "Auto-solver skipped: the \`c-autosolve\` label should be applied by someone other than the issue author."
-            gh issue edit ${{ github.event.issue.number }} --remove-label "c-autosolve" || true
+            gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --remove-label "c-autosolve" || true
             exit 1
           fi
 
-      - name: Validate required secrets and configuration
+      - name: Validate configuration
         env:
           AUTOSOLVER_PUSH_TO_FORK_PAT: ${{ secrets.AUTOSOLVER_PUSH_TO_FORK_PAT }}
           AUTOSOLVER_CREATE_PRS_PAT: ${{ secrets.AUTOSOLVER_CREATE_PRS_PAT }}
         run: |
-          if [ -z "${AUTOSOLVER_PUSH_TO_FORK_PAT:-}" ]; then
-            echo "::error::AUTOSOLVER_PUSH_TO_FORK_PAT secret is not configured"
-            exit 1
-          fi
+          for v in AUTOSOLVER_PUSH_TO_FORK_PAT AUTOSOLVER_CREATE_PRS_PAT CODE_REPO AUTOSOLVER_FORK_OWNER; do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::$v is not configured"
+              exit 1
+            fi
+          done
 
-          if [ -z "${AUTOSOLVER_CREATE_PRS_PAT:-}" ]; then
-            echo "::error::AUTOSOLVER_CREATE_PRS_PAT secret is not configured"
-            exit 1
-          fi
+          FORK_REPO="${CODE_REPO#*/}"
+          echo "::add-mask::$FORK_REPO"
+          echo "FORK_REPO=$FORK_REPO" >> "$GITHUB_ENV"
 
-          # Validate that env vars match expected fork (defense against misconfiguration)
-          EXPECTED_FORK="${AUTOSOLVER_FORK_OWNER}/${AUTOSOLVER_FORK_REPO}"
-          if [ "$EXPECTED_FORK" != "cockroach-teamcity/cockroach" ]; then
-            echo "::error::AUTOSOLVER_FORK_OWNER/AUTOSOLVER_FORK_REPO mismatch. Update the env vars or the validation check."
-            exit 1
-          fi
-
+      # Check out CODE_REPO using the autosolver fork PAT (read access).
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          repository: ${{ env.CODE_REPO }}
+          token: ${{ secrets.AUTOSOLVER_PUSH_TO_FORK_PAT }}
           fetch-depth: 0
 
       - name: Authenticate to Google Cloud
@@ -89,6 +89,8 @@ jobs:
           # Pass user-controlled content via env vars to prevent prompt injection
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
+          # The checkout is a different repo; point gh at this repo's issues.
+          GH_REPO: ${{ github.repository }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: "true"
@@ -183,6 +185,8 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           AUTOMATION: "1"
+          # The checkout is a different repo; point gh at this repo's issues.
+          GH_REPO: ${{ github.repository }}
         run: |
           MAX_RETRIES=10
           RETRY_COUNT=0
@@ -234,8 +238,11 @@ jobs:
           **OUTPUT REQUIREMENT**: Before reporting your result, read the commit
           message format guidelines in `.claude/skills/commit-helper/SKILL.md`
           and produce a commit message following that format. The commit message
-          should explain the root cause, what the fix does, and why. Use
-          `Resolves:` (not `Fixes:`) for issue references. Use `Release note: None`
+          should explain the root cause, what the fix does, and why. The PR
+          targets a different repo than the issue, so reference the issue in
+          its fully-qualified form
+          `Resolves: ${{ github.repository }}#${{ github.event.issue.number }}`
+          (not a bare `#N`, and not `Fixes:`). Use `Release note: None`
           unless the fix is user-facing.
 
           Wrap your commit message in markers exactly like this:
@@ -384,7 +391,7 @@ jobs:
           git config --local credential.helper '!f() { echo "username=${AUTOSOLVER_FORK_OWNER}"; echo "password=${AUTOSOLVER_PUSH_TO_FORK_PAT}"; }; f'
 
           # Add the fork as a remote (handle case where it already exists)
-          FORK_URL="https://github.com/${AUTOSOLVER_FORK_OWNER}/${AUTOSOLVER_FORK_REPO}.git"
+          FORK_URL="https://github.com/${AUTOSOLVER_FORK_OWNER}/${FORK_REPO}.git"
           if ! git remote add fork "$FORK_URL" 2>/dev/null; then
             # Remote already exists, update the URL
             if ! git remote set-url fork "$FORK_URL"; then
@@ -450,7 +457,7 @@ jobs:
             printf 'Co-Authored-By: Claude <noreply@anthropic.com>\n' >> "$COMMIT_MSG_FILE"
           else
             # Fallback: construct a minimal commit message
-            ISSUE_TITLE=$(gh issue view ${{ github.event.issue.number }} --json title -q '.title' 2>/dev/null || echo "fix issue #${{ github.event.issue.number }}")
+            ISSUE_TITLE=$(gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json title -q '.title' 2>/dev/null || echo "fix issue #${{ github.event.issue.number }}")
             ISSUE_TITLE=$(echo "$ISSUE_TITLE" | tr '\n\r' ' ' | tr '`' "'" | cut -c1-100)
             PREFIX=$(git diff --name-only --cached 2>/dev/null | grep '\.go$' | head -1 | sed 's|pkg/||' | cut -d'/' -f1)
             if [ -z "$PREFIX" ]; then
@@ -459,7 +466,8 @@ jobs:
             ISSUE_NUMBER="${{ github.event.issue.number }}"
             {
               printf '%s: %s\n\n' "$PREFIX" "$ISSUE_TITLE"
-              printf 'Resolves: #%s\n\n' "$ISSUE_NUMBER"
+              # Fully-qualify the issue reference: the PR targets a different repo.
+              printf 'Resolves: %s#%s\n\n' "${{ github.repository }}" "$ISSUE_NUMBER"
               printf 'Release note: None\n\n'
               printf 'Generated by Claude Code Auto-Solver\n'
               printf 'Co-Authored-By: Claude <noreply@anthropic.com>\n'
@@ -471,7 +479,7 @@ jobs:
           # Sync the fork's default branch with upstream so the push doesn't
           # include upstream workflow file changes that the fork hasn't seen yet.
           GH_TOKEN="${AUTOSOLVER_PUSH_TO_FORK_PAT}" gh api \
-            "repos/${AUTOSOLVER_FORK_OWNER}/${AUTOSOLVER_FORK_REPO}/merge-upstream" \
+            "repos/${AUTOSOLVER_FORK_OWNER}/${FORK_REPO}/merge-upstream" \
             --method POST --field branch=master 2>/dev/null \
             || echo "::warning::Failed to sync fork with upstream (may already be in sync)"
 
@@ -511,10 +519,10 @@ jobs:
             echo "*Please review carefully before approving.*"
           )
 
-          # Create the PR from fork to upstream.
+          # Create the PR from the fork to CODE_REPO.
           # Assign and request review from the user who triggered autosolve.
           PR_URL=$(gh pr create \
-            --repo ${{ github.repository }} \
+            --repo "$CODE_REPO" \
             --head "${AUTOSOLVER_FORK_OWNER}:${{ steps.push.outputs.branch_name }}" \
             --base master \
             --draft \
@@ -532,7 +540,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue comment ${{ github.event.issue.number }} --body \
+          gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body \
             "Auto-solver has created a draft PR to address this issue: ${{ steps.create_pr.outputs.pr_url }}
 
           Please review the changes carefully before approving.
@@ -568,7 +576,7 @@ jobs:
             echo ""
             echo "[Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > "$COMMENT_FILE"
-          gh issue comment ${{ github.event.issue.number }} --body-file "$COMMENT_FILE"
+          gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body-file "$COMMENT_FILE"
 
       - name: Comment on issue - Failed
         if: |
@@ -579,7 +587,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue comment ${{ github.event.issue.number }} --body \
+          gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body \
             "Auto-solver attempted to fix this issue but was unable to complete the implementation.
 
           This issue may require human intervention.


### PR DESCRIPTION
These workflows previously assumed they operated on their own repository. Read the target repository from configuration instead, so it can differ from where the issue lives. Issues are still read and commented on in github.repository.

Epic: none
Release note: None