### PR TITLE
roachtest: take a full backup after fingerprint mismatch post-cutover

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1103,20 +1103,37 @@ func (rd *replicationDriver) onFingerprintMismatch(
 	fingerPrintMonitor := rd.newMonitor(ctx)
 
 	fingerPrintMonitor.Go(func(ctx context.Context) error {
-		return rd.backupAfterFingerprintMismatch(ctx, srcTenantConn, rd.setup.src.name, startTime, endTime)
+		// The source tenant is never cut over, so its backup chain can be
+		// extended with an incremental.
+		return rd.backupAfterFingerprintMismatch(ctx, srcTenantConn, rd.setup.src.name, false /* postCutover */, startTime, endTime)
 	})
 	fingerPrintMonitor.Go(func(ctx context.Context) error {
-		return rd.backupAfterFingerprintMismatch(ctx, dstTenantConn, rd.setup.dst.name, startTime, endTime)
+		// onFingerprintMismatch only runs after the destination tenant has been
+		// cut over, so flag it as post-cutover.
+		return rd.backupAfterFingerprintMismatch(ctx, dstTenantConn, rd.setup.dst.name, true /* postCutover */, startTime, endTime)
 	})
 	fingerprintMonitorError := fingerPrintMonitor.WaitE()
 	require.NoError(rd.t, errors.CombineErrors(fingerprintBisectErr, fingerprintMonitorError))
 }
 
-// backupAfterFingerprintMismatch runs two backups on the provided tenant: a
-// full backup AOST the provided startTime, and an incremental backup AOST the
-// provided endTime. Both backups run with revision history.
+// backupAfterFingerprintMismatch captures the state of the provided tenant at
+// two timestamps to aid offline debugging of a fingerprint mismatch: the
+// startTime (the replication retained time) and the endTime (the cutover time).
+// Both backups run with revision history.
+//
+// The startTime is always captured with a full backup. The endTime is normally
+// captured with an incremental backup layered on top, but a tenant that has
+// already been cut over (postCutover) cannot extend that chain: the backup
+// engine rejects an incremental whose chain's full backup predates the cutover
+// time, requiring a new full backup after cutover. For such a tenant we capture
+// the endTime with a second full backup instead, which is equivalent for
+// debugging purposes.
 func (rd *replicationDriver) backupAfterFingerprintMismatch(
-	ctx context.Context, conn *gosql.DB, tenantName string, startTime, endTime hlc.Timestamp,
+	ctx context.Context,
+	conn *gosql.DB,
+	tenantName string,
+	postCutover bool,
+	startTime, endTime hlc.Timestamp,
 ) error {
 	if rd.c.IsLocal() {
 		rd.t.L().Printf("skip taking backups of tenants on local roachtest run")
@@ -1142,11 +1159,16 @@ func (rd *replicationDriver) backupAfterFingerprintMismatch(
 	if err != nil {
 		return errors.Wrapf(err, "full backup for %s failed", tenantName)
 	}
-	// The incremental backup for each tenant must match.
-	incBackupQuery := fmt.Sprintf("BACKUP INTO LATEST IN '%s' AS OF SYSTEM TIME '%s' with revision_history", collection, endTime.AsOfSystemTime())
-	_, err = conn.ExecContext(ctx, incBackupQuery)
-	if err != nil {
-		return errors.Wrapf(err, "inc backup for %s failed", tenantName)
+	// Capture the endTime state. A post-cutover tenant cannot extend the chain
+	// started above, so take a second full backup instead of an incremental.
+	endTimeBackupQuery := fmt.Sprintf("BACKUP INTO LATEST IN '%s' AS OF SYSTEM TIME '%s' with revision_history", collection, endTime.AsOfSystemTime())
+	backupKind := "inc"
+	if postCutover {
+		endTimeBackupQuery = fmt.Sprintf("BACKUP INTO '%s' AS OF SYSTEM TIME '%s' with revision_history", collection, endTime.AsOfSystemTime())
+		backupKind = "second full"
+	}
+	if _, err := conn.ExecContext(ctx, endTimeBackupQuery); err != nil {
+		return errors.Wrapf(err, "%s backup for %s failed", backupKind, tenantName)
 	}
 	return nil
 }


### PR DESCRIPTION
# roachtest: take a full backup after fingerprint mismatch post-cutover

## Summary

Fixes the flaky failure in `c2c/shutdown/src/coordinator` where the
fingerprint-mismatch debugging path failed while backing up the destination
tenant after a PCR cutover.

Fixes #171628

## Background — the failing test

`roachtest.c2c/shutdown/src/coordinator` failed on `master` with:

```
monitor failure: inc backup for destination-tenant failed: pq: previous
backup in this chain ended at 1781338991.597650000,0, before the cutover
time 1781339200.845449000,0; a new full backup is required after cutover
```

Stack (abridged):

```
pkg/cmd/roachtest/tests/cluster_to_cluster.go:1149  backupAfterFingerprintMismatch
pkg/cmd/roachtest/tests/cluster_to_cluster.go:1109  onFingerprintMismatch.func2
pkg/cmd/roachtest/tests/cluster_to_cluster.go:1385  (*replicationDriver).main
```

The `c2c/shutdown/src/coordinator` test runs with
`sometimesTestFingerprintMismatchCode: true`, so roughly 1 in 5 runs
deliberately exercises the fingerprint-mismatch code path
(`cluster_to_cluster.go:1381-1384`).

## Root cause

When the mismatch path is exercised, `onFingerprintMismatch` calls
`backupAfterFingerprintMismatch` for both the source and destination tenants.
That function takes two backups of each tenant for offline debugging:

1. a **full** backup `AS OF SYSTEM TIME` the replication retained time
   (`startTime`), then
2. an **incremental** backup `AS OF SYSTEM TIME` the cutover time (`endTime`).

The problem: this path only runs **after** the destination tenant has already
been cut over (it is reached via `compareTenantFingerprintsAtTimestamp` at
`cluster_to_cluster.go:1376` and the direct call at `:1383`, both downstream of
`stopReplicationStream`). After a PCR cutover, the backup engine refuses to
extend a backup chain whose most recent backup ended **before** the cutover
time — it requires a fresh full backup taken after cutover. Since the chain's
full backup was taken `AS OF SYSTEM TIME startTime` (the retained time, which
precedes the cutover), the follow-up incremental is rejected with the
`pq.Error` above.

The source tenant is never cut over, so its incremental succeeds and it is
unaffected.

## Fix

`backupAfterFingerprintMismatch` now takes a `postCutover bool` parameter. For a
post-cutover tenant, the second backup is taken as a **new full backup** at the
cutover time (`BACKUP INTO ...`) instead of an incremental
(`BACKUP INTO LATEST IN ...`). This satisfies the engine's "a new full backup is
required after cutover" rule and is equivalent for offline-debugging purposes,
which only needs the tenant state captured at the two timestamps — it does not
need a restorable chain.

Call sites:

- **source tenant** — `postCutover=false` (never cut over): unchanged behavior,
  still takes an incremental.
- **destination tenant** — `postCutover=true` (always cut over on this path):
  takes a second full backup.

## Testing

- Built with `./dev build pkg/cmd/roachtest/tests:tests` — compiles cleanly.
- Change is confined to the roachtest driver; no production code is touched.

## Files changed

| File | Change |
|------|--------|
| `pkg/cmd/roachtest/tests/cluster_to_cluster.go` | Add `postCutover` parameter to `backupAfterFingerprintMismatch`; take a second full backup instead of an incremental for the cut-over destination tenant; update both call sites and the doc comment. |

## Footers

```
Fixes #171628
Epic: none
Release note: None
```
