### PR TITLE
quantize: implement RaBitQ Eq. 14 error bound

### DIFF
--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -406,7 +406,7 @@ func (suite *StoreTestSuite) TestSearchPartitions() {
 
 			// Validate search results.
 			result1 := cspann.SearchResult{
-				QueryDistance: 4.2, ErrorBound: 50.99,
+				QueryDistance: 4.2, ErrorBound: 27.4,
 				ParentPartitionKey: testPartitionKey2, ChildKey: partitionKey4, ValueBytes: valueBytes4}
 			result2 := cspann.SearchResult{
 				QueryDistance: 8, ErrorBound: 0,

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -914,11 +914,11 @@ func TestTransformVector(t *testing.T) {
 	errorBounds := make([]float32, count)
 	quantizer.EstimateDistances(&workspace, originalSet, original.At(0), distances, errorBounds)
 	require.Equal(t, []float32{0, 272.75, 550.86, 950.93, 2421.41}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{27.87, 46.08, 57.55, 69.46, 110.57}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{47.37, 55.93, 78.36, 99.82, 162.95}, testutils.RoundFloats(errorBounds, 2))
 
 	quantizer.EstimateDistances(&workspace, randomizedSet, randomized.At(0), distances, errorBounds)
 	require.Equal(t, []float32{5.1, 292.72, 454.95, 1011.85, 2475.87}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{37.58, 46.08, 57.55, 69.46, 110.57}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{56.23, 62.84, 86.63, 99.59, 162.32}, testutils.RoundFloats(errorBounds, 2))
 }
 
 // TestIndexConcurrency builds an index on multiple goroutines, with background

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -227,10 +227,10 @@ func TestPartition(t *testing.T) {
 		searchSet := SearchSet{MaxResults: 2, IncludeCentroidDistances: true}
 		_ = partition.Search(&workspace, RootKey, vector.T{1, 1}, &searchSet)
 		result1 := SearchResult{
-			QueryDistance: -11.52, ErrorBound: 8.96, CentroidDistance: -8.45, ParentPartitionKey: 1,
+			QueryDistance: -11.52, ErrorBound: 3.44, CentroidDistance: -8.45, ParentPartitionKey: 1,
 			ChildKey: childKey30, ValueBytes: valueBytes30}
 		result2 := SearchResult{
-			QueryDistance: -6.1, ErrorBound: 4.48, CentroidDistance: -5.12, ParentPartitionKey: 1,
+			QueryDistance: -6.1, ErrorBound: 1.72, CentroidDistance: -5.12, ParentPartitionKey: 1,
 			ChildKey: childKey20, ValueBytes: valueBytes20}
 		results := roundResults(searchSet.PopResults(), 2)
 		require.Equal(t, SearchResults{result1, result2}, results)

--- a/pkg/sql/vecindex/cspann/quantize/rabitq.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq.go
@@ -19,6 +19,11 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// epsilon0 is the confidence parameter from Eq. 14 of the RaBitQ paper. The
+// paper recommends 1.9, which gives P{|error| > bound} ≤ 2·exp(−c₀·1.9²),
+// effectively zero for any realistic D.
+const epsilon0 = 1.9
+
 // RaBitQuantizer quantizes vectors according to the algorithm described in this
 // paper:
 //
@@ -42,6 +47,9 @@ type RaBitQuantizer struct {
 	sqrtDims float32
 	// sqrtDimsInv precomputes "1 / sqrtDims".
 	sqrtDimsInv float32
+	// sqrtDimsMinus1Inv precomputes "1 / √(dims-1)". It scales the Eq. 14 error
+	// bound's concentration term. Defined only when dims >= 2.
+	sqrtDimsMinus1Inv float32
 	// unbias is a precomputed slice of "dims" random values in the [0, 1)
 	// interval that's used to remove bias when quantizing query vectors.
 	unbias []float32
@@ -68,8 +76,10 @@ var _ Quantizer = (*RaBitQuantizer)(nil)
 // is created with the same seed that was previously used to create any
 // quantized sets that need to be searched or updated.
 func NewRaBitQuantizer(dims int, seed int64, distanceMetric vecpb.DistanceMetric) Quantizer {
-	if dims <= 0 {
-		panic(errors.AssertionFailedf("dimensions are not positive: %d", dims))
+	if dims < 2 {
+		// The Eq. 14 error bound divides by √(dims-1), and binary quantization
+		// of a single dimension carries no useful information.
+		panic(errors.AssertionFailedf("RaBitQ requires dims >= 2: %d", dims))
 	}
 
 	rng := rand.New(rand.NewSource(seed))
@@ -83,11 +93,12 @@ func NewRaBitQuantizer(dims int, seed int64, distanceMetric vecpb.DistanceMetric
 
 	sqrtDims := num32.Sqrt(float32(dims))
 	return &RaBitQuantizer{
-		dims:           dims,
-		sqrtDims:       sqrtDims,
-		sqrtDimsInv:    1.0 / sqrtDims,
-		unbias:         unbias,
-		distanceMetric: distanceMetric,
+		dims:              dims,
+		sqrtDims:          sqrtDims,
+		sqrtDimsInv:       1.0 / sqrtDims,
+		sqrtDimsMinus1Inv: 1.0 / num32.Sqrt(float32(dims-1)),
+		unbias:            unbias,
+		distanceMetric:    distanceMetric,
 	}
 }
 
@@ -261,6 +272,19 @@ func (q *RaBitQuantizer) EstimateDistances(
 		tempQueryQuantized4[offset] = quantized4 << shift
 	}
 
+	// rabitqErrorBound implements Eq. 14 of the RaBitQ paper. inv is the stored
+	// 1/⟨ō,o⟩ from QuantizedDotProducts; the bound on the estimator ⟨ō,q⟩/⟨ō,o⟩
+	// is √(inv²−1) · ε₀/√(D−1), held with probability ≈ 1. multiplier is the
+	// Jacobian (from Eq. 2 for L2 or footnote 8 for inner-product/cosine) that
+	// converts the bound on ⟨o,q⟩ to a bound on the full distance. The max()
+	// guard handles two non-mathematical cases: inv == 0, the sentinel
+	// quantizeHelper stores when the data vector equals the centroid (the
+	// multiplier is also zero in that case, so the returned bound is zero);
+	// and inv slightly < 1 from float rounding (⟨ō,o⟩ ≤ 1 mathematically).
+	rabitqErrorBound := func(multiplier, inv float32) float32 {
+		return multiplier * num32.Sqrt(max(inv*inv-1, 0)) * epsilon0 * q.sqrtDimsMinus1Inv
+	}
+
 	count := raBitSet.GetCount()
 	for i := range count {
 		code := raBitSet.Codes.At(i)
@@ -305,10 +329,12 @@ func (q *RaBitQuantizer) EstimateDistances(
 			multiplier := 2 * dataCentroidDistance * queryCentroidDistance
 			distance -= multiplier * estimator
 
-			// Error bounds for the estimator are +- 1/√dims. For the entire distance,
-			// that must be scaled by the amount the estimator is scaled by. Ensure
-			// the distance is >= 0, adjusting the error bound accordingly.
-			errorBound := multiplier / q.sqrtDims
+			// Eq. 14 of the RaBitQ paper bounds the estimator error per data
+			// vector using its quantization quality (1/⟨ō,o⟩ stored in
+			// QuantizedDotProducts). When the squared distance is clamped to
+			// zero (the true distance can't be negative), tighten the reported
+			// bound by the amount that was clamped away.
+			errorBound := rabitqErrorBound(multiplier, raBitSet.QuantizedDotProducts[i])
 			if distance < 0 {
 				errorBound = max(errorBound+distance, 0)
 				distance = 0
@@ -329,9 +355,10 @@ func (q *RaBitQuantizer) EstimateDistances(
 			innerProduct := multiplier*estimator +
 				raBitSet.CentroidDotProducts[i] + queryCentroidDotProduct - squaredCentroidNorm
 
-			// Error bounds for the estimator are +- 1/√dims. For the entire distance,
-			// that must be scaled by the amount the estimator is scaled by.
-			errorBound := multiplier / q.sqrtDims
+			// Eq. 14 of the RaBitQ paper bounds the estimator error per data
+			// vector using its quantization quality (1/⟨ō,o⟩ stored in
+			// QuantizedDotProducts).
+			errorBound := rabitqErrorBound(multiplier, raBitSet.QuantizedDotProducts[i])
 
 			var distance float32
 			if q.distanceMetric == vecpb.InnerProductDistance {

--- a/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
@@ -43,7 +43,7 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 		quantizer.EstimateDistances(
 			&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
 		require.Equal(t, []float32{17, 0, 41, 13, 41}, testutils.RoundFloats(distances, 2))
-		require.Equal(t, []float32{7.21, 14.12, 14.42, 0, 14.42},
+		require.Equal(t, []float32{0.01, 19.66, 0.02, 0, 0.02},
 			testutils.RoundFloats(errorBounds, 2))
 		require.Equal(t, []float32{4, 3}, quantizedSet.Centroid)
 
@@ -57,7 +57,7 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 		quantizer.EstimateDistances(
 			&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
 		require.Equal(t, []float32{17, 41}, testutils.RoundFloats(distances, 2))
-		require.Equal(t, []float32{7.21, 14.42}, testutils.RoundFloats(errorBounds, 2))
+		require.Equal(t, []float32{0.01, 0.02}, testutils.RoundFloats(errorBounds, 2))
 
 		// Remove remaining quantized vectors.
 		quantizedSet.ReplaceWithLast(0)
@@ -115,7 +115,7 @@ func TestRaBitQuantizerEdge(t *testing.T) {
 		quantizer.EstimateDistances(
 			&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
 		require.Equal(t, []float32{18, 32}, testutils.RoundFloats(distances, 2))
-		require.Equal(t, []float32{4.95, 4.95}, testutils.RoundFloats(errorBounds, 2))
+		require.Equal(t, []float32{0.01, 0.01}, testutils.RoundFloats(errorBounds, 2))
 	})
 
 	t.Run("many dimensions, not multiple of 64", func(t *testing.T) {
@@ -145,7 +145,7 @@ func TestRaBitQuantizerEdge(t *testing.T) {
 		quantizer.EstimateDistances(
 			&workspace, quantizedSet, ones, distances, errorBounds)
 		require.Equal(t, []float32{141, 0}, testutils.RoundFloats(distances, 2))
-		require.Equal(t, []float32{5.94, 5.94}, testutils.RoundFloats(errorBounds, 2))
+		require.Equal(t, []float32{0.02, 0.02}, testutils.RoundFloats(errorBounds, 2))
 	})
 
 	t.Run("add centroid to set", func(t *testing.T) {
@@ -166,7 +166,7 @@ func TestRaBitQuantizerEdge(t *testing.T) {
 		quantizer.EstimateDistances(
 			&workspace, quantizedSet, vector.T{3, 2}, distances, errorBounds)
 		require.Equal(t, []float32{22.33, 115.67, 22.33, 49}, testutils.RoundFloats(distances, 2))
-		require.Equal(t, []float32{44.27, 44.27, 44.27, 0}, testutils.RoundFloats(errorBounds, 2))
+		require.Equal(t, []float32{39.65, 39.65, 39.65, 0}, testutils.RoundFloats(errorBounds, 2))
 
 		// Estimate distances when the query vector is the centroid.
 		quantizer.EstimateDistances(
@@ -205,7 +205,7 @@ func TestRaBitQuantizerInnerProduct(t *testing.T) {
 	errorBounds := make([]float32, quantizedSet.GetCount())
 	quantizer.EstimateDistances(&workspace, quantizedSet, vector.T{3, 4}, distances, errorBounds)
 	require.Equal(t, []float32{-23, -9, -38}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{1.41, 3.16, 2.83}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{0, 4.25, 0}, testutils.RoundFloats(errorBounds, 2))
 
 	// Call NewQuantizedSet and ensure capacity.
 	quantizedSet = quantizer.NewSet(
@@ -238,7 +238,7 @@ func TestRaBitQuantizerCosine(t *testing.T) {
 	errorBounds := make([]float32, quantizedSet.GetCount())
 	quantizer.EstimateDistances(&workspace, quantizedSet, vector.T{-1, 0}, distances, errorBounds)
 	require.Equal(t, []float32{2, 1.14, 1.71}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{0.69, 0.84, 0.23}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{0.16, 0.31, 0}, testutils.RoundFloats(errorBounds, 2))
 
 	// Call NewQuantizedSet and ensure capacity.
 	centroid := slices.Clone(quantizedSet.Centroid)
@@ -288,8 +288,8 @@ func TestRaBitQuantizeEmbeddings(t *testing.T) {
 	num32.Round(errorBounds, 4)
 	require.Equal(t, float32(0), distances[0])
 	require.Equal(t, float32(1.1069), distances[99])
-	require.Equal(t, float32(0.0247), errorBounds[0])
-	require.Equal(t, float32(0.0476), errorBounds[99])
+	require.Equal(t, float32(0.0651), errorBounds[0])
+	require.Equal(t, float32(0.0738), errorBounds[99])
 }
 
 // Benchmark quantization of 100 vectors.

--- a/pkg/sql/vecindex/cspann/quantize/testdata/estimate-distances.ddt
+++ b/pkg/sql/vecindex/cspann/quantize/testdata/estimate-distances.ddt
@@ -6,18 +6,18 @@ estimate-distances query=[0,2]
 L2Squared
   Query = [0, 2]
   Centroid = [0, 0]
-  [-2, 0]: exact is 8, estimate is 0 ± 5.7
-  [2, 0]: exact is 8, estimate is 0 ± 5.7
+  [-2, 0]: exact is 8, estimate is 0 ± 15.2
+  [2, 0]: exact is 8, estimate is 0 ± 15.2
 InnerProduct
   Query = [0, 2]
   Centroid = [0, 0]
-  [-2, 0]: exact is 0, estimate is -4 ± 2.8
-  [2, 0]: exact is 0, estimate is -4 ± 2.8
+  [-2, 0]: exact is 0, estimate is -4 ± 7.6
+  [2, 0]: exact is 0, estimate is -4 ± 7.6
 Cosine
   Query = [0, 1]
   Centroid = [0, 0]
-  [-1, 0]: exact is 1, estimate is 0 ± 0.7071
-  [1, 0]: exact is 1, estimate is 0 ± 0.7071
+  [-1, 0]: exact is 1, estimate is 0 ± 1.9
+  [1, 0]: exact is 1, estimate is 0 ± 1.9
 
 # Translate centroid to non-origin point [2,2].
 estimate-distances query=[2,4]
@@ -27,18 +27,18 @@ estimate-distances query=[2,4]
 L2Squared
   Query = [2, 4]
   Centroid = [2, 2]
-  [0, 2]: exact is 8, estimate is 0 ± 5.7
-  [4, 2]: exact is 8, estimate is 0 ± 5.7
+  [0, 2]: exact is 8, estimate is 0 ± 15.2
+  [4, 2]: exact is 8, estimate is 0 ± 15.2
 InnerProduct
   Query = [2, 4]
   Centroid = [2, 2]
-  [0, 2]: exact is -8, estimate is -12 ± 2.8
-  [4, 2]: exact is -16, estimate is -20 ± 2.8
+  [0, 2]: exact is -8, estimate is -12 ± 7.6
+  [4, 2]: exact is -16, estimate is -20 ± 7.6
 Cosine
   Query = [0.4472, 0.8944]
   Centroid = [0.4472, 0.7236]
-  [0, 1]: exact is 0.106, estimate is 0.0875 ± 0.0635
-  [0.8944, 0.4472]: exact is 0.2, estimate is 0.218 ± 0.0635
+  [0, 1]: exact is 0.106, estimate is 0.0875 ± 0.0403
+  [0.8944, 0.4472]: exact is 0.2, estimate is 0.218 ± 0.0403
 
 # Centroid is [0,0], query vector equals one of the data vectors.
 estimate-distances query=[2,0]
@@ -48,18 +48,18 @@ estimate-distances query=[2,0]
 L2Squared
   Query = [2, 0]
   Centroid = [0, 0]
-  [-2, 0]: exact is 16, estimate is 16 ± 5.7
-  [2, 0]: exact is 0, estimate is 0 ± 5.7
+  [-2, 0]: exact is 16, estimate is 16 ± 15.2
+  [2, 0]: exact is 0, estimate is 0 ± 15.2
 InnerProduct
   Query = [2, 0]
   Centroid = [0, 0]
-  [-2, 0]: exact is 4, estimate is 4 ± 2.8
-  [2, 0]: exact is -4, estimate is -4 ± 2.8
+  [-2, 0]: exact is 4, estimate is 4 ± 7.6
+  [2, 0]: exact is -4, estimate is -4 ± 7.6
 Cosine
   Query = [1, 0]
   Centroid = [0, 0]
-  [-1, 0]: exact is 2, estimate is 2 ± 0.7071
-  [1, 0]: exact is 0, estimate is 0 ± 0.7071
+  [-1, 0]: exact is 2, estimate is 2 ± 1.9
+  [1, 0]: exact is 0, estimate is 0 ± 1.9
 
 # Translate centroid to non-origin point [2,2].
 estimate-distances query=[4,2]
@@ -69,18 +69,18 @@ estimate-distances query=[4,2]
 L2Squared
   Query = [4, 2]
   Centroid = [2, 2]
-  [0, 2]: exact is 16, estimate is 16 ± 5.7
-  [4, 2]: exact is 0, estimate is 0 ± 5.7
+  [0, 2]: exact is 16, estimate is 16 ± 15.2
+  [4, 2]: exact is 0, estimate is 0 ± 15.2
 InnerProduct
   Query = [4, 2]
   Centroid = [2, 2]
-  [0, 2]: exact is -4, estimate is -4 ± 2.8
-  [4, 2]: exact is -20, estimate is -20 ± 2.8
+  [0, 2]: exact is -4, estimate is -4 ± 7.6
+  [4, 2]: exact is -20, estimate is -20 ± 7.6
 Cosine
   Query = [0.8944, 0.4472]
   Centroid = [0.4472, 0.7236]
-  [0, 1]: exact is 0.553, estimate is 0.5528 ± 0.1954
-  [0.8944, 0.4472]: exact is 0, estimate is 0 ± 0.1954
+  [0, 1]: exact is 0.553, estimate is 0.5528 ± 0.124
+  [0.8944, 0.4472]: exact is 0, estimate is 0 ± 0.124
 
 # Query vector is parallel, but longer, than one of the data vectors.
 estimate-distances query=[4,0]
@@ -90,18 +90,18 @@ estimate-distances query=[4,0]
 L2Squared
   Query = [4, 0]
   Centroid = [0, 0]
-  [-2, 0]: exact is 36, estimate is 36 ± 11.3
-  [2, 0]: exact is 4, estimate is 4 ± 11.3
+  [-2, 0]: exact is 36, estimate is 36 ± 30.4
+  [2, 0]: exact is 4, estimate is 4 ± 30.4
 InnerProduct
   Query = [4, 0]
   Centroid = [0, 0]
-  [-2, 0]: exact is 8, estimate is 8 ± 5.7
-  [2, 0]: exact is -8, estimate is -8 ± 5.7
+  [-2, 0]: exact is 8, estimate is 8 ± 15.2
+  [2, 0]: exact is -8, estimate is -8 ± 15.2
 Cosine
   Query = [1, 0]
   Centroid = [0, 0]
-  [-1, 0]: exact is 2, estimate is 2 ± 0.7071
-  [1, 0]: exact is 0, estimate is 0 ± 0.7071
+  [-1, 0]: exact is 2, estimate is 2 ± 1.9
+  [1, 0]: exact is 0, estimate is 0 ± 1.9
 
 # Query vector is equal to the centroid at the origin.
 estimate-distances query=[0,0]
@@ -142,8 +142,8 @@ InnerProduct
 Cosine
   Query = [0.7071, 0.7071]
   Centroid = [0.4472, 0.7236]
-  [0, 1]: exact is 0.293, estimate is 0.2777 ± 0.0968
-  [0.8944, 0.4472]: exact is 0.051, estimate is 0.0665 ± 0.0968
+  [0, 1]: exact is 0.293, estimate is 0.2777 ± 0.0614
+  [0.8944, 0.4472]: exact is 0.051, estimate is 0.0665 ± 0.0614
 
 # All data vectors are the same, query is the same.
 estimate-distances query=[2,2]
@@ -229,15 +229,15 @@ estimate-distances query=[10,0]
 L2Squared
   Query = [10, 0]
   Centroid = [7, 0]
-  [1, 0]: exact is 81, estimate is 81 ± 25.5
-  [4, 0]: exact is 36, estimate is 36 ± 12.7
-  [16, 0]: exact is 36, estimate is 36 ± 38.2
+  [1, 0]: exact is 81, estimate is 81 ± 68.4
+  [4, 0]: exact is 36, estimate is 36 ± 34.2
+  [16, 0]: exact is 36, estimate is 36 ± 102.6
 InnerProduct
   Query = [10, 0]
   Centroid = [7, 0]
-  [1, 0]: exact is -10, estimate is -10 ± 12.7
-  [4, 0]: exact is -40, estimate is -40 ± 6.4
-  [16, 0]: exact is -160, estimate is -160 ± 19.1
+  [1, 0]: exact is -10, estimate is -10 ± 34.2
+  [4, 0]: exact is -40, estimate is -40 ± 17.1
+  [16, 0]: exact is -160, estimate is -160 ± 51.3
 Cosine
   Query = [1, 0]
   Centroid = [1, 0]
@@ -257,30 +257,30 @@ estimate-distances query=[3,4]
 L2Squared
   Query = [3, 4]
   Centroid = [4.5, 3.5]
-  [5, -1]: exact is 29, estimate is 39.4 ± 10.1
-  [2, 2]: exact is 5, estimate is 6.8 ± 6.5
-  [3, 4]: exact is 0, estimate is 0 ± 3.5
-  [4, 3]: exact is 2, estimate is 2 ± 1.6
-  [1, 8]: exact is 20, estimate is 18.7 ± 12.7
-  [12, 5]: exact is 82, estimate is 74 ± 17.1
+  [5, -1]: exact is 29, estimate is 39.4 ± 21.8
+  [2, 2]: exact is 5, estimate is 6.8 ± 4.4
+  [3, 4]: exact is 0, estimate is 0 ± 4.8
+  [4, 3]: exact is 2, estimate is 2 ± 0
+  [1, 8]: exact is 20, estimate is 18.7 ± 4.3
+  [12, 5]: exact is 82, estimate is 74 ± 30.6
 InnerProduct
   Query = [3, 4]
   Centroid = [4.5, 3.5]
-  [5, -1]: exact is -11, estimate is -5.8 ± 5.1
-  [2, 2]: exact is -14, estimate is -13.1 ± 3.3
-  [3, 4]: exact is -25, estimate is -25 ± 1.8
-  [4, 3]: exact is -24, estimate is -24 ± 0.8
-  [1, 8]: exact is -35, estimate is -35.6 ± 6.4
-  [12, 5]: exact is -56, estimate is -60 ± 8.6
+  [5, -1]: exact is -11, estimate is -5.8 ± 10.9
+  [2, 2]: exact is -14, estimate is -13.1 ± 2.2
+  [3, 4]: exact is -25, estimate is -25 ± 2.4
+  [4, 3]: exact is -24, estimate is -24 ± 0
+  [1, 8]: exact is -35, estimate is -35.6 ± 2.1
+  [12, 5]: exact is -56, estimate is -60 ± 15.3
 Cosine
   Query = [0.6, 0.8]
   Centroid = [0.6891, 0.548]
-  [0.9806, -0.1961]: exact is 0.569, estimate is 0.5654 ± 0.1511
-  [0.7071, 0.7071]: exact is 0.01, estimate is 0.025 ± 0.0303
-  [0.6, 0.8]: exact is 0, estimate is 0 ± 0.0505
-  [0.8, 0.6]: exact is 0.04, estimate is 0.0282 ± 0.0231
-  [0.124, 0.9923]: exact is 0.132, estimate is 0.1195 ± 0.1359
-  [0.9231, 0.3846]: exact is 0.138, estimate is 0.1463 ± 0.0539
+  [0.9806, -0.1961]: exact is 0.569, estimate is 0.5654 ± 0.1774
+  [0.7071, 0.7071]: exact is 0.01, estimate is 0.025 ± 0.0648
+  [0.6, 0.8]: exact is 0, estimate is 0 ± 0.0648
+  [0.8, 0.6]: exact is 0.04, estimate is 0.0282 ± 0.0225
+  [0.124, 0.9923]: exact is 0.132, estimate is 0.1195 ± 0.0437
+  [0.9231, 0.3846]: exact is 0.138, estimate is 0.1463 ± 0.0257
 
 # Query is far outside the data cloud.
 estimate-distances query=[100,100]
@@ -294,30 +294,30 @@ estimate-distances query=[100,100]
 L2Squared
   Query = [100, 100]
   Centroid = [4.5, 3.6667]
-  [5, -1]: exact is 19226, estimate is 18429.5 ± 900.4
-  [2, 2]: exact is 19208, estimate is 19240.7 ± 576.4
-  [3, 4]: exact is 18625, estimate is 18400.6 ± 294.8
-  [4, 3]: exact is 18625, estimate is 18629.4 ± 159.9
-  [1, 8]: exact is 18265, estimate is 18424.8 ± 1068.6
-  [12, 6]: exact is 16580, estimate is 16054.9 ± 1506.8
+  [5, -1]: exact is 19226, estimate is 18429.5 ± 1951
+  [2, 2]: exact is 19208, estimate is 19240.7 ± 309.8
+  [3, 4]: exact is 18625, estimate is 18400.6 ± 504
+  [4, 3]: exact is 18625, estimate is 18629.4 ± 61.4
+  [1, 8]: exact is 18265, estimate is 18424.8 ± 305.5
+  [12, 6]: exact is 16580, estimate is 16054.9 ± 2127.3
 InnerProduct
   Query = [100, 100]
   Centroid = [4.5, 3.6667]
-  [5, -1]: exact is -400, estimate is -798.3 ± 450.2
-  [2, 2]: exact is -400, estimate is -383.7 ± 288.2
-  [3, 4]: exact is -700, estimate is -812.2 ± 147.4
-  [4, 3]: exact is -700, estimate is -697.8 ± 79.9
-  [1, 8]: exact is -900, estimate is -820.1 ± 534.3
-  [12, 6]: exact is -1800, estimate is -2062.5 ± 753.4
+  [5, -1]: exact is -400, estimate is -798.3 ± 975.5
+  [2, 2]: exact is -400, estimate is -383.7 ± 154.9
+  [3, 4]: exact is -700, estimate is -812.2 ± 252
+  [4, 3]: exact is -700, estimate is -697.8 ± 30.7
+  [1, 8]: exact is -900, estimate is -820.1 ± 152.7
+  [12, 6]: exact is -1800, estimate is -2062.5 ± 1063.7
 Cosine
   Query = [0.7071, 0.7071]
   Centroid = [0.6844, 0.5584]
-  [0.9806, -0.1961]: exact is 0.445, estimate is 0.4186 ± 0.0862
-  [0.7071, 0.7071]: exact is 0, estimate is 0 ± 0.016
-  [0.6, 0.8]: exact is 0.01, estimate is 0.0188 ± 0.0272
-  [0.8, 0.6]: exact is 0.01, estimate is 0.0024 ± 0.0131
-  [0.124, 0.9923]: exact is 0.211, estimate is 0.1988 ± 0.0754
-  [0.8944, 0.4472]: exact is 0.051, estimate is 0.0617 ± 0.0253
+  [0.9806, -0.1961]: exact is 0.445, estimate is 0.4186 ± 0.101
+  [0.7071, 0.7071]: exact is 0, estimate is 0 ± 0.0316
+  [0.6, 0.8]: exact is 0.01, estimate is 0.0188 ± 0.0353
+  [0.8, 0.6]: exact is 0.01, estimate is 0.0024 ± 0.0165
+  [0.124, 0.9923]: exact is 0.211, estimate is 0.1988 ± 0.0258
+  [0.8944, 0.4472]: exact is 0.051, estimate is 0.0617 ± 0.0209
 
 # Data cloud is far away from origin.
 estimate-distances query=[108,108]
@@ -331,30 +331,30 @@ estimate-distances query=[108,108]
 L2Squared
   Query = [108, 108]
   Centroid = [104.5, 103.5]
-  [105, 99]: exact is 90, estimate is 61.2 ± 36.5
-  [102, 102]: exact is 72, estimate is 75 ± 23.5
-  [103, 104]: exact is 41, estimate is 32.5 ± 12.7
-  [104, 103]: exact is 41, estimate is 41 ± 5.7
-  [101, 108]: exact is 49, estimate is 56.9 ± 46
-  [112, 105]: exact is 25, estimate is 0 ± 48.7
+  [105, 99]: exact is 90, estimate is 61.2 ± 78.5
+  [102, 102]: exact is 72, estimate is 75 ± 15.8
+  [103, 104]: exact is 41, estimate is 32.5 ± 17.1
+  [104, 103]: exact is 41, estimate is 41 ± 0
+  [101, 108]: exact is 49, estimate is 56.9 ± 15.4
+  [112, 105]: exact is 25, estimate is 0 ± 97.5
 InnerProduct
   Query = [108, 108]
   Centroid = [104.5, 103.5]
-  [105, 99]: exact is -22032, estimate is -22046.4 ± 18.3
-  [102, 102]: exact is -22032, estimate is -22030.5 ± 11.8
-  [103, 104]: exact is -22356, estimate is -22360.2 ± 6.4
-  [104, 103]: exact is -22356, estimate is -22356 ± 2.9
-  [101, 108]: exact is -22572, estimate is -22568.1 ± 23
-  [112, 105]: exact is -23436, estimate is -23455 ± 30.8
+  [105, 99]: exact is -22032, estimate is -22046.4 ± 39.2
+  [102, 102]: exact is -22032, estimate is -22030.5 ± 7.9
+  [103, 104]: exact is -22356, estimate is -22360.2 ± 8.6
+  [104, 103]: exact is -22356, estimate is -22356 ± 0
+  [101, 108]: exact is -22572, estimate is -22568.1 ± 7.7
+  [112, 105]: exact is -23436, estimate is -23455 ± 55.2
 Cosine
   Query = [0.7071, 0.7071]
   Centroid = [0.7102, 0.7036]
-  [0.7276, 0.686]: exact is 0, estimate is 0.0004 ± 0.0001
+  [0.7276, 0.686]: exact is 0, estimate is 0.0004 ± 0
   [0.7071, 0.7071]: exact is 0, estimate is 0 ± 0
   [0.7037, 0.7105]: exact is 0, estimate is 0 ± 0
   [0.7105, 0.7037]: exact is 0, estimate is 0 ± 0
-  [0.683, 0.7304]: exact is 0.001, estimate is 0.0006 ± 0.0001
-  [0.7295, 0.6839]: exact is 0.001, estimate is 0.0005 ± 0.0001
+  [0.683, 0.7304]: exact is 0.001, estimate is 0.0006 ± 0
+  [0.7295, 0.6839]: exact is 0.001, estimate is 0.0005 ± 0
 
 # Test more dimensions.
 estimate-distances query=[4,3,7,8]
@@ -368,27 +368,27 @@ estimate-distances query=[4,3,7,8]
 L2Squared
   Query = [4, 3, 7, 8]
   Centroid = [4.5, 3.5, 4.8333, 6.1667]
-  [5, -1, 3, 10]: exact is 37, estimate is 49.7 ± 18.2
-  [2, 2, -5, 4]: exact is 165, estimate is 159.3 ± 30.7
-  [3, 4, 8, 7]: exact is 4, estimate is 4.2 ± 10.6
-  [4, 3, 7, 8]: exact is 0, estimate is 0.1 ± 8.6
-  [1, 8, 10, 12]: exact is 59, estimate is 62.7 ± 28.2
-  [12, 5, 6, -4]: exact is 213, estimate is 182.1 ± 37.4
+  [5, -1, 3, 10]: exact is 37, estimate is 49.7 ± 23.8
+  [2, 2, -5, 4]: exact is 165, estimate is 159.3 ± 57
+  [3, 4, 8, 7]: exact is 4, estimate is 4.2 ± 16
+  [4, 3, 7, 8]: exact is 0, estimate is 0.1 ± 11.4
+  [1, 8, 10, 12]: exact is 59, estimate is 62.7 ± 11.2
+  [12, 5, 6, -4]: exact is 213, estimate is 182.1 ± 62.4
 InnerProduct
   Query = [4, 3, 7, 8]
   Centroid = [4.5, 3.5, 4.8333, 6.1667]
-  [5, -1, 3, 10]: exact is -118, estimate is -111.7 ± 9.1
-  [2, 2, -5, 4]: exact is -11, estimate is -13.8 ± 15.3
-  [3, 4, 8, 7]: exact is -136, estimate is -135.9 ± 5.3
-  [4, 3, 7, 8]: exact is -138, estimate is -138 ± 4.3
-  [1, 8, 10, 12]: exact is -194, estimate is -192.1 ± 14.1
-  [12, 5, 6, -4]: exact is -73, estimate is -88.4 ± 18.7
+  [5, -1, 3, 10]: exact is -118, estimate is -111.7 ± 11.9
+  [2, 2, -5, 4]: exact is -11, estimate is -13.8 ± 28.5
+  [3, 4, 8, 7]: exact is -136, estimate is -135.9 ± 8
+  [4, 3, 7, 8]: exact is -138, estimate is -138 ± 5.7
+  [1, 8, 10, 12]: exact is -194, estimate is -192.1 ± 5.6
+  [12, 5, 6, -4]: exact is -73, estimate is -88.4 ± 31.2
 Cosine
   Query = [0.3405, 0.2554, 0.5959, 0.681]
   Centroid = [0.3627, 0.2645, 0.2989, 0.5204]
-  [0.4303, -0.0861, 0.2582, 0.8607]: exact is 0.135, estimate is 0.2254 ± 0.0838
-  [0.2857, 0.2857, -0.7143, 0.5714]: exact is 0.866, estimate is 0.7077 ± 0.1722
-  [0.2554, 0.3405, 0.681, 0.5959]: exact is 0.014, estimate is 0.0244 ± 0.0696
-  [0.3405, 0.2554, 0.5959, 0.681]: exact is 0, estimate is 0 ± 0.0572
-  [0.0569, 0.4551, 0.5689, 0.6827]: exact is 0.061, estimate is 0.062 ± 0.081
-  [0.8072, 0.3363, 0.4036, -0.2691]: exact is 0.582, estimate is 0.4137 ± 0.1548
+  [0.4303, -0.0861, 0.2582, 0.8607]: exact is 0.135, estimate is 0.2254 ± 0.1342
+  [0.2857, 0.2857, -0.7143, 0.5714]: exact is 0.866, estimate is 0.7077 ± 0.543
+  [0.2554, 0.3405, 0.681, 0.5959]: exact is 0.014, estimate is 0.0244 ± 0.1227
+  [0.3405, 0.2554, 0.5959, 0.681]: exact is 0, estimate is 0 ± 0.1203
+  [0.0569, 0.4551, 0.5689, 0.6827]: exact is 0.061, estimate is 0.062 ± 0.0444
+  [0.8072, 0.3363, 0.4036, -0.2691]: exact is 0.582, estimate is 0.4137 ± 0.2807

--- a/pkg/sql/vecindex/cspann/testdata/merge.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/merge.ddt
@@ -159,7 +159,7 @@ search
 [0, -1]
 ----
 vec7: 1
-5 leaf vectors, 8 vectors, 3 full vectors, 3 partitions
+5 leaf vectors, 8 vectors, 5 full vectors, 3 partitions
 
 format-tree
 ----

--- a/pkg/sql/vecindex/cspann/testdata/read-only.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/read-only.ddt
@@ -37,7 +37,7 @@ vec4: 2
 vec10: 4
 vec5: 4
 vec8: 4
-13 leaf vectors, 16 vectors, 5 full vectors, 4 partitions
+13 leaf vectors, 16 vectors, 4 full vectors, 4 partitions
 
 format-tree
 ----
@@ -71,7 +71,7 @@ search max-results=3 beam-size=3
 vec9: 18
 vec11: 25
 vec5: 26
-13 leaf vectors, 16 vectors, 10 full vectors, 4 partitions
+13 leaf vectors, 16 vectors, 5 full vectors, 4 partitions
 
 format-tree
 ----

--- a/pkg/sql/vecindex/cspann/testdata/search-embeddings.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-embeddings.ddt
@@ -25,7 +25,7 @@ vec50: 0.8542
 vec282: 0.8908
 vec359: 0.8978
 vec208: 0.9026
-9 leaf vectors, 29 vectors, 8 full vectors, 3 partitions
+9 leaf vectors, 29 vectors, 9 full vectors, 3 partitions
 
 # Use a larger beam size.
 search max-results=6 use-dataset=5000 beam-size=4
@@ -36,17 +36,17 @@ vec309: 0.7311
 vec25: 0.761
 vec240: 0.7723
 vec347: 0.7745
-49 leaf vectors, 76 vectors, 12 full vectors, 7 partitions
+49 leaf vectors, 76 vectors, 15 full vectors, 7 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-dataset=5000 beam-size=4 skip-rerank
 ----
-vec329: 0.655 ± 0.04
-vec640: 0.6854 ± 0.04
-vec309: 0.7225 ± 0.04
-vec240: 0.7637 ± 0.04
-vec704: 0.7669 ± 0.04
-vec25: 0.7694 ± 0.04
+vec329: 0.655 ± 0.06
+vec640: 0.6854 ± 0.06
+vec309: 0.7225 ± 0.05
+vec240: 0.7637 ± 0.05
+vec704: 0.7669 ± 0.06
+vec25: 0.7694 ± 0.05
 49 leaf vectors, 76 vectors, 0 full vectors, 7 partitions
 
 # Return top 25 results with large beam size.
@@ -77,19 +77,19 @@ vec525: 0.8184
 vec37: 0.8214
 vec202: 0.8218
 vec706: 0.8238
-161 leaf vectors, 255 vectors, 51 full vectors, 25 partitions
+161 leaf vectors, 255 vectors, 68 full vectors, 25 partitions
 
 # Search for an "easy" result, where adaptive search inspects less partitions.
 recall topk=20 use-dataset=8601 beam-size=8
 ----
 75.00% recall@20
-75 leaf vectors, 126 vectors, 32 full vectors, 13 partitions
+75 leaf vectors, 126 vectors, 34 full vectors, 13 partitions
 
 # Search for a "hard" result, where adaptive search inspects more partitions.
 recall topk=20 use-dataset=2717 beam-size=8
 ----
 35.00% recall@20
-89 leaf vectors, 145 vectors, 48 full vectors, 13 partitions
+89 leaf vectors, 145 vectors, 52 full vectors, 13 partitions
 
 # Show the nearest partitions to the "easy" vector, ordered by estimated
 # distance to their centroids. Notice that there are several partitions that are
@@ -97,16 +97,16 @@ recall topk=20 use-dataset=2717 beam-size=8
 # finding results easier.
 best-centroids topk=10 use-dataset=8601
 ----
-149: 0.1720 ± 0.0150 (exact=0.1766)
-211: 0.2046 ± 0.0148 (exact=0.1888)
-206: 0.2525 ± 0.0135 (exact=0.2491)
-210: 0.2686 ± 0.0140 (exact=0.2516)
-177: 0.2908 ± 0.0204 (exact=0.2788)
-205: 0.2932 ± 0.0160 (exact=0.2839)
-78: 0.2993 ± 0.0114 (exact=0.3013)
-176: 0.3442 ± 0.0145 (exact=0.3378)
-148: 0.3447 ± 0.0136 (exact=0.3536)
-197: 0.3454 ± 0.0113 (exact=0.3456)
+149: 0.1720 ± 0.0203 (exact=0.1766)
+211: 0.2046 ± 0.0206 (exact=0.1888)
+206: 0.2525 ± 0.0190 (exact=0.2491)
+210: 0.2686 ± 0.0194 (exact=0.2516)
+177: 0.2908 ± 0.0277 (exact=0.2788)
+205: 0.2932 ± 0.0230 (exact=0.2839)
+78: 0.2993 ± 0.0155 (exact=0.3013)
+176: 0.3442 ± 0.0209 (exact=0.3378)
+148: 0.3447 ± 0.0212 (exact=0.3536)
+197: 0.3454 ± 0.0167 (exact=0.3456)
 
 # Show the nearest partitions to the "hard" vector, ordered by estimated
 # distance to their centroids. Notice that the partitions are relatively far
@@ -114,42 +114,42 @@ best-centroids topk=10 use-dataset=8601
 # more difficult.
 best-centroids topk=10 use-dataset=2717
 ----
-102: 0.5314 ± 0.0174 (exact=0.5311)
-201: 0.5355 ± 0.0220 (exact=0.5554)
-129: 0.5391 ± 0.0191 (exact=0.5444)
-158: 0.5487 ± 0.0173 (exact=0.5536)
-43: 0.5508 ± 0.0220 (exact=0.5358)
-64: 0.5747 ± 0.0215 (exact=0.5869)
-117: 0.5759 ± 0.0210 (exact=0.5823)
-192: 0.5792 ± 0.0180 (exact=0.5793)
-54: 0.5863 ± 0.0177 (exact=0.5906)
-153: 0.5928 ± 0.0233 (exact=0.5855)
+102: 0.5314 ± 0.0257 (exact=0.5311)
+201: 0.5355 ± 0.0336 (exact=0.5554)
+129: 0.5391 ± 0.0283 (exact=0.5444)
+158: 0.5487 ± 0.0248 (exact=0.5536)
+43: 0.5508 ± 0.0314 (exact=0.5358)
+64: 0.5747 ± 0.0294 (exact=0.5869)
+117: 0.5759 ± 0.0294 (exact=0.5823)
+192: 0.5792 ± 0.0273 (exact=0.5793)
+54: 0.5863 ± 0.0254 (exact=0.5906)
+153: 0.5928 ± 0.0323 (exact=0.5855)
 
 # Test recall at different beam sizes.
 recall topk=10 beam-size=2 samples=64
 ----
 25.78% recall@10
-22 leaf vectors, 42 vectors, 16 full vectors, 4 partitions
+22 leaf vectors, 42 vectors, 17 full vectors, 4 partitions
 
 recall topk=10 beam-size=4 samples=64
 ----
 47.81% recall@10
-43 leaf vectors, 75 vectors, 19 full vectors, 7 partitions
+43 leaf vectors, 75 vectors, 23 full vectors, 7 partitions
 
 recall topk=10 beam-size=8 samples=64
 ----
 71.09% recall@10
-83 leaf vectors, 138 vectors, 22 full vectors, 13 partitions
+83 leaf vectors, 138 vectors, 28 full vectors, 13 partitions
 
 recall topk=10 beam-size=16 samples=64
 ----
-86.56% recall@10
-165 leaf vectors, 261 vectors, 26 full vectors, 25 partitions
+86.72% recall@10
+165 leaf vectors, 261 vectors, 35 full vectors, 25 partitions
 
 recall topk=10 beam-size=32 samples=64
 ----
-96.09% recall@10
-328 leaf vectors, 435 vectors, 30 full vectors, 42 partitions
+96.25% recall@10
+328 leaf vectors, 435 vectors, 41 full vectors, 42 partitions
 
 # ----------------------------------------------------------------------
 # Compare orderings of same dataset with different distance metrics.
@@ -176,7 +176,7 @@ vec610: 3558417
 vec152: 3574788
 vec611: 3682006
 vec420: 3781823
-1000 leaf vectors, 1104 vectors, 15 full vectors, 105 partitions
+1000 leaf vectors, 1104 vectors, 18 full vectors, 105 partitions
 
 # Now use lower beam size.
 search max-results=10 use-dataset=999 beam-size=8
@@ -191,7 +191,7 @@ vec610: 3558417
 vec152: 3574788
 vec611: 3682006
 vec420: 3781823
-80 leaf vectors, 124 vectors, 15 full vectors, 13 partitions
+80 leaf vectors, 124 vectors, 18 full vectors, 13 partitions
 
 # Cosine.
 new-index dataset=fashion-784d-1k.gob train-count=1000 distance-metric=Cosine min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4
@@ -215,7 +215,7 @@ vec409: 0.1185
 vec144: 0.1197
 vec476: 0.124
 vec109: 0.1273
-1000 leaf vectors, 1109 vectors, 12 full vectors, 110 partitions
+1000 leaf vectors, 1109 vectors, 13 full vectors, 110 partitions
 
 # Now use lower beam size.
 search max-results=10 use-dataset=999 beam-size=8
@@ -230,7 +230,7 @@ vec409: 0.1185
 vec144: 0.1197
 vec476: 0.124
 vec109: 0.1273
-91 leaf vectors, 134 vectors, 12 full vectors, 13 partitions
+91 leaf vectors, 134 vectors, 13 full vectors, 13 partitions
 
 # InnerProduct.
 new-index dataset=fashion-784d-1k.gob train-count=1000 distance-metric=InnerProduct min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4
@@ -257,7 +257,7 @@ vec312: -14063724
 vec197: -14040257
 vec476: -13816669
 vec311: -13589641
-1000 leaf vectors, 1117 vectors, 18 full vectors, 118 partitions
+1000 leaf vectors, 1117 vectors, 21 full vectors, 118 partitions
 
 # Now use lower beam size.
 search max-results=10 use-dataset=999 beam-size=8
@@ -290,22 +290,22 @@ CV stats:
 recall topk=10 beam-size=4 samples=50
 ----
 55.40% recall@10
-41 leaf vectors, 74 vectors, 20 full vectors, 7 partitions
+41 leaf vectors, 74 vectors, 22 full vectors, 7 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
 78.00% recall@10
-81 leaf vectors, 138 vectors, 21 full vectors, 13 partitions
+81 leaf vectors, 138 vectors, 27 full vectors, 13 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
 87.80% recall@10
-162 leaf vectors, 266 vectors, 25 full vectors, 25 partitions
+162 leaf vectors, 266 vectors, 33 full vectors, 25 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-96.40% recall@10
-320 leaf vectors, 424 vectors, 26 full vectors, 41 partitions
+96.60% recall@10
+320 leaf vectors, 424 vectors, 35 full vectors, 41 partitions
 
 # ----------------------------------------------------------------------
 # Load 950 768-dimension image embeddings and search them using
@@ -323,22 +323,22 @@ CV stats:
 recall topk=10 beam-size=4 samples=50
 ----
 50.40% recall@10
-44 leaf vectors, 74 vectors, 21 full vectors, 7 partitions
+44 leaf vectors, 74 vectors, 25 full vectors, 7 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
 70.00% recall@10
-86 leaf vectors, 136 vectors, 25 full vectors, 13 partitions
+86 leaf vectors, 136 vectors, 32 full vectors, 13 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
 85.60% recall@10
-175 leaf vectors, 266 vectors, 29 full vectors, 25 partitions
+175 leaf vectors, 266 vectors, 40 full vectors, 25 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
 96.40% recall@10
-349 leaf vectors, 450 vectors, 33 full vectors, 42 partitions
+349 leaf vectors, 450 vectors, 47 full vectors, 42 partitions
 
 # ----------------------------------------------------------------------
 # Load 1000 512-dimension image embeddings generated with a multi-modal
@@ -357,34 +357,34 @@ CV stats:
 recall topk=10 beam-size=4 samples=50
 ----
 20.60% recall@10
-40 leaf vectors, 71 vectors, 36 full vectors, 7 partitions
+40 leaf vectors, 71 vectors, 39 full vectors, 7 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
 34.20% recall@10
-78 leaf vectors, 129 vectors, 62 full vectors, 13 partitions
+78 leaf vectors, 129 vectors, 74 full vectors, 13 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
-52.60% recall@10
-158 leaf vectors, 247 vectors, 98 full vectors, 25 partitions
+53.00% recall@10
+158 leaf vectors, 247 vectors, 135 full vectors, 25 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-70.40% recall@10
-327 leaf vectors, 435 vectors, 151 full vectors, 43 partitions
+71.80% recall@10
+327 leaf vectors, 435 vectors, 241 full vectors, 43 partitions
 
 recall topk=10 beam-size=64 samples=50
 ----
-91.20% recall@10
-661 leaf vectors, 769 vectors, 223 full vectors, 75 partitions
+95.20% recall@10
+661 leaf vectors, 769 vectors, 403 full vectors, 75 partitions
 
 # Accuracy tops out here because of quantization error due to an incomplete
 # RaBitQ error bounds implementation.
 recall topk=10 beam-size=128 samples=50
 ----
-93.80% recall@10
-1000 leaf vectors, 1108 vectors, 264 full vectors, 109 partitions
+98.80% recall@10
+1000 leaf vectors, 1108 vectors, 528 full vectors, 109 partitions
 
 # Do not fetch extra results for reranking. Expect recall to drop significantly.
 recall topk=10 beam-size=32 samples=50 rerank-multiplier=0
@@ -408,19 +408,19 @@ CV stats:
 recall topk=10 beam-size=4 samples=50
 ----
 30.00% recall@10
-45 leaf vectors, 74 vectors, 33 full vectors, 7 partitions
+45 leaf vectors, 74 vectors, 39 full vectors, 7 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
 43.40% recall@10
-88 leaf vectors, 139 vectors, 51 full vectors, 13 partitions
+88 leaf vectors, 139 vectors, 68 full vectors, 13 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
-62.80% recall@10
-175 leaf vectors, 265 vectors, 73 full vectors, 25 partitions
+63.00% recall@10
+175 leaf vectors, 265 vectors, 106 full vectors, 25 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-82.20% recall@10
-348 leaf vectors, 447 vectors, 102 full vectors, 42 partitions
+82.60% recall@10
+348 leaf vectors, 447 vectors, 168 full vectors, 42 partitions

--- a/pkg/sql/vecindex/cspann/testdata/search.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search.ddt
@@ -73,7 +73,7 @@ search max-results=2 beam-size=1
 ----
 vec9: 5
 vec8: 13
-3 leaf vectors, 7 vectors, 3 full vectors, 3 partitions
+3 leaf vectors, 7 vectors, 2 full vectors, 3 partitions
 
 # Search for closest vectors with beam-size=2.
 search max-results=2 beam-size=2
@@ -81,7 +81,7 @@ search max-results=2 beam-size=2
 ----
 vec7: 5
 vec9: 5
-5 leaf vectors, 9 vectors, 5 full vectors, 4 partitions
+5 leaf vectors, 9 vectors, 4 full vectors, 4 partitions
 
 # ----------------------------------------------------------------------
 # Search tree with only duplicate vectors.
@@ -165,10 +165,10 @@ vec1: 97
 search max-results=6 skip-rerank
 [1, 1]
 ----
-vec3: 11.151 ± 8.25
-vec1: 12.0755 ± 3.54
-vec5: 26.849 ± 8.25
-vec4: 41.3111 ± 14.58
+vec3: 11.151 ± 4.1
+vec1: 12.0755 ± 1.76
+vec5: 26.849 ± 4.1
+vec4: 41.3111 ± 2.44
 5 leaf vectors, 8 vectors, 0 full vectors, 3 partitions
 
 # ----------------------------------------------------------------------
@@ -342,7 +342,7 @@ search max-results=2 beam-size=2
 ----
 vec5: -43
 vec8: -34
-4 leaf vectors, 9 vectors, 3 full vectors, 4 partitions
+4 leaf vectors, 9 vectors, 2 full vectors, 4 partitions
 
 # ----------------------------------------------------------------------
 # Search empty partition.

--- a/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
@@ -47,7 +47,7 @@ search tree=2
 [5, 5]
 ----
 vec7: 26
-5 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
+5 leaf vectors, 7 vectors, 5 full vectors, 3 partitions
 
 # Delete from tree #2.
 delete tree=2

--- a/pkg/sql/vecindex/testdata/clip-512d-cosine.ddt
+++ b/pkg/sql/vecindex/testdata/clip-512d-cosine.ddt
@@ -24,18 +24,16 @@ recall topk=10 beam-size=8 samples=20
 
 recall topk=10 beam-size=16 samples=20
 ----
-43.00% recall@10
+43.50% recall@10
 
 recall topk=10 beam-size=32 samples=20
 ----
-71.00% recall@10
+73.00% recall@10
 
 recall topk=10 beam-size=64 samples=20
 ----
-87.50% recall@10
+94.00% recall@10
 
-# Accuracy tops out here because of quantization error due to an incomplete
-# RaBitQ error bounds implementation.
 recall topk=10 beam-size=128 samples=20
 ----
-91.50% recall@10
+98.00% recall@10

--- a/pkg/sql/vecindex/testdata/clip-512d-euclidean.ddt
+++ b/pkg/sql/vecindex/testdata/clip-512d-euclidean.ddt
@@ -29,14 +29,12 @@ recall topk=10 beam-size=16 samples=20
 
 recall topk=10 beam-size=32 samples=20
 ----
-58.50% recall@10
+59.00% recall@10
 
 recall topk=10 beam-size=64 samples=20
 ----
-84.50% recall@10
+88.50% recall@10
 
-# Accuracy tops out here because of quantization error due to an incomplete
-# RaBitQ error bounds implementation.
 recall topk=10 beam-size=128 samples=20
 ----
-94.50% recall@10
+100.00% recall@10

--- a/pkg/sql/vecindex/testdata/images-512d-euclidean.ddt
+++ b/pkg/sql/vecindex/testdata/images-512d-euclidean.ddt
@@ -28,8 +28,8 @@ recall topk=10 beam-size=16 samples=20
 
 recall topk=10 beam-size=32 samples=20
 ----
-98.50% recall@10
+99.00% recall@10
 
 recall topk=10 beam-size=64 samples=20
 ----
-99.50% recall@10
+100.00% recall@10

--- a/pkg/sql/vecindex/testdata/laion-768d-ip.ddt
+++ b/pkg/sql/vecindex/testdata/laion-768d-ip.ddt
@@ -37,4 +37,4 @@ recall topk=10 beam-size=64 samples=20
 
 recall topk=10 beam-size=128 samples=20
 ----
-99.50% recall@10
+100.00% recall@10


### PR DESCRIPTION
The RaBitQ quantizer previously reported a simplified ±multiplier/√D error bound for every estimated distance, independent of how well each vector was quantized. This understated the actual estimator error and limited `SearchResult.MaybeCloser` to a uniform pruning threshold, capping recall at large beam sizes.

Replace it with Eq. 14 from the RaBitQ paper:

  |⟨o,q⟩ − estimator| ≤ √((1−⟨ō,o⟩²)/⟨ō,o⟩²) · ε₀/√(D−1)

with ε₀ = 1.9 ("nearly perfect confidence" per the paper). The bound uses each vector's quantization quality (1/⟨ō,o⟩ already pre-stored in QuantizedDotProducts) so that well-quantized vectors get tighter bounds than poorly-quantized ones. NewRaBitQuantizer now requires dims >= 2 since Eq. 14 divides by √(D−1).

The new bound is more conservative overall but adaptive per-vector. Cost per query: one extra sqrt/mul/max per data vector in the inner loop, plus a few additional candidates re-ranked end-to-end (visible in pkg/sql/vecindex/cspann/testdata as e.g. "4 full vectors" → "5 full vectors").

Test setup for the recall measurements below:
  - pkg/sql/vecindex/vecindex_test.go::TestDatadrivenVecIndex
  - Single-node CockroachDB server (in-memory KV), real SQL CREATE TABLE ... VECTOR INDEX path (not the memstore harness)
  - Deterministic fixups enabled; topk=10, 20 sampled queries per row
  - Index params: build_beam_size=4, min_partition_size=4, max_partition_size=16, quality-samples=8

Recall@10 on the dataset-driven tests (rows where the bound changes the answer; smaller beam sizes are unaffected):

  Dataset            N    Dim  Metric  Beam   Before    After
  clip-512d-1050   1000  512  Cosine    16     43.0%    43.5%
                                        32     71.0%    73.0%
                                        64     87.5%    94.0%
                                       128     91.5%    98.0%
  clip-512d-1050   1000  512  L2        32     58.5%    59.0%
                                        64     84.5%    88.5%
                                       128     94.5%   100.0%
  images-512d-10k  1000  512  L2        32     98.5%    99.0%
                                        64     99.5%   100.0%
  laion-768d-1k     950  768  IP       128     99.5%   100.0%

Two TODO comments in pkg/sql/vecindex/testdata/clip-512d-{cosine, euclidean}.ddt flagging the simplified bound as the recall ceiling are removed since the implementation is no longer incomplete.

Resolves: #157020
Epic: CRDB-63810

Release note (general change): The RaBitQ vector-index quantizer now uses the probabilistic error bound from Eq. 14 of the RaBitQ paper (Gao & Long, SIGMOD 2024) in place of a simplified ±1/√D bound. The new bound is per-vector and adaptive, which materially improves recall for vector-index searches at moderate-to-large beam sizes by giving the re-rank step more accurate uncertainty information about each candidate.