### PR TITLE
log: elevate severity of overload and failure indicators above INFO

### DIFF
--- a/pkg/jobs/structured_log.go
+++ b/pkg/jobs/structured_log.go
@@ -47,5 +47,15 @@ func LogStateChangeStructured(
 		}
 	}
 
-	log.StructuredEventDepth(ctx, severity.INFO, 1, &out)
+	// Job transitions to a terminal failure state (failed / revert-failed) are
+	// emitted at ERROR since they indicate a job did not complete its work and
+	// can degrade dependent subsystems (e.g. a failed AUTO CREATE PARTIAL STATS
+	// job blocks stats freshness and degrades optimizer plans); other
+	// transitions (running, paused, succeeded, canceled by the user) stay at
+	// INFO.
+	sev := severity.INFO
+	if state == StateFailed || state == StateRevertFailed {
+		sev = severity.ERROR
+	}
+	log.StructuredEventDepth(ctx, sev, 1, &out)
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1649,7 +1649,7 @@ func (r *Replica) initializeRaftLearners(
 	// them all back.
 	defer func() {
 		if err != nil {
-			log.KvExec.Infof(
+			log.KvExec.Errorf(
 				ctx,
 				"could not successfully add and upreplicate %s replica(s) on %s, rolling back: %v",
 				replicaType,

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -208,7 +208,7 @@ func (r *Replica) checkConsistencyImpl(
 		// isn't duplicated except in rare leaseholder change scenarios (and concurrent invocation of
 		// RecomputeStats is allowed because these requests block on one another). Also, we're
 		// essentially paced by the consistency checker so we won't call this too often.
-		log.KvExec.Infof(ctx, "triggering stats recomputation to resolve delta of %+v", results[0].Response.Delta)
+		log.KvExec.Warningf(ctx, "triggering stats recomputation to resolve delta of %+v", results[0].Response.Delta)
 
 		var b kv.Batch
 		b.AddRawRequest(&kvpb.RecomputeStatsRequest{

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1817,7 +1817,7 @@ func (r *replicaSyncCallback) OnLogSync(
 
 	r.store.metrics.RaftLogCommitLatency.RecordValue(stats.CommitDur.Nanoseconds())
 	if stats.TotalDuration > defaultReplicaRaftMuWarnThreshold {
-		log.KvExec.Infof(repl.raftCtx, "slow non-blocking raft commit: %s", stats.BatchCommitStats)
+		log.KvExec.Warningf(repl.raftCtx, "slow non-blocking raft commit: %s", stats.BatchCommitStats)
 	}
 }
 

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -880,7 +880,7 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 		)
 		traceOutput := redact.Sprintf("\ntrace:\n%s", rec)
 		if err != nil {
-			log.KvDistribution.Infof(logCtx, "error processing replica: %v%s", err, traceOutput)
+			log.KvDistribution.Warningf(logCtx, "error processing replica: %v%s", err, traceOutput)
 		} else {
 			log.KvDistribution.Infof(logCtx, "processing replica took %s, exceeding threshold of %s%s",
 				processDuration, loggingThreshold, traceOutput)

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -286,7 +286,7 @@ func (s *Store) HandleSnapshot(
 		if err != nil && ctx.Err() != nil {
 			// Log trace of incoming snapshot on context cancellation (e.g.
 			// times out or caller goes away).
-			log.KvExec.Infof(ctx, "incoming snapshot stream failed with error: %v\ntrace:\n%v",
+			log.KvExec.Errorf(ctx, "incoming snapshot stream failed with error: %v\ntrace:\n%v",
 				err, tracing.SpanFromContext(ctx).GetConfiguredRecording())
 		}
 		return err
@@ -773,7 +773,7 @@ func (s *Store) processReady(rangeID roachpb.RangeID) {
 	// processing time means we'll have starved local replicas of ticks and
 	// remote replicas will likely start campaigning.
 	if elapsed >= defaultReplicaRaftMuWarnThreshold {
-		log.KvExec.Infof(ctx, "%s; node might be overloaded", stats)
+		log.KvExec.Warningf(ctx, "%s; node might be overloaded", stats)
 	}
 }
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1096,7 +1096,7 @@ func (txn *Txn) rollback(ctx context.Context) *kvpb.Error {
 						// already committed. We don't spam the logs with those.
 						log.VEventf(ctx, 2, "async rollback failed: %s", pErr)
 					} else {
-						log.KvExec.Infof(ctx, "async rollback failed: %s", pErr)
+						log.KvExec.Warningf(ctx, "async rollback failed: %s", pErr)
 					}
 				}
 				return nil

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -298,7 +298,14 @@ func (p *planner) maybeLogStatementInternal(
 				CommonSQLEventDetails: commonSQLEventDetails,
 				CommonSQLExecDetails:  execDetails,
 			}
-			log.StructuredEvent(ctx, severity.INFO, event)
+			// A slow query that also carries an error (e.g. a transaction retry
+			// or uncertainty error) signals contention or overload, not just
+			// "this took a while", so it is elevated to WARNING.
+			sev := severity.INFO
+			if execDetails.ErrorText != "" {
+				sev = severity.WARNING
+			}
+			log.StructuredEvent(ctx, sev, event)
 		case execType == executorTypeInternal && slowInternalQueryLogEnabled:
 			// Internal queries that surpass the slow query log threshold should only
 			// be logged to the slow-internal-only log if the cluster setting dictates.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1275,12 +1275,26 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		el := cfg.opts.EventListener
 		p.asyncDone.Go(func() { el.DiskSlow(info) })
 	})
+	loggingListener := pebble.MakeLoggingEventListener(pebbleLogger{
+		ctx:   logCtx,
+		depth: 2, // skip over the EventListener stack frame
+	})
+	// Cancelled compactions (errors.Is(info.Err, pebble.ErrCancelledCompaction))
+	// indicate LSM maintenance is being preempted by concurrent operations.
+	// Sustained cancellations starve L0 cleanup and can lead to read stalls,
+	// so they are surfaced at WARNING rather than INFO. Other CompactionEnd
+	// events stay on the default INFO path.
+	defaultCompactionEnd := loggingListener.CompactionEnd
+	loggingListener.CompactionEnd = func(info pebble.CompactionInfo) {
+		if errors.Is(info.Err, pebble.ErrCancelledCompaction) {
+			log.Storage.Warningf(logCtx, "%s", info)
+			return
+		}
+		defaultCompactionEnd(info)
+	}
 	el := pebble.TeeEventListener(
 		p.makeMetricEtcEventListener(logCtx),
-		pebble.MakeLoggingEventListener(pebbleLogger{
-			ctx:   logCtx,
-			depth: 2, // skip over the EventListener stack frame
-		}),
+		loggingListener,
 	)
 
 	p.eventListener = &el


### PR DESCRIPTION
## Motivation

Analysis of a debug bundle (internal ref EaaS-45, against v25.4.8) revealed that during a real cluster overload incident, more than six million log entries describing degraded health, replication failure, snapshot failure, slow raft commits, transaction rollback failures, cancelled compactions, and failed background jobs were all emitted at `I` (info). Any severity-based monitoring filtering on `WARN` and above missed the entire incident, even though the underlying log text already says things like ``"node might be overloaded"``, ``"slow non-blocking raft commit"``, ``"could not successfully add and upreplicate ... rolling back"``, and ``"async rollback failed"``.

The messages already describe the abnormality; only their severity was wrong.

## Consolidated list of misclassified messages

All ten Info-level messages identified in the analysis, sorted by suggested severity (E first), then by approximate count. Counts are taken from the EaaS-45 debug bundle (63 nodes, ~75 GB of logs).

| # | Message pattern | Approx. count | Suggested | Why it should not be Info |
|---|---|---:|:---:|---|
| 1 | ``incoming snapshot stream failed ... giving up during snapshot reservation`` (receiver side) | ~67,546 | **E** | Snapshot queue timeouts block replication cluster-wide; systemic queueing / backpressure. |
| 2 | ``could not successfully add and upreplicate LEARNER replica(s) ... rolling back`` | ~22,500 | **E** | Failed replication is a cluster-health failure; risks underreplication and quorum loss. |
| 3 | ``status_change`` event with ``NewStatus:"failed"`` (e.g. ``AUTO CREATE PARTIAL STATS``) | ~20–50 | **E** | Failed background jobs block stats freshness and degrade the optimizer. |
| 4 | ``slow_query`` event carrying an ``ErrorText`` (e.g. ``TransactionRetryWithProtoRefreshError``) | ~5,500,000 | **W** | The line is no longer "this was slow" — it is "this failed and was retried." |
| 5 | ``async rollback failed: ... result is ambiguous: context deadline exceeded`` | ~641,535 | **W** | Ambiguous-result rollbacks indicate severe latency / overload. |
| 6 | ``triggering stats recomputation to resolve delta of ...`` | ~3,000–5,000 | **W** | Consistency checker detected range-stat skew; ongoing reconciliation load. |
| 7 | pebble ``compaction cancelled by a concurrent operation, will retry compaction`` | ~1,800–2,200 | **W** | LSM maintenance preempted; sustained cancellations starve L0 cleanup → read stalls. |
| 8 | ``raft ready handling: ...; node might be overloaded`` | ~1,667 | **W** | Multi-second raft apply times — the message text itself flags degraded consensus. |
| 9 | ``slow non-blocking raft commit: commit-wait ... sem ...`` | ~1,360 | **W** | Explicit ``slow`` prefix — code already classifies as abnormal but emits at Info. |
| 10 | ``error processing replica: requeuing due to priority inversion ...`` | ~450–600 | **W** | Low-priority rebalance blocks high-priority work; can cause rebalancing storms. |

**Totals:** ~6.27M Info-level lines would have been reclassified — ~6.17M as W, ~90k as E.

## Change

### Sites bumped to ERROR

| File | Behaviour |
|---|---|
| ``pkg/kv/kvserver/store_raft.go`` | ``incoming snapshot stream failed`` (row 1) → unconditional ``Errorf`` |
| ``pkg/kv/kvserver/replica_command.go`` | ``could not successfully add and upreplicate ... rolling back`` (row 2) → unconditional ``Errorf`` |
| ``pkg/jobs/structured_log.go`` | ``StatusChange`` (row 3) → ``severity.ERROR`` only when ``state == StateFailed \|\| state == StateRevertFailed``; other transitions stay at ``severity.INFO`` |

### Sites bumped to WARNING

| File | Behaviour |
|---|---|
| ``pkg/sql/exec_log.go`` | ``SlowQuery`` event (row 4) → ``severity.WARNING`` only when ``execDetails.ErrorText != ""``; pure slow queries stay at ``severity.INFO`` |
| ``pkg/kv/txn.go`` | ``async rollback failed`` (row 5) → unconditional ``Warningf`` on the non-``REASON_TXN_COMMITTED`` branch; the ``VEventf`` branch is unchanged |
| ``pkg/kv/kvserver/replica_consistency.go`` | ``triggering stats recomputation`` (row 6) → unconditional ``Warningf`` |
| ``pkg/storage/pebble.go`` | ``CompactionEnd`` (row 7) → ``Warningf`` only when ``errors.Is(info.Err, pebble.ErrCancelledCompaction)``. Implemented by wrapping the ``EventListener`` returned by ``MakeLoggingEventListener`` rather than touching ``pebbleLogger.Infof``, so non-cancellation pebble Info messages (compaction starts, flushes, manifest rolls, etc.) are unaffected. |
| ``pkg/kv/kvserver/store_raft.go`` | ``node might be overloaded`` (row 8) → unconditional ``Warningf`` |
| ``pkg/kv/kvserver/replica_raft.go`` | ``slow non-blocking raft commit`` (row 9) → unconditional ``Warningf`` |
| ``pkg/kv/kvserver/replicate_queue.go`` | ``error processing replica`` (row 10) → unconditional ``Warningf`` |

## Backport request

Please apply the ``backport-25.4.x`` label so this fix reaches the 25.4 release branch. The motivating incident is on 25.4 and the change is small and self-contained.

## Tests

- ``gofmt`` clean on all touched files.
- No tests in tree assert on the INFO severity of these specific events; data-driven tests over the SQL slow-query log, jobs structured-event log, or pebble event listener may need golden updates if they capture the channel/severity. CI will surface those.