### PR TITLE
sql: pin read sequence number while draining a WITH HOLD cursor for persistence

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -960,3 +960,57 @@ statement ok
 CLOSE foo_first;
 
 subtest end
+
+subtest regression_172772
+
+# Regression for #172772:
+# A WITH HOLD cursor persisted at COMMIT must not observe writes from after DECLARE.
+
+statement ok
+CREATE TABLE bigq (a INT PRIMARY KEY, b STRING)
+
+statement ok
+INSERT INTO bigq SELECT g, 'placeholder' FROM generate_series(1, 11) AS g
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE cq CURSOR WITH HOLD FOR SELECT a FROM bigq ORDER BY a
+
+# Write after DECLARE, before COMMIT.
+statement ok
+INSERT INTO bigq VALUES (100, 'blargh')
+
+# Read advances the txn read seqnum so persistCursor would stamp rows
+# with a post-DECLARE seqnum without the fix.
+statement ok
+SELECT count(*) FROM bigq
+
+statement ok
+COMMIT
+
+# Must return only rows 1..11 (the DECLARE-time snapshot).
+# Without the fix, FETCH also returns 100.
+query I rowsort
+FETCH ALL cq
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+
+statement ok
+CLOSE cq
+
+statement ok
+DROP TABLE bigq
+
+subtest end

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -677,6 +677,21 @@ func persistCursor(p *planner, cursor *sqlCursor) (retErr error) {
 			helper.container.Close(helper.ctx)
 		}
 	}()
+	// Pin the transaction's read sequence number to the cursor's declared
+	// sequence number while draining the cursor, so the persisted rows reflect
+	// the cursor's declared-time snapshot instead of any writes that have
+	// advanced the transaction's read sequence since the cursor was declared.
+	// This matches the bracket that fetchMoveNodeBase applies during a normal
+	// FETCH on a non-persisted cursor.
+	origReadSeqNum := cursor.txn.GetReadSeqNum()
+	if err := cursor.txn.SetReadSeqNum(cursor.readSeqNum); err != nil {
+		return err
+	}
+	defer func() {
+		if rerr := cursor.txn.SetReadSeqNum(origReadSeqNum); rerr != nil && retErr == nil {
+			retErr = rerr
+		}
+	}()
 	for {
 		ok, err := cursor.Next(helper.ctx)
 		if err != nil {


### PR DESCRIPTION
persistCursor drains the cursor via bare cursor.Next() calls during the
COMMIT phase for WITH HOLD cursors, but never brackets the iteration
with SetReadSeqNum / restore. The fetchMoveNodeBase path already does
this to preserve Postgres-style cursor sensitivity; persistCursor
omits it, so the persisted rows can be stamped with whatever the
txn's read seqnum has advanced to since DECLARE.

Apply the same pin/restore in persistCursor. Add a logictest regression.

Fixes #172772

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
