### PR TITLE
ci/ai: reliably check out failure SHAs in the investigate workflow

### DIFF
--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -13,18 +13,18 @@ commands. The working tree is checked out from `CODE_REPO`; use that
 when building source links (blob/permalink URLs).
 
 You are inside a blobless clone of the `CODE_REPO` repository with
-full commit history. `git log`, `git blame`, `git diff`, etc. work
-normally — no need to deepen or unshallow. File contents (blobs) are
-fetched transparently on demand when you check out a commit or read
-a file at a specific revision.
+full commit history. `git log`, `git diff`, etc. work normally — no
+need to deepen or unshallow.
 
-To inspect a specific commit, just check it out:
+To inspect a specific commit, check it out with the `checkout-sha`
+helper (do not use a plain `git checkout <sha>` — it cannot reliably
+fetch file contents for commits on non-default branches):
 
 ```bash
-git checkout <sha>
+checkout-sha <sha>
 ```
 
-If the checkout fails (SHA not reachable from this remote — rare,
+If `checkout-sha` fails (SHA not reachable from this remote — rare,
 only happens for commits exclusive to a fork), proceed with the
 currently checked-out code instead, but add a prominent warning at
 the very top of `artifacts/findings.md`:
@@ -47,7 +47,8 @@ to check what's available.
 Key tools at your disposal:
 
 - **Code reading**: Read, Grep, Glob, and common shell text tools
-- **Git**: all git commands (log, blame, diff, show, fetch, etc.)
+- **Git**: all git commands (log, diff, show, etc.); use
+  `checkout-sha <sha>` to check out a specific commit
 - **GitHub CLI**: gh issue view/list, gh pr view/list/diff, gh search
 - **Web browsing**: WebFetch tool for reading web pages and JSON APIs
 - **File download**: `fetch-url <url> [output-file]` (GET-only HTTP
@@ -128,10 +129,10 @@ fix is present in the failure SHA's history using `git log`.
 After determining the failure SHA from Step 1, check it out:
 
 ```bash
-git checkout <failure-sha>
+checkout-sha <failure-sha>
 ```
 
-If the checkout fails, fall back to the default branch tip (see the
+If `checkout-sha` fails, fall back to the default branch tip (see the
 warning note in the checkout instructions above).
 
 Then explore the relevant source code:

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -114,7 +114,7 @@ jobs:
           filter: blob:none
           fetch-depth: 0
 
-      - name: Create fetch-url wrapper
+      - name: Create helper scripts
         run: |
           cat > /usr/local/bin/fetch-url <<'WRAPPER'
           #!/bin/bash
@@ -127,6 +127,43 @@ jobs:
           fi
           WRAPPER
           chmod +x /usr/local/bin/fetch-url
+
+          # checkout-sha SHA — check out a commit in the blobless clone.
+          #
+          # A plain `git checkout <sha>` triggers a partial-clone lazy fetch
+          # of the commit's blobs (`want <blob-oid>`). GitHub's on-demand
+          # object serving rejects that with "not our ref" for commits not
+          # reachable from the checked-out repo's default branch (e.g.
+          # release-branch SHAs), which is most failure SHAs we investigate.
+          # To avoid that path, fetch the commit's complete snapshot in an
+          # isolated repo — there the request is `want <commit-sha>` with no
+          # haves, which GitHub serves reliably for any reachable commit —
+          # import those objects into this repo's object store, then check
+          # out locally with no further network access.
+          cat > /usr/local/bin/checkout-sha <<'WRAPPER'
+          #!/bin/bash
+          set -euo pipefail
+          sha="${1:?Usage: checkout-sha SHA}"
+          git_dir=$(git rev-parse --absolute-git-dir)
+          url=$(git config --get remote.origin.url)
+          auth=$(git config --get http.https://github.com/.extraheader || true)
+
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          git -C "$tmp" init -q
+          if [ -n "$auth" ]; then
+            git -C "$tmp" config http.https://github.com/.extraheader "$auth"
+          fi
+          # fetch.unpackLimit=1 keeps the result as a packfile (instead of
+          # loose objects) regardless of object count, so the copy below has
+          # a stable source.
+          git -C "$tmp" -c fetch.unpackLimit=1 fetch -q --depth=1 "$url" "$sha"
+          cp "$tmp"/.git/objects/pack/pack-*.pack \
+             "$tmp"/.git/objects/pack/pack-*.idx \
+             "$git_dir/objects/pack/"
+          git -c advice.detachedHead=false checkout --force "$sha"
+          WRAPPER
+          chmod +x /usr/local/bin/checkout-sha
 
       # Vertex AI auth for cockroachdb/cockroach. Skipped when an
       # ANTHROPIC_API_KEY secret is set (e.g. on a personal fork).
@@ -175,7 +212,7 @@ jobs:
           # based permissions may work after upgrading the action.
           claude_args: |
             --model ${{ inputs.cheap == true && 'claude-sonnet-4-5' || 'claude-opus-4-6' }}
-            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(.claude/skills/engflow-artifacts/run.sh:*),Bash(go tool pprof:*),Bash(go run ./pkg/cmd/tsdump2duck:*),Bash(duckdb:*)"
+            --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(checkout-sha:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(.claude/skills/engflow-artifacts/run.sh:*),Bash(go tool pprof:*),Bash(go run ./pkg/cmd/tsdump2duck:*),Bash(duckdb:*)"
           prompt: |
             Read and follow the instructions in the prompt file
             `.github/prompts/${{ inputs.smoke_test == true && 'investigate-smoke' || 'investigate' }}.md`.


### PR DESCRIPTION
The /investigate workflow checks out the code as a blobless clone, then has the agent run `git checkout <failure-sha>` to inspect the failing code. This failed for many failures with:

    fatal: remote error: upload-pack: not our ref <oid>
    fatal: could not fetch <oid> from promisor remote

This is not an authentication problem. The blobless clone already has the commit and its trees; only blobs are missing. `git checkout <sha>` then triggers a partial-clone lazy fetch of those blobs (`want <blob-oid>`), and the server rejects object-level wants for commits that are not reachable from the repository's default branch. Failure SHAs on non-default branches therefore fail, while default-branch SHAs happen to work, which is why the problem was intermittent.

Add a `checkout-sha` helper that sidesteps the broken path: it fetches the commit's complete depth-1 snapshot in an isolated repo (where the request is `want <commit-sha>` with no haves, which the server serves for any reachable commit), copies the resulting packfile into the main object store, then runs a normal checkout that resolves entirely locally. The investigate prompt now calls `checkout-sha` instead of `git checkout`.

Epic: none
Release note: none