### PR TITLE
sql: escape external connection name in create-time GRANT

### DIFF
--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -147,9 +147,13 @@ func (p *planner) createExternalConnection(
 		return errors.Wrap(err, "failed to create external connection")
 	}
 
-	// Grant user `ALL` on the newly created External Connection.
-	grantStatement := fmt.Sprintf(`GRANT ALL ON EXTERNAL CONNECTION "%s" TO %s`,
-		ec.name, p.User().SQLIdentifier())
+	// Grant user `ALL` on the newly created External Connection. The connection
+	// name is only checked for non-emptiness, so it can contain arbitrary
+	// characters (including a double quote). Escape it as a SQL identifier
+	// rather than wrapping it in bare quotes so a crafted name cannot break out
+	// of the identifier and alter this statement, which runs as the node user.
+	grantStatement := fmt.Sprintf(`GRANT ALL ON EXTERNAL CONNECTION %s TO %s`,
+		tree.NameString(ec.name), p.User().SQLIdentifier())
 	_, err = txn.ExecEx(params.ctx,
 		"grant-on-create-external-connection", txn.KV(),
 		sessiondata.NodeUserSessionDataOverride, grantStatement)

--- a/pkg/sql/create_external_connection_test.go
+++ b/pkg/sql/create_external_connection_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateExternalConnectionGrantNameEscaping verifies that a connection name
+// containing a double quote cannot break out of the identifier in the GRANT
+// statement that createExternalConnection runs as the node user, which would
+// otherwise let the creator grant themselves privileges on a connection they do
+// not own.
+func TestCreateExternalConnectionGrantNameEscaping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	srv := s.ApplicationLayer()
+
+	adminDB := sqlutils.MakeSQLRunner(db)
+	// A connection owned by another user; the attacker must not gain any
+	// privilege on it.
+	adminDB.Exec(t, `CREATE EXTERNAL CONNECTION victim AS 'userfile:///'`)
+
+	const password = "correcthorsebatterystaple"
+	adminDB.Exec(t, "CREATE USER attacker WITH PASSWORD $1", password)
+	adminDB.Exec(t, "GRANT SYSTEM EXTERNALCONNECTION TO attacker")
+
+	attackerDB := sqlutils.MakeSQLRunner(srv.SQLConn(
+		t, serverutils.UserPassword("attacker", password), serverutils.ClientCerts(false),
+	))
+	// A connection the attacker legitimately owns, used as the first entry of
+	// the crafted object list so the injected GRANT resolves.
+	attackerDB.Exec(t, `CREATE EXTERNAL CONNECTION evil AS 'userfile:///'`)
+	// The crafted name closes the identifier early. Without escaping, the
+	// node-run GRANT becomes GRANT ALL ON EXTERNAL CONNECTION "evil" , "victim"
+	// TO attacker, handing the attacker ALL on the victim connection.
+	attackerDB.Exec(t, `CREATE EXTERNAL CONNECTION "evil"" , ""victim" AS 'userfile:///'`)
+
+	// The attacker should only hold privileges on the connections it created
+	// (each stored under its literal name), never on victim.
+	adminDB.CheckQueryResults(t,
+		`SELECT path FROM system.privileges WHERE username = 'attacker' ORDER BY path`,
+		[][]string{{`/externalconn/evil`}, {`/externalconn/evil" , "victim`}},
+	)
+}


### PR DESCRIPTION
CREATE EXTERNAL CONNECTION grants the creator ALL privileges on the new connection by building a GRANT statement with fmt.Sprintf and running it as the node user. The connection name is taken straight from the statement and is only checked for being non-empty, so it can hold any characters, including a double quote. Because the name was placed inside bare quotes, a name such as `mine" , "other` closes the identifier early and appends a second entry to the grant's object list, letting the creator hand themselves ALL on an external connection they do not own. I hit it while working out what the connection label is allowed to contain before it reaches the internal executor. Escaping the name with tree.NameString doubles any embedded quote and keeps it a single identifier, which is how the SHOW path already renders these names. The grant target already went through SQLIdentifier, so only the name side needed the same handling.

Epic: none