### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Merge qualifying PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/backport-stale.yml
+++ b/.github/workflows/backport-stale.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
       with:
         operations-per-run: 1000
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -13,14 +13,14 @@ jobs:
     if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - run: cd build/release/bincheck && ./test-linux ${{ github.ref_name }} ${{ github.sha }}
 
   darwin-arm64:
     if: github.repository == 'cockroachdb/cockroach'
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - run: cd build/release/bincheck && ./test-macos-arm64 ${{ github.ref_name }} ${{ github.sha }}
 
   windows:
@@ -28,5 +28,5 @@ jobs:
     runs-on: windows-latest
     steps:
     - run: git config --system core.longpaths true
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - run: cd build/release/bincheck && bash test-windows ${{ github.ref_name }} ${{ github.sha }}

--- a/.github/workflows/blathers-backport.yml
+++ b/.github/workflows/blathers-backport.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.BLATHERS_APP_ID }}
           private-key: ${{ secrets.BLATHERS_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -261,7 +261,7 @@ jobs:
       - name: Analyze conflicts
         id: analyze
         if: always() && steps.backport.outputs.has_conflicts == 'true'
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ env.HAS_API_KEY != 'true' && 'vertex-model-runners' || '' }}
           CLOUD_ML_REGION: ${{ env.HAS_API_KEY != 'true' && 'us-east5' || '' }}

--- a/.github/workflows/check-pebble-dep.yml
+++ b/.github/workflows/check-pebble-dep.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Notify Slack on failure
         if: steps.run_script.outputs.exitcode != '0'
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           errors: true
           method: chat.postMessage

--- a/.github/workflows/close-fixed-on-release-branch.yml
+++ b/.github/workflows/close-fixed-on-release-branch.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     steps:
       - name: Close issues for deleted RC branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -17,12 +17,12 @@ jobs:
         working-directory: pkg/ui/workspaces/cluster-ui
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
     - name: Bazel Cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
@@ -32,7 +32,7 @@ jobs:
         version: "9.15.5"
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -20,12 +20,12 @@ jobs:
         working-directory: pkg/ui/workspaces/cluster-ui
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 
     - name: Bazel Cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-cache
@@ -35,7 +35,7 @@ jobs:
         version: "9.15.5"
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/code-cover-gen.yml
+++ b/.github/workflows/code-cover-gen.yml
@@ -13,7 +13,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       FETCH_DEPTH: 15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           # By default, checkout merges the PR into the current master.
           # Instead, we want to check out the PR as is.
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - name: Set up Bazel cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             ~/.cache/bazel
@@ -118,7 +118,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cover
           path: artifacts/cover-*.json

--- a/.github/workflows/code-cover-publish.yaml
+++ b/.github/workflows/code-cover-publish.yaml
@@ -19,7 +19,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/flaky-test-notifier.yml
+++ b/.github/workflows/flaky-test-notifier.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: ./build/github/get-engflow-keys.sh
       - name: Run flaky-test-notifier
         env:

--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_big_2404]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: compute metadata
@@ -79,7 +79,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: compute metadata
@@ -94,7 +94,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: compute metadata
@@ -115,11 +115,11 @@ jobs:
     runs-on: [self-hosted, ubuntu_big_2404]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: cockroach
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: examples-orms
           repository: cockroachdb/examples-orms
@@ -148,7 +148,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_huge_2404]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           submodules: true
@@ -172,7 +172,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_big_2404]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           submodules: true
@@ -181,11 +181,11 @@ jobs:
       - run: ./build/github/get-engflow-keys.sh
       - name: run local roachtests
         run: ./build/github/local-roachtest.sh crosslinux
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: local_roachtest_test_summary.tsv
           path: artifacts/test_summary.tsv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ failure() }}
         with:
           name: local roachtest artifacts
@@ -197,7 +197,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_big_2404]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           submodules: true
@@ -206,11 +206,11 @@ jobs:
       - run: ./build/github/get-engflow-keys.sh
       - name: run local roachtests
         run: ./build/github/local-roachtest.sh crosslinuxfips
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: local_roachtest_fips_test_summary.tsv
           path: artifacts/test_summary.tsv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ failure() }}
         with:
           name: local roachtest (FIPS) artifacts
@@ -222,7 +222,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: compute metadata
@@ -243,7 +243,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_2404]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: compute metadata
@@ -264,7 +264,7 @@ jobs:
     runs-on: [self-hosted, ubuntu_big_2404]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: run race canary test
@@ -276,7 +276,7 @@ jobs:
       - name: calculate commit depth
         if: github.event.pull_request.commits
         run: echo COMMIT_DEPTH=$(echo '${{ github.event.pull_request.commits }} + 1' | bc) >> "$GITHUB_ENV"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # By default, checkout merges the PR into the current master.
           # Instead, we want to check out the PR as is.

--- a/.github/workflows/github-actions-extended-ci.yml
+++ b/.github/workflows/github-actions-extended-ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: calculate commit depth
         run: echo COMMIT_DEPTH=$(echo '${{ github.event.pull_request.commits }} + 1' | bc) >> "$GITHUB_ENV"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: ${{ env.COMMIT_DEPTH }}
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: calculate commit depth
         run: echo COMMIT_DEPTH=$(echo '${{ github.event.pull_request.commits }} + 1' | bc) >> "$GITHUB_ENV"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: ${{ env.COMMIT_DEPTH }}

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -107,7 +107,7 @@ jobs:
       # full clone of the cockroach repo while still giving the agent
       # full history without manual deepening.
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ env.HAS_API_KEY == 'true' && github.repository || env.CODE_REPO }}
           token: ${{ env.HAS_API_KEY == 'true' && secrets.GITHUB_TOKEN || secrets.INVESTIGATE_PAT }}
@@ -260,7 +260,7 @@ jobs:
           fi
 
       - name: Investigate
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ env.HAS_API_KEY != 'true' && 'vertex-model-runners' || '' }}
           CLOUD_ML_REGION: ${{ env.HAS_API_KEY != 'true' && 'global' || '' }}
@@ -301,7 +301,7 @@ jobs:
 
       - name: Upload findings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: investigation-findings
           path: artifacts/findings.md

--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -56,7 +56,7 @@ jobs:
           done
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ env.CODE_REPO }}
           token: ${{ secrets.AUTOSOLVER_CREATE_PRS_PAT }}

--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -24,7 +24,7 @@ jobs:
       merge_base: ${{ steps.build.outputs.merge_base }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build
         id: build
         uses: ./.github/actions/microbenchmark-build
@@ -38,7 +38,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'X-skip-perf-check') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build
         id: build
         uses: ./.github/actions/microbenchmark-build
@@ -51,7 +51,7 @@ jobs:
     needs: [base, head]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run
         uses: ./.github/actions/microbenchmark-run
         with:
@@ -64,7 +64,7 @@ jobs:
     needs: [base, head]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run
         uses: ./.github/actions/microbenchmark-run
         with:
@@ -81,7 +81,7 @@ jobs:
     needs: [base, run-group-1, run-group-2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: ./build/github/get-engflow-keys.sh
         shell: bash
       - name: Unique Build ID

--- a/.github/workflows/pr-analyzer-threestage.yml
+++ b/.github/workflows/pr-analyzer-threestage.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 1
@@ -41,7 +41,7 @@ jobs:
 
       - name: Get usermapper token
         id: usermapper_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           project_id: 'dev-inf-prod'
           service_account: 'ai-review@dev-inf-prod.iam.gserviceaccount.com'
@@ -76,7 +76,7 @@ jobs:
       - name: Stage 1 - Initial Bug Screening
         id: stage1
         if: steps.verify_author.outputs.authorized == 'true'
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: global
@@ -128,7 +128,7 @@ jobs:
       - name: Stage 2 - Database Expert Review
         id: stage2
         if: contains(steps.stage1_result.outputs.result, 'STAGE1_RESULT - POTENTIAL_BUG_DETECTED')
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: global
@@ -179,7 +179,7 @@ jobs:
       - name: Stage 3 - Principal Engineer Final Review
         id: stage3
         if: contains(steps.stage2_result.outputs.result, 'STAGE2_RESULT - POTENTIAL_BUG_DETECTED')
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: global
@@ -244,7 +244,7 @@ jobs:
 
       - name: Final Analysis Report
         if: always() && steps.verify_author.outputs.authorized == 'true'
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: global

--- a/.github/workflows/pr-autosolve-ci.yml
+++ b/.github/workflows/pr-autosolve-ci.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Checkout PR branch from fork
         if: steps.loop_check.outputs.proceed == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ env.AUTOSOLVER_FORK_OWNER }}/${{ env.AUTOSOLVER_FORK_REPO }}
           ref: ${{ github.event.workflow_run.head_branch }}
@@ -217,7 +217,7 @@ jobs:
       - name: Fix CI failures
         id: fix
         if: steps.loop_check.outputs.proceed == 'true'
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: us-east5

--- a/.github/workflows/pr-autosolve-comments-trigger.yml
+++ b/.github/workflows/pr-autosolve-comments-trigger.yml
@@ -97,7 +97,7 @@ jobs:
           echo "$HEAD_REF" > /tmp/event-context/head_ref.txt
 
       - name: Upload context
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-comment-context
           path: /tmp/event-context/

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Download event context
         id: download
         if: steps.check_trigger.outputs.has_artifact == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pr-comment-context
           run-id: ${{ github.event.workflow_run.id }}
@@ -143,7 +143,7 @@ jobs:
           esac
 
       - name: Checkout PR branch from fork
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: ${{ steps.context.outputs.head_repo }}
           ref: ${{ steps.context.outputs.head_ref }}
@@ -325,7 +325,7 @@ jobs:
 
       - name: Address review comments
         id: address
-        uses: cockroachdb/claude-code-action@v1
+        uses: cockroachdb/claude-code-action@426380f01bad0a17200865605a85cb28926dccbf # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
           CLOUD_ML_REGION: us-east5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v8
+    - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
       with:
         operations-per-run: 1000
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-failure-stale.yml
+++ b/.github/workflows/test-failure-stale.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
       with:
         operations-per-run: 1000
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -35,11 +35,11 @@ jobs:
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: "${{ matrix.branch }}"
       - name: Mount bazel cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: "~/.cache/bazel"
           key: bazel


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions