### PR TITLE
backup: clean up BACKUP-LOCK on compaction failure

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	bulkutil "github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -1960,6 +1961,20 @@ func (b *backupResumer) OnFailOrCancel(
 	details := b.job.Details().(jobspb.BackupDetails)
 
 	b.deleteCheckpoint(ctx, cfg, p.User())
+
+	// For compaction jobs, clean up the BACKUP-LOCK file from the backup
+	// destination to unblock subsequent compaction attempts that may target
+	// the same location. A failed compaction does not produce a valid backup at
+	// the destination, so the lock serves no purpose and only blocks future
+	// compactions.
+	if details.Compact && details.URI != "" {
+		besteffort.Warning(ctx, "delete-compaction-backup-lock", func(ctx context.Context) error {
+			return backupinfo.DeleteBackupLock(
+				ctx, cfg, details.URI, b.job.ID(), p.User(),
+			)
+		})
+	}
+
 	if err := cfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		pts := cfg.ProtectedTimestampProvider.WithTxn(txn)
 		return releaseProtectedTimestamp(ctx, pts, details.ProtectedTimestampRecord)

--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -1948,9 +1948,7 @@ func (b *backupResumer) processScheduledBackupCompletion(
 }
 
 // compactionBackupLockCleanupOp is the besteffort operation name used when
-// removing the BACKUP-LOCK file left behind by a failed compaction job. Tests
-// reference it via besteffort.TestForbidSkip to force the cleanup to run
-// deterministically instead of being randomly skipped in test builds.
+// removing the BACKUP-LOCK file left behind by a failed compaction job.
 const compactionBackupLockCleanupOp = "delete-compaction-backup-lock"
 
 // OnFailOrCancel is part of the jobs.Resumer interface.

--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -1947,6 +1947,12 @@ func (b *backupResumer) processScheduledBackupCompletion(
 	return nil
 }
 
+// compactionBackupLockCleanupOp is the besteffort operation name used when
+// removing the BACKUP-LOCK file left behind by a failed compaction job. Tests
+// reference it via besteffort.TestForbidSkip to force the cleanup to run
+// deterministically instead of being randomly skipped in test builds.
+const compactionBackupLockCleanupOp = "delete-compaction-backup-lock"
+
 // OnFailOrCancel is part of the jobs.Resumer interface.
 func (b *backupResumer) OnFailOrCancel(
 	ctx context.Context, execCtx interface{}, jobErr error,
@@ -1968,7 +1974,7 @@ func (b *backupResumer) OnFailOrCancel(
 	// the destination, so the lock serves no purpose and only blocks future
 	// compactions.
 	if details.Compact && details.URI != "" {
-		besteffort.Warning(ctx, "delete-compaction-backup-lock", func(ctx context.Context) error {
+		besteffort.Warning(ctx, compactionBackupLockCleanupOp, func(ctx context.Context) error {
 			return backupinfo.DeleteBackupLock(
 				ctx, cfg, details.URI, b.job.ID(), p.User(),
 			)

--- a/pkg/backup/backupinfo/manifest_handling.go
+++ b/pkg/backup/backupinfo/manifest_handling.go
@@ -541,6 +541,37 @@ func WriteBackupLock(
 	return cloud.WriteFile(ctx, defaultStore, lockFileName, bytes.NewReader([]byte("lock")))
 }
 
+// DeleteBackupLock removes the backup lock file for the given jobID from the
+// default backup destination. This is used to clean up lock files from failed
+// compaction jobs so that subsequent compaction attempts to the same destination
+// are not blocked.
+func DeleteBackupLock(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	defaultURI string,
+	jobID jobspb.JobID,
+	user username.SQLUsername,
+) error {
+	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.DeleteBackupLock")
+	defer sp.Finish()
+
+	defaultStore, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, defaultURI, user)
+	if err != nil {
+		return err
+	}
+	defer defaultStore.Close()
+
+	lockFileName := fmt.Sprintf("%s%s", BackupLockFilePrefix, strconv.FormatInt(int64(jobID), 10))
+	if err := defaultStore.Delete(ctx, lockFileName); err != nil {
+		// If the lock file does not exist, there is nothing to clean up.
+		if errors.Is(err, cloud.ErrFileDoesNotExist) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 // WriteMetadataWithExternalSSTs writes a "slim" version of manifest to
 // `exportStore`. This version has the alloc heavy `Files`, `Descriptors`, and
 // `DescriptorChanges` repeated fields nil'ed out, and written to an

--- a/pkg/backup/datadriven_test.go
+++ b/pkg/backup/datadriven_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/besteffort"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -514,6 +515,17 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 	var lastCreatedCluster string
 	ds := newDatadrivenTestState()
 	defer ds.cleanup(ctx, t)
+
+	// The compaction-failed-lock-cleanup test cancels a compaction after its
+	// BACKUP-LOCK is written and then relies on OnFailOrCancel deleting that
+	// lock so a subsequent compaction can proceed. That deletion is a
+	// besteffort operation, which is randomly skipped in test builds; forbid
+	// skipping it here so the cleanup runs deterministically. Scoped to this
+	// file so the random-skip coverage is preserved for every other test.
+	if strings.Contains(path, "compaction-failed-lock-cleanup") {
+		defer besteffort.TestForbidSkip(compactionBackupLockCleanupOp)()
+	}
+
 	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 		execWithTagAndPausePoint := func(jobType jobspb.Type) string {
 			ds.noticeBuffer = nil

--- a/pkg/backup/datadriven_test.go
+++ b/pkg/backup/datadriven_test.go
@@ -486,6 +486,11 @@ func (d *datadrivenTestState) getSQLDBForVC(
 //   - "sleep ms=TIME"
 //     Sleep for TIME milliseconds.
 //
+//   - "besteffort-forbid-skip op=OP"
+//     Forbids the besteffort operation named OP from being randomly skipped in
+//     test builds for the remainder of the test, so its side effects run
+//     deterministically. See pkg/util/besteffort.
+//
 //lint:ignore U1000 unused
 func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 	// TODO(at): data driven tests will need some tweaks to work with OR metamorphic, which will
@@ -516,15 +521,14 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 	ds := newDatadrivenTestState()
 	defer ds.cleanup(ctx, t)
 
-	// The compaction-failed-lock-cleanup test cancels a compaction after its
-	// BACKUP-LOCK is written and then relies on OnFailOrCancel deleting that
-	// lock so a subsequent compaction can proceed. That deletion is a
-	// besteffort operation, which is randomly skipped in test builds; forbid
-	// skipping it here so the cleanup runs deterministically. Scoped to this
-	// file so the random-skip coverage is preserved for every other test.
-	if strings.Contains(path, "compaction-failed-lock-cleanup") {
-		defer besteffort.TestForbidSkip(compactionBackupLockCleanupOp)()
-	}
+	// The "besteffort-forbid-skip" command registers cleanups that must remain
+	// in effect for the remainder of the test; run them once it finishes.
+	var besteffortCleanups []func()
+	defer func() {
+		for _, cleanup := range besteffortCleanups {
+			cleanup()
+		}
+	}()
 
 	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 		execWithTagAndPausePoint := func(jobType jobspb.Type) string {
@@ -582,6 +586,12 @@ func runTestDataDriven(t *testing.T, testFilePathFromWorkspace string) {
 
 		case "skip-under-duress":
 			skip.UnderDuress(t)
+			return ""
+
+		case "besteffort-forbid-skip":
+			var op string
+			d.ScanArgs(t, "op", &op)
+			besteffortCleanups = append(besteffortCleanups, besteffort.TestForbidSkip(op))
 			return ""
 
 		case "reset":

--- a/pkg/backup/testdata/backup-restore/compaction-failed-lock-cleanup
+++ b/pkg/backup/testdata/backup-restore/compaction-failed-lock-cleanup
@@ -1,0 +1,76 @@
+# Test that when a compaction job is cancelled/fails, its BACKUP-LOCK file is
+# cleaned up, allowing subsequent compactions to proceed without being blocked.
+# See: https://github.com/cockroachdb/cockroach/issues/172889
+
+reset test-nodelocal
+----
+
+new-cluster name=s1 disable-tenant
+----
+
+# 1. Setup: create a table and take a full backup followed by two incrementals,
+# saving timestamps to use as compaction start/end boundaries.
+exec-sql
+CREATE DATABASE orig;
+USE orig;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foo VALUES (1, 'a'), (2, 'b');
+----
+
+save-cluster-ts tag=start
+----
+
+backup aost=start
+BACKUP INTO 'nodelocal://1/test-root/' AS OF SYSTEM TIME start;
+----
+
+exec-sql
+INSERT INTO orig.foo VALUES (3, 'c');
+----
+
+backup
+BACKUP INTO LATEST IN 'nodelocal://1/test-root/';
+----
+
+exec-sql
+INSERT INTO orig.foo VALUES (4, 'd');
+----
+
+save-cluster-ts tag=end
+----
+
+backup aost=end
+BACKUP INTO LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME end;
+----
+
+let $backup_path
+SHOW BACKUPS IN 'nodelocal://1/test-root/';
+----
+
+# 2. Pause compaction after the BACKUP-LOCK is written so we can cancel it.
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup_compaction.after.details_has_checkpoint';
+----
+
+compact expect-pausepoint start=start end=end tag=comp1
+SELECT crdb_internal.backup_compaction(0, 'BACKUP INTO LATEST IN ''nodelocal://1/test-root/''', '$backup_path', start, end);
+----
+job paused at pausepoint
+
+# 3. Cancel the compaction job to trigger OnFailOrCancel cleanup.
+job cancel=comp1
+----
+
+# 4. Clear pausepoints so the next compaction can run to completion.
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# 5. Run a new compaction over the same range. If the stale BACKUP-LOCK from the
+# cancelled job was not cleaned up, this would fail with FileAlreadyExists.
+compact start=start end=end tag=comp2
+SELECT crdb_internal.backup_compaction(0, 'BACKUP INTO LATEST IN ''nodelocal://1/test-root/''', '$backup_path', start, end);
+----
+
+job tag=comp2 wait-for-state=succeeded
+----

--- a/pkg/backup/testdata/backup-restore/compaction-failed-lock-cleanup
+++ b/pkg/backup/testdata/backup-restore/compaction-failed-lock-cleanup
@@ -47,17 +47,24 @@ let $backup_path
 SHOW BACKUPS IN 'nodelocal://1/test-root/';
 ----
 
-# 2. Pause compaction after the BACKUP-LOCK is written so we can cancel it.
+# 2. Set a pausepoint so the compaction pauses right after it writes the
+# BACKUP-LOCK, letting us cancel it while the lock is still present. The
+# crdb_internal.backup_compaction builtin starts the job asynchronously, so the
+# call returns immediately with the job ID; we wait for the job to pause
+# separately rather than expecting a synchronous pausepoint error.
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'backup_compaction.after.details_has_checkpoint';
 ----
 
-compact expect-pausepoint start=start end=end tag=comp1
+compact start=start end=end tag=comp1
 SELECT crdb_internal.backup_compaction(0, 'BACKUP INTO LATEST IN ''nodelocal://1/test-root/''', '$backup_path', start, end);
 ----
-job paused at pausepoint
 
-# 3. Cancel the compaction job to trigger OnFailOrCancel cleanup.
+job tag=comp1 wait-for-state=paused
+----
+
+# 3. Cancel the paused compaction to trigger OnFailOrCancel, which cleans up the
+# BACKUP-LOCK file.
 job cancel=comp1
 ----
 

--- a/pkg/backup/testdata/backup-restore/compaction-failed-lock-cleanup
+++ b/pkg/backup/testdata/backup-restore/compaction-failed-lock-cleanup
@@ -8,6 +8,13 @@ reset test-nodelocal
 new-cluster name=s1 disable-tenant
 ----
 
+# The BACKUP-LOCK cleanup in OnFailOrCancel is a besteffort operation, which is
+# randomly skipped in test builds. Forbid skipping it so the cancelled
+# compaction below deterministically removes its lock and the subsequent
+# compaction can proceed.
+besteffort-forbid-skip op=delete-compaction-backup-lock
+----
+
 # 1. Setup: create a table and take a full backup followed by two incrementals,
 # saving timestamps to use as compaction start/end boundaries.
 exec-sql


### PR DESCRIPTION
Fixes #172889

When a compaction job fails, the leftover BACKUP_LOCK file is now removed in OnFailOrCancel. Subsequent compactions will no longer be blocked by stale locks.