### PR TITLE
opt: use histograms for constant columns outside of the exact prefix

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/inverted-json-multi-column
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-json-multi-column
@@ -1,0 +1,163 @@
+exec-ddl
+CREATE TABLE t (
+    k INT PRIMARY KEY,
+    i INT,
+    s STRING,
+    j JSONB,
+    INVERTED INDEX isj (i, s, j)
+)
+----
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 41,
+    "null_count": 0
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 40,
+    "null_count": 100,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 200, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 300, "distinct_range": 9, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 400, "distinct_range": 9, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 400, "distinct_range": 9, "upper_bound": "pineapple"}
+    ]
+  },
+  {
+    "columns": ["j"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 10,
+    "null_count": 0,
+    "histo_col_type": "BYTES",
+    "histo_buckets": [
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x37000138"},
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x37000139"},
+      {"distinct_range": 0, "num_eq": 990, "num_range": 0, "upper_bound": "\\x37000300012a0200"},
+      {"distinct_range": 0, "num_eq": 100, "num_range": 0, "upper_bound": "\\x37000300012a0400"},
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x37000300012a0600"},
+      {"distinct_range": 0, "num_eq": 990, "num_range": 0, "upper_bound": "\\x3761000112620001"},
+      {"distinct_range": 0, "num_eq": 100, "num_range": 0, "upper_bound": "\\x3763000112640001"},
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x3765000112660001"}
+    ]
+  }
+]'
+----
+
+# Test a multi-column inverted index scan where the leading prefix column i
+# spans multiple values but the second prefix column s is held to a single
+# value. s's histogram should be used even though s is outside the exact prefix.
+opt
+SELECT k FROM t@isj WHERE i IN (200, 300) AND s = 'banana' AND j @> '{"a": "b"}'
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── key: (1)
+ └── scan t@isj,inverted
+      ├── columns: k:1(int!null)
+      ├── constraint: /2/3
+      │    ├── [/200/'banana' - /200/'banana']
+      │    └── [/300/'banana' - /300/'banana']
+      ├── inverted constraint: /7/1
+      │    └── spans: ["a"/"b", "a"/"b"]
+      ├── flags: force-index=isj
+      ├── stats: [rows=2.41463, distinct(2)=2, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(3,7)=1, null(3,7)=0, distinct(2,3,7)=2, null(2,3,7)=0]
+      │   histogram(3)=  0   2.4146
+      │                <--- 'banana'
+      │   histogram(7)=  0         2.4146         0           0
+      │                <--- '\x3761000112620001' --- '\x3761000112620002'
+      └── key: (1)
+
+exec-ddl
+CREATE TABLE rbr (
+    k INT PRIMARY KEY,
+    s STRING,
+    j JSONB,
+    INVERTED INDEX sj (s, j)
+) LOCALITY REGIONAL BY ROW
+----
+
+exec-ddl
+ALTER TABLE rbr INJECT STATISTICS '[
+  {
+    "columns": ["crdb_region"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 3,
+    "null_count": 0
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 40,
+    "null_count": 100,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 200, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 300, "distinct_range": 9, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 400, "distinct_range": 9, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 400, "distinct_range": 9, "upper_bound": "pineapple"}
+    ]
+  },
+  {
+    "columns": ["j"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000,
+    "distinct_count": 10,
+    "null_count": 0,
+    "histo_col_type": "BYTES",
+    "histo_buckets": [
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x37000138"},
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x37000139"},
+      {"distinct_range": 0, "num_eq": 990, "num_range": 0, "upper_bound": "\\x37000300012a0200"},
+      {"distinct_range": 0, "num_eq": 100, "num_range": 0, "upper_bound": "\\x37000300012a0400"},
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x37000300012a0600"},
+      {"distinct_range": 0, "num_eq": 990, "num_range": 0, "upper_bound": "\\x3761000112620001"},
+      {"distinct_range": 0, "num_eq": 100, "num_range": 0, "upper_bound": "\\x3763000112640001"},
+      {"distinct_range": 0, "num_eq": 10, "num_range": 0, "upper_bound": "\\x3765000112660001"}
+    ]
+  }
+]'
+----
+
+# Same scenario on a REGIONAL BY ROW table where the query does not constrain
+# crdb_region. The optimizer enumerates crdb_region into one span per region, all
+# pinning s='banana', so crdb_region varies while s is a constant column outside
+# the exact prefix.
+opt
+SELECT k FROM rbr@sj WHERE s = 'banana' AND j @> '{"a": "b"}'
+----
+project
+ ├── columns: k:1(int!null)
+ ├── immutable
+ ├── stats: [rows=11.1111]
+ ├── key: (1)
+ └── scan rbr@sj,inverted
+      ├── columns: k:1(int!null) crdb_region:4(string!null)
+      ├── constraint: /4/2
+      │    ├── [/'central'/'banana' - /'central'/'banana']
+      │    ├── [/'east'/'banana' - /'east'/'banana']
+      │    └── [/'west'/'banana' - /'west'/'banana']
+      ├── inverted constraint: /7/1
+      │    └── spans: ["a"/"b", "a"/"b"]
+      ├── flags: force-index=sj
+      ├── stats: [rows=49.5, distinct(2)=1, null(2)=0, distinct(4)=3, null(4)=0, distinct(7)=1, null(7)=0, distinct(2,4,7)=3, null(2,4,7)=0]
+      │   histogram(2)=  0    49.5
+      │                <--- 'banana'
+      │   histogram(7)=  0          49.5          0           0
+      │                <--- '\x3761000112620001' --- '\x3761000112620002'
+      ├── key: (1)
+      └── fd: (1)-->(4)

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -3466,3 +3466,119 @@ index-join stale
       ├── stats: [rows=0.00200002]
       ├── key: ()
       └── fd: ()-->(1-3)
+
+exec-ddl
+CREATE TABLE hist_multi (
+  k INT PRIMARY KEY,
+  a INT NOT NULL,
+  b INT,
+  INDEX ab (a, b)
+)
+----
+
+exec-ddl
+ALTER TABLE hist_multi INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 5,
+    "null_count": 0
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "null_count": 0,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 180, "distinct_range": 9, "upper_bound": "20"},
+      {"num_eq": 30, "num_range": 270, "distinct_range": 9, "upper_bound": "30"},
+      {"num_eq": 40, "num_range": 360, "distinct_range": 9, "upper_bound": "40"}
+    ]
+  }
+]'
+----
+
+# The leading index column a spans multiple values while b is held to a single
+# value, so b's histogram is used for the estimate even though b falls outside
+# the constraint's exact prefix.
+opt
+SELECT k FROM hist_multi@ab WHERE a IN (1, 2) AND b = 10
+----
+project
+ ├── columns: k:1(int!null)
+ ├── stats: [rows=4]
+ ├── key: (1)
+ └── scan hist_multi@ab
+      ├── columns: k:1(int!null) a:2(int!null) b:3(int!null)
+      ├── constraint: /2/3/1
+      │    ├── [/1/10 - /1/10]
+      │    └── [/2/10 - /2/10]
+      ├── flags: force-index=ab
+      ├── stats: [rows=4, distinct(2)=2, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=2, null(2,3)=0]
+      │   histogram(3)=  0  4
+      │                <--- 10
+      ├── key: (1)
+      └── fd: ()-->(3), (1)-->(2)
+
+exec-ddl
+CREATE TABLE hist_rbr (
+  k INT PRIMARY KEY,
+  a INT,
+  INDEX a_idx (a)
+) LOCALITY REGIONAL BY ROW
+----
+
+exec-ddl
+ALTER TABLE hist_rbr INJECT STATISTICS '[
+  {
+    "columns": ["crdb_region"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 3,
+    "null_count": 0
+  },
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "null_count": 0,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 20, "num_range": 180, "distinct_range": 9, "upper_bound": "20"},
+      {"num_eq": 30, "num_range": 270, "distinct_range": 9, "upper_bound": "30"},
+      {"num_eq": 40, "num_range": 360, "distinct_range": 9, "upper_bound": "40"}
+    ]
+  }
+]'
+----
+
+# On a REGIONAL BY ROW table with crdb_region left unconstrained, the optimizer
+# enumerates crdb_region into one span per region, so crdb_region varies while a
+# is held to a single value outside the exact prefix. a's histogram is still used.
+opt
+SELECT k FROM hist_rbr@a_idx WHERE a = 10
+----
+project
+ ├── columns: k:1(int!null)
+ ├── stats: [rows=10]
+ ├── key: (1)
+ └── scan hist_rbr@a_idx
+      ├── columns: k:1(int!null) a:2(int!null)
+      ├── constraint: /3/2/1
+      │    ├── [/'central'/10 - /'central'/10]
+      │    ├── [/'east'/10 - /'east'/10]
+      │    └── [/'west'/10 - /'west'/10]
+      ├── flags: force-index=a_idx
+      ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+      │   histogram(2)=  0  10
+      │                <--- 10
+      ├── key: (1)
+      └── fd: ()-->(2)

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -350,11 +350,12 @@ func (h *Histogram) CanFilter(
 	// A constant column (constrained to a single value in every span) can filter
 	// the histogram even when an earlier unconstrained column pushes it past the
 	// exact prefix, e.g. crdb_region on a REGIONAL BY ROW table. See Filter.
-	if c.ExtractConstCols(ctx, h.evalCtx).Contains(h.col) {
-		for i := 0; i < constrainedCols; i++ {
-			if c.Columns.Get(i).ID() == h.col {
+	for i := exactPrefix + 1; i < constrainedCols; i++ {
+		if c.Columns.Get(i).ID() == h.col {
+			if c.ExtractConstCols(ctx, h.evalCtx).Contains(h.col) {
 				return i, exactPrefix, true
 			}
+			break
 		}
 	}
 	return 0, exactPrefix, false

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -333,7 +333,8 @@ func maxDistinctValuesInRange(lowerBound, upperBound tree.Datum) (n float64, ok 
 
 // CanFilter returns true if the given constraint can filter the histogram.
 // This is the case if the histogram column matches one of the columns in
-// the exact prefix of c or the next column immediately after the exact prefix.
+// the exact prefix of c, the next column immediately after the exact prefix,
+// or a column constrained to a single value in every span (a constant column).
 // Returns the offset of the matching column in the constraint if found, as
 // well as the exact prefix.
 func (h *Histogram) CanFilter(
@@ -344,6 +345,16 @@ func (h *Histogram) CanFilter(
 	for i := 0; i < constrainedCols && i <= exactPrefix; i++ {
 		if c.Columns.Get(i).ID() == h.col {
 			return i, exactPrefix, true
+		}
+	}
+	// A constant column (constrained to a single value in every span) can filter
+	// the histogram even when an earlier unconstrained column pushes it past the
+	// exact prefix, e.g. crdb_region on a REGIONAL BY ROW table. See Filter.
+	if c.ExtractConstCols(ctx, h.evalCtx).Contains(h.col) {
+		for i := 0; i < constrainedCols; i++ {
+			if c.Columns.Get(i).ID() == h.col {
+				return i, exactPrefix, true
+			}
 		}
 	}
 	return 0, exactPrefix, false
@@ -582,6 +593,25 @@ func (h *Histogram) Filter(ctx context.Context, c *constraint.Constraint) *Histo
 	if !ok {
 		panic(errors.AssertionFailedf("column mismatch"))
 	}
+
+	// A column past the exact prefix was admitted as a constant column with value
+	// V. The prefix-based path below assumes the columns before colOffset are
+	// fixed to the first span's values, which does not hold when an earlier
+	// column varies, so filter against a synthetic single-column [V - V]
+	// constraint instead.
+	if colOffset > exactPrefix {
+		val := c.Spans.Get(0).StartKey().Value(colOffset)
+		var cols constraint.Columns
+		cols.InitSingle(opt.MakeOrderingColumn(h.col, false /* descending */))
+		key := constraint.MakeKey(val)
+		var span constraint.Span
+		span.Init(key, constraint.IncludeBoundary, key, constraint.IncludeBoundary)
+		return h.filter(
+			ctx, 1 /* spanCount */, func(int) *constraint.Span { return &span },
+			false /* desc */, 0 /* colOffset */, 1 /* exactPrefix */, nil /* prefix */, cols,
+		)
+	}
+
 	prefix := make([]tree.Datum, colOffset)
 	for i := range prefix {
 		prefix[i] = c.Spans.Get(0).StartKey().Value(i)

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -79,7 +79,7 @@ func TestCanFilter(t *testing.T) {
 
 	// The histogram column ID is 1 for all test cases. CanFilter should only
 	// return true for constraints in which column ID 1 is part of the exact
-	// prefix or the first column after.
+	// prefix, the first column after, or a constant column.
 	testData := []struct {
 		constraint string
 		canFilter  bool
@@ -111,7 +111,8 @@ func TestCanFilter(t *testing.T) {
 		},
 		{
 			constraint: "/2/-1: [/0/3 - /0/3] [/2/3 - /2/3]",
-			canFilter:  false,
+			canFilter:  true,
+			colIdx:     1,
 		},
 		{
 			constraint: "/2/1: [/0/3 - /0/3] [/0/5 - /0/5]",
@@ -357,6 +358,18 @@ func TestHistogram(t *testing.T) {
 		},
 		{
 			constraint: "/2/1/3: [/1/40/2 - /1/40/2] [/1/40/4 - /1/40/4] [/1/40/6 - /1/40/6]",
+			//   0 5.7143
+			// <---- 40 -
+			buckets: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 5.71, DistinctRange: 0, UpperBound: tree.NewDInt(40)},
+			},
+			count:        5.71,
+			maxDistinct:  1,
+			distinct:     1,
+			maxFrequency: 5.71,
+		},
+		{
+			constraint: "/2/1: [/0/40 - /0/40] [/2/40 - /2/40]",
 			//   0 5.7143
 			// <---- 40 -
 			buckets: []cat.HistogramBucket{


### PR DESCRIPTION
When estimating the row count for a scan over an index whose leading column is left unconstrained (and therefore spans multiple values), the optimizer discarded the histogram of a later, equality-constrained column and fell back to a distinct-count estimate. This happened because Histogram.CanFilter only admitted a column whose position was within the constraint's exact prefix, and an unconstrained leading column collapses that exact prefix to zero.

The effect was most visible on REGIONAL BY ROW tables queried without pinning crdb_region, especially for multi-column inverted indexes such as (crdb_region, s, j): the inverted column kept its histogram via the separate inverted-constraint path, while the forward prefix column s silently lost its own, producing large row-count misestimates and, in turn, suboptimal plans.

CanFilter now also admits a histogram column that is constrained to a single value in every span (a constant column, per Constraint.ExtractConstCols) even when it falls outside the exact prefix. Filter cannot reuse the general prefix-based machinery in this case, because that machinery assumes every column ahead of the histogram column is fixed to the value taken from the first span, which is false when an earlier column varies. Instead, Filter projects onto the constant value V and filters against a synthetic single-column [V - V] constraint, which is sound precisely because every span agrees on V.

Instructions for reproducing this behaviour are available in the ticket.

Resolves: #172569
Epic: none

Release note (performance improvement): Improved row-count estimation for queries over an index whose leading column is left unconstrained, for example a REGIONAL BY ROW table queried without specifying crdb_region. In these cases the optimizer did not use an available histogram on a later, equality-filtered index column and produced a less accurate estimate, which could lead it to choose a suboptimal query plan. It now uses the histogram, improving estimate accuracy and plan selection.