### PR TITLE
sql: refresh stale UDTs when binding prepared statements

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -457,6 +457,18 @@ func (ex *connExecutor) execBind(
 		}
 	}()
 
+	if len(ps.UDTs) > 0 {
+		// A portal retains a reference to the prepared statement. Refresh a stale
+		// enum constant before creating the portal so that its AST and the decoded
+		// query arguments use the same enum version. SQL EXECUTE does this in
+		// execStmtInOpenState; Bind is the corresponding extended-protocol path.
+		p := &ex.planner
+		ex.resetPlanner(ctx, p, ex.state.mu.txn, ex.server.cfg.Clock.PhysicalTime())
+		if err := ex.maybeReparsePrepStmt(ctx, ps, bindCmd.PreparedStatementName); err != nil {
+			return retErr(err)
+		}
+	}
+
 	// Decode the arguments, except for internal queries for which we just verify
 	// that the arguments match what's expected.
 	qargs := make(tree.QueryArguments, numQArgs)

--- a/pkg/sql/pgwire/testdata/pgtest/enum
+++ b/pkg/sql/pgwire/testdata/pgtest/enum
@@ -225,6 +225,46 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"ALTER TYPE"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# Regression for #172900. The enum constant in the prepared statement was
+# type-checked before the ALTER TYPE. Bind must reparse the statement before
+# creating a portal, otherwise the argument is decoded with the new enum
+# version and comparison fails with "comparison of two different versions of
+# enum".
+send crdb_only
+Parse {"Name": "stale_enum", "Query": "SELECT $1 = 'hi'", "ParameterOIDs": [100104]}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "ALTER TYPE te ADD VALUE 'bonjour'"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ALTER TYPE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Bind {"DestinationPortal": "stale_enum", "PreparedStatement": "stale_enum", "ParameterFormatCodes": [0], "Parameters": [{"text":"hi"}]}
+Execute {"Portal": "stale_enum"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"t"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 # Reuse original prepared statement now that there's a new enum value.
 send
 Bind {"DestinationPortal": "p", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [{"text":"hola"}]}


### PR DESCRIPTION
Fixes #172900

## Summary
- reparse prepared statements with stale user-defined types during pgwire Bind, before decoding arguments and creating the portal
- add a pgwire regression test for Parse → ALTER TYPE → Bind → Execute

## Root cause
SQL-level EXECUTE already refreshes stale enum constants. The pgwire extended-protocol path materializes the prepared statement during Bind and did not perform the same refresh, allowing the stored enum literal and bound enum argument to have different descriptor versions.

## Testing
- `gofmt -w pkg/sql/conn_executor_prepare.go`
- `git diff --check`
- `./dev test pkg/sql/pgwire --filter=TestPGTest` *(blocked before build: local WSL/Docker virtual disk is missing)*