### PR TITLE
ci: remove push and merge_group triggers from Essential CI

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -1,37 +1,11 @@
 name: GitHub Actions Essential CI
 on:
-  merge_group:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
       - "master"
       - "release-*"
       - "staging-*"
-      - "!release-1.0*"
-      - "!release-1.1*"
-      - "!release-2.0*"
-      - "!release-2.1*"
-      - "!release-19.1*"
-      - "!release-19.2*"
-      - "!release-20.1*"
-      - "!release-20.2*"
-      - "!release-21.1*"
-      - "!release-21.2*"
-      - "!release-22.1*"
-      - "!release-22.2*"
-      - "!release-23.1*"
-      - "!release-23.2*"
-      - "!staging-v22.2*"
-      - "!staging-v23.1*"
-      - "!staging-v23.2*"
-  push:
-    branches:
-      - "master"
-      - "release-*"
-      - "staging-*"
-      - "staging"
-      - "trunk-merge/**"
-      - "trying"
       - "!release-1.0*"
       - "!release-1.1*"
       - "!release-2.0*"


### PR DESCRIPTION
Epic: None
Release note: None