### PR TITLE
admission: export bypassed requests as a metric

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -15278,6 +15278,15 @@ layers:
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
       owner: cockroachdb/admission-control
+    - name: admission.granter.bypassed_requests.kv
+      exported_name: admission_granter_bypassed_requests_kv
+      description: Total number of requests that bypassed admission control (for example, below-raft writes that were not subject to replication admission control). A growing value indicates replication writes from nodes that do not have replication admission control enabled, which can overload the cluster.
+      y_axis_label: Requests
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      owner: cockroachdb/admission-control
     - name: admission.granter.cpu_load_long_period_duration.kv
       exported_name: admission_granter_cpu_load_long_period_duration_kv
       description: Total duration when CPULoad was being called with a long period. This is reported in nanoseconds from 26.1 onwards, and was microseconds before that.

--- a/pkg/internal/metricscan/metric_owners.yaml
+++ b/pkg/internal/metricscan/metric_owners.yaml
@@ -49,6 +49,7 @@ owners:
   admission_elastic_cpu_utilization: cockroachdb/admission-control
   admission_elastic_cpu_utilization_limit: cockroachdb/admission-control
   admission_elastic_cpu_yield_delay_nanos: cockroachdb/admission-control
+  admission_granter_bypassed_requests_kv: cockroachdb/admission-control
   admission_granter_cpu_load_long_period_duration_kv: cockroachdb/admission-control
   admission_granter_cpu_load_short_period_duration_kv: cockroachdb/admission-control
   admission_granter_disk_write_byte_tokens_exhausted_duration_kv: cockroachdb/admission-control

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -1126,6 +1126,15 @@ var (
 		Measurement: "Tokens",
 		Unit:        metric.Unit_COUNT,
 	}
+	kvBypassedRequests = metric.Metadata{
+		Name: "admission.granter.bypassed_requests.kv",
+		Help: "Total number of requests that bypassed admission control (for example, " +
+			"below-raft writes that were not subject to replication admission control). A " +
+			"growing value indicates replication writes from nodes that do not have " +
+			"replication admission control enabled, which can overload the cluster.",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
 	kvIOTokensAvailable = metric.Metadata{
 		Name:        "admission.granter.io_tokens_available.kv",
 		Help:        "Number of tokens available",

--- a/pkg/util/admission/io_load_listener.go
+++ b/pkg/util/admission/io_load_listener.go
@@ -239,6 +239,7 @@ type ioLoadListener struct {
 
 	l0CompactedBytes        *metric.Counter
 	l0TokensProduced        *metric.Counter
+	bypassedWorkCount       *metric.Counter
 	diskWriteByteTokensUsed [admissionpb.NumStoreWorkTypes]*metric.Counter
 }
 
@@ -750,6 +751,14 @@ func (io *ioLoadListener) adjustTokens(ctx context.Context, metrics StoreMetrics
 		metrics.Levels[0], cumIngestedBytes, metrics.DiskStats.BytesWritten, sas,
 		io.aux.recentUnflushedMemTableTooLarge)
 	io.copyAuxEtcFromPerWorkEstimator()
+	// Export the number of requests that bypassed admission control this
+	// interval (e.g. below-raft replication writes not subject to replication
+	// admission control). This is the same per-interval count reported in the
+	// [accounting] section of the IO admission controller log. Guard against a
+	// negative delta from non-monotonic stats so the counter stays monotonic.
+	if bypassed := io.adjustTokensResult.aux.perWorkTokensAux.intBypassedWorkCount; bypassed > 0 {
+		io.bypassedWorkCount.Inc(bypassed)
+	}
 	requestEstimates := io.perWorkTokenEstimator.getStoreRequestEstimatesAtAdmission()
 	io.kvRequester.setStoreRequestEstimates(requestEstimates)
 	l0WriteLM, l0IngestLM, ingestLM, writeAmpLM := io.perWorkTokenEstimator.getModelsAtDone()

--- a/pkg/util/admission/io_load_listener_test.go
+++ b/pkg/util/admission/io_load_listener_test.go
@@ -69,6 +69,7 @@ func TestIOLoadListener(t *testing.T) {
 					diskBandwidthLimiter:    newDiskBandwidthLimiter(),
 					l0CompactedBytes:        metric.NewCounter(l0CompactedBytes),
 					l0TokensProduced:        metric.NewCounter(l0TokensProduced),
+					bypassedWorkCount:       metric.NewCounter(kvBypassedRequests),
 					diskWriteByteTokensUsed: newDiskWriteByteTokensUsedCounters(),
 				}
 				// The mutex is needed by ioLoadListener but is not useful in this
@@ -292,6 +293,7 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 		diskBandwidthLimiter:    newDiskBandwidthLimiter(),
 		l0CompactedBytes:        metric.NewCounter(l0CompactedBytes),
 		l0TokensProduced:        metric.NewCounter(l0TokensProduced),
+		bypassedWorkCount:       metric.NewCounter(kvBypassedRequests),
 		diskWriteByteTokensUsed: newDiskWriteByteTokensUsedCounters(),
 	}
 	ioll.kvGranter = kvGranter
@@ -311,6 +313,52 @@ func TestIOLoadListenerOverflow(t *testing.T) {
 	ioll.pebbleMetricsTick(ctx, StoreMetrics{Metrics: &m})
 	ioll.pebbleMetricsTick(ctx, StoreMetrics{Metrics: &m})
 	ioll.allocateTokensTick(unloadedDuration.ticksInAdjustmentInterval())
+}
+
+// TestIOLoadListenerBypassedRequestsMetric verifies that the
+// admission.granter.bypassed_requests.kv counter accumulates the per-interval
+// count of requests that bypassed admission control.
+func TestIOLoadListenerBypassedRequestsMetric(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	req := &testRequesterForIOLL{}
+	kvGranter := &testGranterWithIOTokens{}
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	bypassedWorkCount := metric.NewCounter(kvBypassedRequests)
+	ioll := &ioLoadListener{
+		settings:                st,
+		kvRequester:             req,
+		perWorkTokenEstimator:   makeStorePerWorkTokenEstimator(),
+		diskBandwidthLimiter:    newDiskBandwidthLimiter(),
+		l0CompactedBytes:        metric.NewCounter(l0CompactedBytes),
+		l0TokensProduced:        metric.NewCounter(l0TokensProduced),
+		bypassedWorkCount:       bypassedWorkCount,
+		diskWriteByteTokensUsed: newDiskWriteByteTokensUsedCounters(),
+	}
+	ioll.kvGranter = kvGranter
+
+	// L0 flushed bytes must be non-zero so the estimator initializes its
+	// cumulative state on the first tick and computes real interval deltas
+	// on subsequent ticks.
+	var m pebble.Metrics
+	m.Levels[0] = pebble.LevelMetrics{Sublevels: 1}
+	m.Levels[0].Tables.Count = 1
+	m.Levels[0].TablesFlushed.Bytes = 1 << 20
+
+	// The first tick only initializes cumulative stats; no interval is computed
+	// yet, so nothing is counted.
+	req.stats = storeAdmissionStats{workCount: 10}
+	req.stats.aux.bypassedCount = 3
+	ioll.pebbleMetricsTick(ctx, StoreMetrics{Metrics: &m})
+	require.Equal(t, int64(0), bypassedWorkCount.Count())
+
+	// The second tick computes the interval delta of bypassed requests: 8-3 = 5.
+	req.stats = storeAdmissionStats{workCount: 25}
+	req.stats.aux.bypassedCount = 8
+	ioll.pebbleMetricsTick(ctx, StoreMetrics{Metrics: &m})
+	require.Equal(t, int64(5), bypassedWorkCount.Count())
 }
 
 // TODO(sumeer): we now do more work outside adjustTokensInner, so the parts
@@ -409,6 +457,7 @@ func TestBadIOLoadListenerStats(t *testing.T) {
 		diskBandwidthLimiter:    newDiskBandwidthLimiter(),
 		l0CompactedBytes:        metric.NewCounter(l0CompactedBytes),
 		l0TokensProduced:        metric.NewCounter(l0TokensProduced),
+		bypassedWorkCount:       metric.NewCounter(kvBypassedRequests),
 		diskWriteByteTokensUsed: newDiskWriteByteTokensUsedCounters(),
 	}
 	ioll.kvGranter = kvGranter

--- a/pkg/util/admission/store_grant_coordinator.go
+++ b/pkg/util/admission/store_grant_coordinator.go
@@ -293,6 +293,7 @@ func (sgc *StoreGrantCoordinators) initGrantCoordinator(
 		kvGranter:               kvg,
 		l0CompactedBytes:        sgcMetrics.L0CompactedBytes,
 		l0TokensProduced:        sgcMetrics.L0TokensProduced,
+		bypassedWorkCount:       sgcMetrics.KVBypassedRequests,
 		diskWriteByteTokensUsed: sgcMetrics.KVDiskWriteByteTokensUsed,
 	}
 	coord := &storeGrantCoordinator{
@@ -382,6 +383,7 @@ type StoreGrantCoordinatorMetrics struct {
 	KVIOTokensTaken             *metric.Counter
 	KVIOTokensReturned          *metric.Counter
 	KVIOTokensBypassed          *metric.Counter
+	KVBypassedRequests          *metric.Counter
 	KVIOTokensAvailable         [admissionpb.NumWorkClasses]*metric.Gauge
 	KVIOTokensExhaustedDuration [admissionpb.NumWorkClasses]*metric.Counter
 
@@ -400,6 +402,7 @@ func makeStoreGrantCoordinatorMetrics(registry *metric.Registry) StoreGrantCoord
 		KVIOTokensTaken:    metric.NewCounter(kvIOTokensTaken),
 		KVIOTokensReturned: metric.NewCounter(kvIOTokensReturned),
 		KVIOTokensBypassed: metric.NewCounter(kvIOTokensBypassed),
+		KVBypassedRequests: metric.NewCounter(kvBypassedRequests),
 		L0CompactedBytes:   metric.NewCounter(l0CompactedBytes),
 		L0TokensProduced:   metric.NewCounter(l0TokensProduced),
 	}


### PR DESCRIPTION
The IO load listener logs the per-interval count of requests that bypass admission control (below-raft writes that were not subject to replication admission control) in its `[accounting]` log line, but this count was never exported as a metric. Operators investigating overload escalations had to read logs to find it. The existing `admission.granter.io_tokens_bypassed.kv` counter tracks bypassed *tokens*, not the request count.

This adds an `admission.granter.bypassed_requests.kv` counter, incremented every adjustment interval with the same per-interval bypassed-request count that is logged. A growing value indicates replication writes from nodes that do not have replication admission control enabled, which is a useful signal that a version upgrade would relieve the overload.

Open question (carried over from the issue): aggregate request count only, or would you also like the bypassed write/ingest *bytes* exported alongside? Happy to add that if wanted.

Epic: none
Fixes: #137408