### PR TITLE
kvserver: add raft.transport.bytes-sent metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -20518,6 +20518,15 @@ layers:
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
       owner: cockroachdb/kv
+    - name: raft.transport.bytes-sent
+      exported_name: raft_transport_bytes_sent
+      description: Total byte size of Raft messages sent by the Raft Transport
+      y_axis_label: Bytes
+      type: COUNTER
+      unit: BYTES
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      owner: cockroachdb/kv
     - name: raft.transport.flow-token-dispatches-dropped
       exported_name: raft_transport_flow_token_dispatches_dropped
       description: Number of flow token dispatches dropped by the Raft Transport

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -737,6 +737,7 @@ owners:
   raft_storage_read_bytes: cockroachdb/kv
   raft_ticks: cockroachdb/kv
   raft_timeoutcampaign: cockroachdb/kv
+  raft_transport_bytes_sent: cockroachdb/kv
   raft_transport_flow_token_dispatches_dropped: cockroachdb/kv
   raft_transport_rcvd: cockroachdb/kv
   raft_transport_reverse_rcvd: cockroachdb/kv

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -737,6 +737,7 @@ func (t *RaftTransport) processQueue(
 				return err
 			}
 			t.metrics.MessagesSent.Inc(int64(len(batch.Requests)))
+			t.metrics.BytesSent.Inc(int64(batch.Size()))
 			clearRequestBatch(batch)
 
 		case <-dispatchPendingFlowTokensCh:
@@ -766,6 +767,7 @@ func (t *RaftTransport) processQueue(
 				return err
 			}
 			t.metrics.MessagesSent.Inc(int64(len(batch.Requests)))
+			t.metrics.BytesSent.Inc(int64(batch.Size()))
 			clearRequestBatch(batch)
 
 			if fn := t.knobs.OnFallbackDispatch; fn != nil {

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -16,6 +16,8 @@ type RaftTransportMetrics struct {
 	MessagesSent    *metric.Counter
 	MessagesRcvd    *metric.Counter
 
+	BytesSent *metric.Counter
+
 	ReverseSent *metric.Counter
 	ReverseRcvd *metric.Counter
 
@@ -67,6 +69,13 @@ have a fuller picture.`,
 			Help:        "Number of Raft messages received by the Raft Transport",
 			Measurement: "Messages",
 			Unit:        metric.Unit_COUNT,
+		}),
+
+		BytesSent: metric.NewCounter(metric.Metadata{
+			Name:        "raft.transport.bytes-sent",
+			Help:        "Total byte size of Raft messages sent by the Raft Transport",
+			Measurement: "Bytes",
+			Unit:        metric.Unit_BYTES,
 		}),
 
 		ReverseSent: metric.NewCounter(metric.Metadata{

--- a/pkg/kv/kvserver/raft_transport_test.go
+++ b/pkg/kv/kvserver/raft_transport_test.go
@@ -452,6 +452,47 @@ func TestInOrderDelivery(t *testing.T) {
 	}
 }
 
+// TestRaftTransportBytesSentMetric verifies that the raft.transport.bytes-sent
+// metric tracks the marshaled size of the batches sent by the transport.
+func TestRaftTransportBytesSentMetric(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	rttc := newRaftTransportTestContext(t, cluster.MakeTestingClusterSettings())
+	defer rttc.Stop()
+
+	serverReplica := roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 2, ReplicaID: 2}
+	rttc.AddNode(serverReplica.NodeID)
+	serverChannel := rttc.ListenStore(serverReplica.NodeID, serverReplica.StoreID)
+
+	clientReplica := roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 1, ReplicaID: 1}
+	clientTransport := rttc.AddNode(clientReplica.NodeID)
+
+	req := &kvserverpb.RaftMessageRequest{
+		RangeID: 1,
+		Message: raftpb.Message{
+			Type: raftpb.MsgApp,
+			From: raftpb.PeerID(clientReplica.ReplicaID),
+			To:   raftpb.PeerID(serverReplica.ReplicaID),
+		},
+		FromReplica: clientReplica,
+		ToReplica:   serverReplica,
+	}
+	// The batch envelope wraps the request, so the bytes recorded for the send
+	// must be at least the request's own marshaled size. Computed before
+	// SendAsync, which takes ownership of req.
+	expectedMin := int64(req.Size())
+
+	require.True(t, clientTransport.SendAsync(req, rpcbase.DefaultClass))
+	<-serverChannel.ch
+
+	testutils.SucceedsSoon(t, func() error {
+		if n := clientTransport.Metrics().BytesSent.Count(); n < expectedMin {
+			return errors.Errorf("expected bytes-sent >= %d, got %d", expectedMin, n)
+		}
+		return nil
+	})
+}
+
 // TestRaftTransportCircuitBreaker verifies that messages will be
 // dropped waiting for raft node connection to be established.
 func TestRaftTransportCircuitBreaker(t *testing.T) {


### PR DESCRIPTION
The Raft Transport exposes a counter for the number of Raft messages sent (`raft.transport.sent`), but nothing tracks the byte volume flowing through it. This adds a `raft.transport.bytes-sent` counter, incremented by the marshaled size of each successfully sent batch (both the regular send path and the fallback flow-token dispatch path), to help diagnose transport saturation and asymmetric traffic between nodes.

Scope question from my comment on the issue (unanswered, so I went with the minimal version): this is the **aggregate** counter, matching the existing aggregate `raft.transport.sent`. If a per-target-node label is wanted instead, happy to rework. The payload-size histogram is left out per the issue's own "likely overkill".

Tested with a new `TestRaftTransportBytesSentMetric` unit test asserting the counter records at least the marshaled size of a sent request.

Informs: #148893

Epic: none

Release note (ops change): Added the raft.transport.bytes-sent metric, which tracks the total byte size of Raft messages sent by the Raft Transport.