### PR TITLE
ci/ai: model and effort selection for /investigate, output-contract hardening

### DIFF
--- a/.github/prompts/investigate.md
+++ b/.github/prompts/investigate.md
@@ -8,6 +8,12 @@ full investigation and write that file; producing it is the entire job,
 and nothing you do outside it has any effect. Create the directory first
 with `mkdir -p artifacts`.
 
+Write `artifacts/findings.md` early and keep it current: as soon as
+you have read the issue, write a skeleton findings file, and update
+it as the investigation progresses. The workflow has a hard timeout,
+and an up-to-date findings file means an interrupted run still
+delivers what was learned.
+
 The issue you are investigating lives in `ISSUE_REPO` (passed in the
 prompt); `gh` defaults to it, so use plain `gh issue`/`gh pr`/`gh search`
 commands. The working tree is checked out from `CODE_REPO`; use that
@@ -399,6 +405,10 @@ improve future investigation runs.
 ```
 
 Important:
+- If a command is denied or blocked, do not retry it or look for
+  another way to run it — note it in the Tooling Feedback section
+  and move on. Posting to GitHub is handled by a later workflow
+  step, never by you.
 - Always write findings, even if the investigation is inconclusive.
   Partial findings and ruling things out is valuable.
 - Keep log excerpts short and focused.

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -325,10 +325,19 @@ jobs:
           # input — tools end up denied even though settings.json is written
           # correctly. The newer space format (Bash(cmd args)) and settings-
           # based permissions may work after upgrading the action.
+          #
+          # Posting to GitHub is the Post findings step's job, never the
+          # agent's. The posting commands are explicitly denied — rather
+          # than merely left off the allowlist — because an unlisted
+          # command fails with "requires approval", which the agent
+          # treats as retryable; an explicit deny is terminal and makes
+          # it fall back to writing artifacts/findings.md. gh api is
+          # included because it can post comments too.
           claude_args: |
             --model ${{ env.CLAUDE_MODEL }}
             --effort ${{ env.CLAUDE_EFFORT }}
             --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(.claude/skills/engflow-artifacts/run.sh:*),Bash(go tool pprof:*),Bash(go run ./pkg/cmd/tsdump2duck:*),Bash(duckdb:*)"
+            --disallowedTools "Bash(gh issue comment:*),Bash(gh pr comment:*),Bash(gh api:*)"
           prompt: |
             Read and follow the instructions in the prompt file
             `.github/prompts/${{ inputs.smoke_test == true && 'investigate-smoke' || 'investigate' }}.md`.
@@ -347,6 +356,13 @@ jobs:
             failure commit). If CHECKED OUT SHA is empty, the working tree is
             at the default-branch tip instead. Do not run `git checkout` — the
             agent's git credentials cannot fetch from CODE_REPO.
+
+            Your only deliverable is the file `artifacts/findings.md`; a
+            later workflow step posts it to the issue. Commands that post
+            to GitHub (`gh issue comment`, `gh pr comment`, `gh api`) are
+            denied unconditionally. If any command is denied, do not retry
+            it or look for another way to run it — note it in the Tooling
+            Feedback section of your findings and move on.
 
       # The agent is instructed to write its report to artifacts/findings.md,
       # which the steps below upload and post. It occasionally finishes a

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -4,6 +4,17 @@
 # issue. Invokes Claude to autonomously analyze the failure and post
 # findings as a comment.
 #
+# Model selection: the first words after `/investigate` pick the model
+# and the reasoning effort:
+#
+#   /investigate                Opus 4.6 at high effort (the default)
+#   /investigate sonnet         Sonnet 5 (cheaper)
+#   /investigate fable          Claude Fable 5 (most capable, 2x Opus price)
+#   /investigate fable xhigh    ...at raised reasoning effort
+#
+# Effort is one of low, medium, high (default), xhigh, max. Opus 4.6
+# does not support xhigh (it is silently downgraded to high).
+#
 # Manual testing via workflow_dispatch:
 #
 #   Changes to this workflow (especially to permissions, allowed tools,
@@ -40,13 +51,14 @@
 #
 #        git push <your-fork-remote> <failure-sha>:refs/heads/investigate-sha
 #
-#   4. Trigger the workflow. Dispatch defaults to a cheaper model
-#      (Sonnet 4.5); add -f cheap=false for Opus 4.6:
+#   4. Trigger the workflow. Dispatch defaults to Opus 4.6 at high
+#      effort; pass a trigger comment to pick another model or effort:
 #
 #        gh workflow run investigate.yml \
 #          --repo <you>/cockroach \
 #          --ref agent-workflow-investigate \
-#          -f issue_number=<fork-issue-number>
+#          -f issue_number=<fork-issue-number> \
+#          -f comment_body='/investigate sonnet xhigh'
 
 name: Investigate Test Failure
 
@@ -59,12 +71,8 @@ on:
         description: 'Issue number to investigate'
         required: true
       comment_body:
-        description: 'Simulated trigger comment'
+        description: 'Simulated trigger comment (selects model and effort)'
         default: '/investigate'
-      cheap:
-        description: 'Use a cheaper model (claude-sonnet-4-5)'
-        type: boolean
-        default: true
       smoke_test:
         description: 'Run a tool smoke test instead of a real investigation'
         type: boolean
@@ -259,6 +267,44 @@ jobs:
             rm -rf "$CERT_DIR"
           fi
 
+      # Model and effort selection from the trigger comment (see the
+      # header comment for the syntax). Only the second and third word
+      # of the comment's first line are considered, and unrecognized
+      # words are ignored, so trailing free text in the comment is
+      # harmless. The comment body is read from the environment rather
+      # than interpolated into the script, so comment content cannot
+      # inject shell.
+      - name: Select model
+        run: |
+          model='claude-opus-4-6'
+          effort='high'
+          arg1=$(printf '%s' "$COMMENT_BODY" | head -n1 | awk '{print tolower($2)}')
+          arg2=$(printf '%s' "$COMMENT_BODY" | head -n1 | awk '{print tolower($3)}')
+          for arg in "$arg1" "$arg2"; do
+            case "$arg" in
+              sonnet|sonnet-5) model='claude-sonnet-5' ;;
+              fable|fable-5)   model='claude-fable-5' ;;
+              low|medium|high|xhigh|max) effort="$arg" ;;
+            esac
+          done
+          # Opus 4.6 predates the xhigh effort level.
+          if [ "$model" = 'claude-opus-4-6' ] && [ "$effort" = 'xhigh' ]; then
+            effort='high'
+          fi
+          echo "Selected model: $model, effort: $effort"
+          echo "CLAUDE_MODEL=$model" >> "$GITHUB_ENV"
+          echo "CLAUDE_EFFORT=$effort" >> "$GITHUB_ENV"
+
+      # claude-code-action@v1 would install Claude Code 1.0.127
+      # (Sep 2025), which predates the --effort flag (the CLI errors on
+      # unknown options) as well as the Sonnet 5 and Fable 5 models.
+      # Install a pinned recent version instead and hand it to the
+      # action via path_to_claude_code_executable below.
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash -s 2.1.209
+          echo "CLAUDE_BIN=$HOME/.local/bin/claude" >> "$GITHUB_ENV"
+
       - name: Investigate
         id: investigate
         uses: cockroachdb/claude-code-action@v1
@@ -272,6 +318,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_vertex: ${{ env.HAS_API_KEY != 'true' && 'true' || 'false' }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_BIN }}
           # Permissions are passed via --allowedTools using the colon
           # format (Bash(cmd:args)) because cockroachdb/claude-code-action@v1
           # (Claude Code 2.0.1) ignores permissions set via the `settings`
@@ -279,7 +326,8 @@ jobs:
           # correctly. The newer space format (Bash(cmd args)) and settings-
           # based permissions may work after upgrading the action.
           claude_args: |
-            --model ${{ inputs.cheap == true && 'claude-sonnet-4-5' || 'claude-opus-4-6' }}
+            --model ${{ env.CLAUDE_MODEL }}
+            --effort ${{ env.CLAUDE_EFFORT }}
             --allowedTools "Write,Read,Grep,Glob,WebFetch,Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(grep:*),Bash(rg:*),Bash(awk:*),Bash(cut:*),Bash(tr:*),Bash(sort:*),Bash(uniq:*),Bash(wc:*),Bash(tee:*),Bash(diff:*),Bash(file:*),Bash(strings:*),Bash(jq:*),Bash(ls:*),Bash(find:*),Bash(tree:*),Bash(stat:*),Bash(du:*),Bash(mkdir:*),Bash(git:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(fetch-url:*),Bash(unzip:*),Bash(tar x*),Bash(tar -x*),Bash(tar --extract:*),Bash(go mod download:*),Bash(go env:*),Bash(.claude/skills/engflow-artifacts/run.sh:*),Bash(go tool pprof:*),Bash(go run ./pkg/cmd/tsdump2duck:*),Bash(duckdb:*)"
           prompt: |
             Read and follow the instructions in the prompt file
@@ -356,13 +404,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Empty if the job failed before the Select model step.
+          : "${CLAUDE_MODEL:=unknown}" "${CLAUDE_EFFORT:=unknown}"
+          # Footer identifying the model, plus a pointer at the deeper
+          # settings (omitted when this run already used them).
+          hint=''
+          if [ "$CLAUDE_MODEL" != 'claude-fable-5' ] || [ "$CLAUDE_EFFORT" != 'max' ]; then
+            hint=' Use `/investigate fable-5 (high|xhigh|max)` to go deeper.'
+          fi
           if [ -s artifacts/findings.md ]; then
-            # Append the run link and feedback footer here rather than asking
-            # the agent to write them, so the prompt never has to describe the
-            # report as a posted comment (which tempted it to post directly).
+            # Append the footers here rather than asking the agent to write
+            # them, so the prompt never has to describe the report as a
+            # posted comment (which tempted it to post directly).
             {
               cat artifacts/findings.md
-              printf '\n\n---\n\n'
+              printf '\n\n---\n*Generated by `%s` at `%s` effort.%s*\n\n' \
+                "$CLAUDE_MODEL" "$CLAUDE_EFFORT" "$hint"
               printf '[Workflow run](%s) · Was this investigation helpful? Leave a 👍 or 👎 on this comment.\n' "$run_url"
             } > "${RUNNER_TEMP:-/tmp}/comment_body.md"
             gh issue comment "$ISSUE_NUMBER" \
@@ -371,7 +428,7 @@ jobs:
           else
             gh issue comment "$ISSUE_NUMBER" \
               --repo ${{ github.repository }} \
-              --body "Investigation did not produce findings. Check the [workflow run]($run_url) for details."
+              --body "Investigation (model \`$CLAUDE_MODEL\`, effort \`$CLAUDE_EFFORT\`) did not produce findings. Check the [workflow run]($run_url) for details."
           fi
 
       - name: Clean up EngFlow certificates

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -278,8 +278,12 @@ jobs:
         run: |
           model='claude-opus-4-6'
           effort='high'
-          arg1=$(printf '%s' "$COMMENT_BODY" | head -n1 | awk '{print tolower($2)}')
-          arg2=$(printf '%s' "$COMMENT_BODY" | head -n1 | awk '{print tolower($3)}')
+          # GitHub delivers comment bodies with CRLF line endings; strip the
+          # carriage return so the first line's last word matches the case
+          # arms below.
+          line1=$(printf '%s' "$COMMENT_BODY" | head -n1 | tr -d '\r')
+          arg1=$(printf '%s' "$line1" | awk '{print tolower($2)}')
+          arg2=$(printf '%s' "$line1" | awk '{print tolower($3)}')
           for arg in "$arg1" "$arg2"; do
             case "$arg" in
               sonnet|sonnet-5) model='claude-sonnet-5' ;;

--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -291,7 +291,9 @@ jobs:
               low|medium|high|xhigh|max) effort="$arg" ;;
             esac
           done
-          # Opus 4.6 predates the xhigh effort level.
+          # Opus 4.6 predates the xhigh effort level; max, in contrast,
+          # is supported on Opus 4.6 (xhigh arrived later, slotted
+          # between high and max), so only xhigh is downgraded.
           if [ "$model" = 'claude-opus-4-6' ] && [ "$effort" = 'xhigh' ]; then
             effort='high'
           fi
@@ -427,10 +429,12 @@ jobs:
           # Empty if the job failed before the Select model step.
           : "${CLAUDE_MODEL:=unknown}" "${CLAUDE_EFFORT:=unknown}"
           # Footer identifying the model, plus a pointer at the deeper
-          # settings (omitted when this run already used them).
+          # settings (omitted when this run already used them). The
+          # suggested setting is strictly deeper than any run that sees
+          # the hint, since fable-5 at max is excluded above.
           hint=''
           if [ "$CLAUDE_MODEL" != 'claude-fable-5' ] || [ "$CLAUDE_EFFORT" != 'max' ]; then
-            hint=' Use `/investigate fable-5 (high|xhigh|max)` to go deeper.'
+            hint=' Use `/investigate fable-5 max` to go deeper.'
           fi
           if [ -s artifacts/findings.md ]; then
             # Append the footers here rather than asking the agent to write


### PR DESCRIPTION
Two changes to the `/investigate` workflow:

**Model and effort selection.** The trigger comment now picks the model and reasoning effort: the second and third word after `/investigate` (either order) select `sonnet` (Sonnet 5) or `fable` (Claude Fable 5) and an effort level (`low`/`medium`/`high`/`xhigh`/`max`). Defaults remain Opus 4.6 at high effort. The parser strips CRLF from the trigger comment (multi-line comments previously dropped the last selector word), reads the body via the environment so comment content cannot inject shell, and downgrades only `xhigh` on Opus 4.6 (`max` is supported there). The posted comment gains a footer naming the model and effort, with a pointer at the deepest setting. The `cheap` dispatch input is replaced by `-f comment_body='/investigate sonnet xhigh'`. Claude Code is pinned at 2.1.209 since the action's bundled version predates `--effort` and the new models.

**Output-contract hardening.** Follow-up to the failure mode seen in #172478, where the agent tried to post its findings itself five times (including sandbox-override attempts) instead of writing `artifacts/findings.md`: posting commands (`gh issue comment`, `gh pr comment`, `gh api`) are now explicitly denied rather than left off the allowlist — a terminal denial instead of the retryable-sounding "requires approval" — and the inline prompt ends by restating that the findings file is the only deliverable and denied commands must not be retried.

Before merging:
- [ ] Confirm `claude-fable-5` and `claude-sonnet-5` are enabled in the `vertex-model-runners` Vertex project (Fable additionally requires a 30-day data-retention configuration).
- [ ] Dispatch smoke run from a branch on this repo (branch creation needs ruleset bypass) with `-f comment_body='/investigate sonnet low'` to confirm the pinned Claude Code accepts `--effort`/`--disallowedTools` and produces the findings artifact.
- [ ] SecEng sign-off (permission and prompt changes).

After merging, run a real `/investigate` on an open test-failure issue as a canary and revert if anything misbehaves.

Epic: none