### PR TITLE
blobs: check external-io-dir containment on path boundaries

### DIFF
--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -59,7 +59,11 @@ func (l *LocalStorage) prependExternalIODir(path string) (string, error) {
 }
 
 func (l *LocalStorage) ensureContained(realPath, inputPath string) error {
-	if !strings.HasPrefix(realPath, l.externalIODir) {
+	// Compare on path boundaries rather than raw string prefixes: the latter
+	// also accepts siblings of the I/O directory whose name merely starts with
+	// it, e.g. "/data/backups-archive" for an I/O directory of "/data/backups".
+	rel, err := filepath.Rel(l.externalIODir, realPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return errors.Errorf("local file access to paths outside of external-io-dir is not allowed: %s", inputPath)
 	}
 	return nil

--- a/pkg/blobs/local_storage_test.go
+++ b/pkg/blobs/local_storage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDirectoryNormalization(t *testing.T) {
@@ -23,4 +24,47 @@ func TestDirectoryNormalization(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, l.externalIODir)
+}
+
+func TestPrependExternalIODir(t *testing.T) {
+	externalIODir := filepath.Join(t.TempDir(), "backups")
+	l, err := NewLocalStorage(externalIODir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		path        string
+		expectedErr string
+	}{
+		{
+			name: "inside",
+			path: "test/file.csv",
+		},
+		{
+			name:        "parent",
+			path:        "../file.csv",
+			expectedErr: "outside of external-io-dir is not allowed",
+		},
+		{
+			name:        "sibling with the io-dir as a name prefix",
+			path:        "../backups-archive/file.csv",
+			expectedErr: "outside of external-io-dir is not allowed",
+		},
+		{
+			name:        "rooted sibling with the io-dir as a name prefix",
+			path:        "/../backups-archive/file.csv",
+			expectedErr: "outside of external-io-dir is not allowed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := l.prependExternalIODir(tc.path)
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
The blob service resolves every nodelocal path against the configured `--external-io-dir` and then checks that the result stayed inside it, but `ensureContained` does that with a plain string prefix test against the absolute directory. `filepath.Join` has already collapsed the `..` segments by the time the check runs, so a path that lands on a sibling directory whose name merely begins with the I/O directory's name satisfies the prefix and is accepted: with `--external-io-dir=/data/backups`, `nodelocal://1/../backups-archive/x` resolves to `/data/backups-archive/x` and passes. Every `LocalStorage` entry point routes through the same helper, so reads, writes, deletes, stats and listings all leave the directory the same way, whether they arrive from a `nodelocal://` URI or over the Blob gRPC service. I noticed it while working out what the I/O directory actually guarantees for a principal that has been given external IO access but is not otherwise trusted with the node's filesystem. Comparing with `filepath.Rel` restores the boundary while keeping the check purely lexical, which is what the comment above `prependExternalIODir` asks for so that operators can still open up the directory with symlinks. The test covers the sibling-prefix case alongside the ordinary parent traversal that was already rejected.

Epic: none