### PR TITLE
workflows: stop deriving the autosolver fork name from CODE_REPO

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -10,8 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Owner of the bot fork the branch is pushed to. The fork repo name is
-  # derived from CODE_REPO (see the validate step).
+  # Owner of the fork the branch is pushed to.
   AUTOSOLVER_FORK_OWNER: cockroach-teamcity
 
 jobs:
@@ -27,6 +26,7 @@ jobs:
     env:
       # Repository the code and the resulting PR target. Issues stay in github.repository.
       CODE_REPO: ${{ secrets.CODE_REPO }}
+      FORK_REPO: ${{ secrets.FORK_REPO }}
 
     steps:
       - name: Check that labeler is not the issue author
@@ -48,16 +48,12 @@ jobs:
           AUTOSOLVER_PUSH_TO_FORK_PAT: ${{ secrets.AUTOSOLVER_PUSH_TO_FORK_PAT }}
           AUTOSOLVER_CREATE_PRS_PAT: ${{ secrets.AUTOSOLVER_CREATE_PRS_PAT }}
         run: |
-          for v in AUTOSOLVER_PUSH_TO_FORK_PAT AUTOSOLVER_CREATE_PRS_PAT CODE_REPO AUTOSOLVER_FORK_OWNER; do
+          for v in AUTOSOLVER_PUSH_TO_FORK_PAT AUTOSOLVER_CREATE_PRS_PAT CODE_REPO FORK_REPO AUTOSOLVER_FORK_OWNER; do
             if [ -z "${!v:-}" ]; then
               echo "::error::$v is not configured"
               exit 1
             fi
           done
-
-          FORK_REPO="${CODE_REPO#*/}"
-          echo "::add-mask::$FORK_REPO"
-          echo "FORK_REPO=$FORK_REPO" >> "$GITHUB_ENV"
 
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/pr-autosolve-ci.yml
+++ b/.github/workflows/pr-autosolve-ci.yml
@@ -18,9 +18,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Autosolver fork configuration - update these if the bot account changes
+  # Owner of the fork - update if the bot account changes.
   AUTOSOLVER_FORK_OWNER: cockroach-teamcity
-  AUTOSOLVER_FORK_REPO: cockroach
 
 jobs:
   fix-ci-failures:
@@ -35,6 +34,8 @@ jobs:
       pull-requests: write
       id-token: write
       actions: read  # needed to read workflow run details
+    env:
+      AUTOSOLVER_FORK_REPO: ${{ secrets.FORK_REPO }}
 
     steps:
       - name: Find autosolver PR

--- a/.github/workflows/pr-autosolve-comments-trigger.yml
+++ b/.github/workflows/pr-autosolve-comments-trigger.yml
@@ -21,10 +21,12 @@ on:
 jobs:
   save-context:
     runs-on: ubuntu-latest
+    # Digest of the expected fork's full name, compared against the PR head repo
+    # in the steps below. Regenerate with: printf '%s' OWNER/REPO | shasum -a 256
+    env:
+      EXPECTED_FORK_SHA256: 80a25215a4402ab61df59d59d8d47987837cc631793aa759a23cd634d78213fd
     # Only trigger for:
-    # - PRs from the autosolver bot's fork (security: prevents force-push to other branches)
-    #   Note: for issue_comment events, head repo is not in the payload so we check it in a step
-    # - PRs with 'o-autosolver' label
+    # - PRs with 'o-autosolver' label (the head-repo check happens in a step)
     # - Comments/reviews NOT from the bot itself
     # - For review_comment/issue_comment events: comments NOT containing our response marker
     # - For review events: only COMMENTED or CHANGES_REQUESTED (not APPROVED/DISMISSED)
@@ -34,13 +36,11 @@ jobs:
       (
         (
           github.event_name == 'pull_request_review_comment' &&
-          github.event.pull_request.head.repo.full_name == 'cockroach-teamcity/cockroach' &&
           contains(github.event.pull_request.labels.*.name, 'o-autosolver') &&
           !contains(github.event.comment.body, '[autosolve-response]')
         ) ||
         (
           github.event_name == 'pull_request_review' &&
-          github.event.pull_request.head.repo.full_name == 'cockroach-teamcity/cockroach' &&
           contains(github.event.pull_request.labels.*.name, 'o-autosolver') &&
           (github.event.review.state == 'commented' || github.event.review.state == 'changes_requested')
         ) ||
@@ -53,6 +53,21 @@ jobs:
       )
 
     steps:
+      # Security: only proceed for PRs from the autosolver bot fork, to prevent
+      # force-pushing to or running untrusted code from other branches. For
+      # issue_comment events the head repo is not in the payload, so it is
+      # verified in the "Fetch PR details" step instead.
+      - name: Verify PR is from autosolver fork
+        if: github.event_name != 'issue_comment'
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          ACTUAL_SHA256=$(printf '%s' "$HEAD_REPO" | sha256sum | cut -d' ' -f1)
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_FORK_SHA256" ]; then
+            echo "::error::PR head repo ($HEAD_REPO) is not the autosolver fork - skipping"
+            exit 1
+          fi
+
       - name: Save event context
         run: |
           mkdir -p /tmp/event-context
@@ -72,7 +87,8 @@ jobs:
         run: |
           PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
           HEAD_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')
-          if [ "$HEAD_REPO" != "cockroach-teamcity/cockroach" ]; then
+          ACTUAL_SHA256=$(printf '%s' "$HEAD_REPO" | sha256sum | cut -d' ' -f1)
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_FORK_SHA256" ]; then
             echo "::error::PR head repo ($HEAD_REPO) is not the autosolver fork - skipping"
             exit 1
           fi

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -19,9 +19,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Autosolver fork configuration - update these if the bot account changes
+  # Owner of the fork - update if the bot account changes.
   AUTOSOLVER_FORK_OWNER: cockroach-teamcity
-  AUTOSOLVER_FORK_REPO: cockroach
 
 jobs:
   address-review-comments:
@@ -33,6 +32,8 @@ jobs:
       pull-requests: write
       id-token: write
       actions: read  # needed to download artifacts from workflow_run
+    env:
+      AUTOSOLVER_FORK_REPO: ${{ secrets.FORK_REPO }}
 
     steps:
       - name: Check if trigger produced an artifact
@@ -117,10 +118,9 @@ jobs:
 
       - name: Validate configuration
         run: |
-          # Validate that env vars match expected fork (defense against misconfiguration)
-          EXPECTED_FORK="${AUTOSOLVER_FORK_OWNER}/${AUTOSOLVER_FORK_REPO}"
-          if [ "$EXPECTED_FORK" != "cockroach-teamcity/cockroach" ]; then
-            echo "::error::AUTOSOLVER_FORK_OWNER/AUTOSOLVER_FORK_REPO mismatch. Update the env vars."
+          # Fail early if the fork repo is not configured.
+          if [ -z "${AUTOSOLVER_FORK_REPO:-}" ]; then
+            echo "::error::AUTOSOLVER_FORK_REPO is not configured"
             exit 1
           fi
 


### PR DESCRIPTION
Epic: none
Release note: None