### PR TITLE
roachtest: add v10.TestBigColumn to gopg blocklist

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -26,10 +26,11 @@ var gopgBlockList = blocklist{
 	"pg | Listener | returns an error on timeout":                     "41522",
 	"pg | Listener | supports concurrent Listen and Receive":          "41522",
 	"v10.ExampleDB_Model_postgresArrayStructTag":                      "32552",
-	"v10.TestConversion":                                              "32552",
-	"v10.TestGinkgo":                                                  "41522",
-	"v10.TestReadColumnValue":                                         "26925",
-	"v10.TestUnixSocket":                                              "31113",
+	"v10.TestBigColumn":       "172196",
+	"v10.TestConversion":      "32552",
+	"v10.TestGinkgo":          "41522",
+	"v10.TestReadColumnValue": "26925",
+	"v10.TestUnixSocket":      "31113",
 }
 
 var gopgIgnoreList = blocklist{


### PR DESCRIPTION
This PR adds the unexpectedly failing test `v10.TestBigColumn` to the `gopgBlockList` inside `pkg/cmd/roachtest/tests/gopg_blocklist.go`.

The test was reported to be failing unexpectedly on the release branch, blocking releases. By adding it to the known failures blocklist, we allow CI to pass and unblock the release pipeline while the root cause is investigated.

Fixes #172196

Release note: None