### PR TITLE
workflows: check commenter permissions via API, not author_association

### DIFF
--- a/.github/workflows/investigate.yml
+++ b/.github/workflows/investigate.yml
@@ -84,10 +84,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request == null &&
        (github.event.comment.body == '/investigate' ||
-        startsWith(github.event.comment.body, '/investigate ')) &&
-       (github.event.comment.author_association == 'COLLABORATOR' ||
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER'))
+        startsWith(github.event.comment.body, '/investigate ')))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -101,6 +98,30 @@ jobs:
       # Repository to check out the code from. Issues and comments use github.repository.
       CODE_REPO: ${{ secrets.CODE_REPO }}
     steps:
+      # Authorization cannot live in the job-level `if:` expression because
+      # checking effective permissions requires an API call. The
+      # author_association field available in expressions reports MEMBER only
+      # for users whose org membership is public, so private members would be
+      # rejected as CONTRIBUTOR. workflow_dispatch needs no check: triggering
+      # it already requires write access.
+      - name: Verify commenter has write permissions
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          PERM=$(gh api "repos/${{ github.repository }}/collaborators/${COMMENTER}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          case "$PERM" in
+            admin|write)
+              echo "User ${COMMENTER} has ${PERM} permission - authorized to trigger an investigation"
+              ;;
+            *)
+              echo "::error::User ${COMMENTER} does not have write access (permission: ${PERM}). Only collaborators with write access can trigger an investigation."
+              exit 1
+              ;;
+          esac
+
       - name: Acknowledge trigger
         if: github.event_name == 'issue_comment'
         env:

--- a/.github/workflows/pr-autosolve-comments.yml
+++ b/.github/workflows/pr-autosolve-comments.yml
@@ -103,13 +103,6 @@ jobs:
           # Reviewable review fields
           echo "review_user=$(jq -r '.review.user.login // empty' "$EVENT_FILE")" >> "$GITHUB_OUTPUT"
 
-          # Extract author_association for permission checking. This field is set
-          # by GitHub on the comment/review object and indicates the commenter's
-          # relationship to the repo (MEMBER, COLLABORATOR, OWNER, etc.).
-          # Using this avoids an API call that requires scopes the GITHUB_TOKEN lacks.
-          ASSOC=$(jq -r '.comment.author_association // .review.author_association // "NONE"' "$EVENT_FILE")
-          echo "author_association=$ASSOC" >> "$GITHUB_OUTPUT"
-
           {
             echo "review_body<<$DELIM"
             jq -r '.review.body // empty' "$EVENT_FILE"
@@ -126,18 +119,22 @@ jobs:
 
       - name: Verify commenter has write permissions
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENTER: ${{ steps.context.outputs.actor }}
-          AUTHOR_ASSOCIATION: ${{ steps.context.outputs.author_association }}
         run: |
-          # Check that the commenter is affiliated with the repo/org. This uses
-          # the author_association field from the GitHub event payload, which
-          # avoids an API call that requires scopes the GITHUB_TOKEN lacks.
-          case "$AUTHOR_ASSOCIATION" in
-            OWNER|MEMBER|COLLABORATOR)
-              echo "User ${COMMENTER} has association ${AUTHOR_ASSOCIATION} - authorized to provide review feedback"
+          # Ask the API for the commenter's effective permission (including
+          # access granted via teams and org roles). The author_association
+          # field from the event payload is not usable here: it reports
+          # MEMBER only for users whose org membership is public, so private
+          # members would be rejected as CONTRIBUTOR.
+          PERM=$(gh api "repos/${{ github.repository }}/collaborators/${COMMENTER}/permission" \
+            --jq '.permission' 2>/dev/null || echo "none")
+          case "$PERM" in
+            admin|write)
+              echo "User ${COMMENTER} has ${PERM} permission - authorized to provide review feedback"
               ;;
             *)
-              echo "::error::User ${COMMENTER} is not a repo collaborator or org member (association: ${AUTHOR_ASSOCIATION}). Only collaborators can provide feedback to the autosolver."
+              echo "::error::User ${COMMENTER} does not have write access (permission: ${PERM}). Only collaborators with write access can provide feedback to the autosolver."
               exit 1
               ;;
           esac


### PR DESCRIPTION
The autosolver comment addresser and the /investigate workflow gated comment triggers on the author_association field of the event payload, accepting OWNER, MEMBER, and COLLABORATOR. That field reports MEMBER only for users whose org membership is public; members with private visibility (the default, and the common case in the cockroachlabs org) show up as CONTRIBUTOR and were rejected despite having write access.

Replace the association check with a collaborator-permission API call, which returns the commenter's effective permission including access granted via teams and org roles, and authorize on admin or write. In investigate.yml the check moves out of the job-level if expression (expressions cannot call APIs) into a first step that runs before the acknowledgment reaction; an unauthorized /investigate comment now starts a job that fails at that step instead of never spawning one. workflow_dispatch runs need no check because dispatching already requires write access.

Epic: None

Release note: None