### PR TITLE
sql: prevent unsafe comparison constant unification

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/issue_172978
+++ b/pkg/sql/logictest/testdata/logic_test/issue_172978
@@ -1,0 +1,56 @@
+# LogicTest: local
+# Regression tests for #172978.
+
+statement ok
+CREATE TABLE big (i INT8 PRIMARY KEY)
+
+statement ok
+INSERT INTO big VALUES (9007199254740993)
+
+query I
+SELECT i FROM big WHERE i = 9007199254740992.0::FLOAT8
+----
+9007199254740993
+
+query I
+SELECT i FROM big WHERE i = ANY(ARRAY[9007199254740992.0]::FLOAT[])
+----
+9007199254740993
+
+statement ok
+CREATE TABLE e (tz TIMESTAMPTZ PRIMARY KEY)
+
+statement ok
+INSERT INTO e VALUES ('2020-06-15 16:00:00+00')
+
+statement ok
+SET TIME ZONE 'UTC'
+
+statement ok
+PREPARE ps AS SELECT count(*) FROM e WHERE tz = '2020-06-15 12:00:00'::TIMESTAMP
+
+statement ok
+PREPARE pp AS SELECT count(*) FROM e WHERE tz = ANY(ARRAY['2020-06-15 12:00:00']::TIMESTAMP[])
+
+query I
+EXECUTE ps
+----
+0
+
+query I
+EXECUTE pp
+----
+0
+
+statement ok
+SET TIME ZONE 'America/New_York'
+
+query I
+EXECUTE ps
+----
+1
+
+query I
+EXECUTE pp
+----
+1

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1345,6 +1345,13 @@ func TestLogic_int_size(
 	runLogicTest(t, "int_size")
 }
 
+func TestLogic_issue_172978(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "issue_172978")
+}
+
 func TestLogic_internal_executor(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -117,8 +118,11 @@ func (c *CustomFuncs) IsConstValueEqual(const1, const2 opt.ScalarExpr) bool {
 }
 
 // UnifyComparison attempts to convert a constant expression to the type of the
-// variable expression, if that conversion can round-trip and is monotonic.
-// Otherwise it returns ok=false.
+// variable expression, if that conversion can round-trip and is monotonic. The
+// implicit conversion of the variable to the original type must also be
+// injective; otherwise distinct variable values can compare equal to the
+// constant before the rewrite but not afterwards. Otherwise it returns
+// ok=false.
 func (c *CustomFuncs) UnifyComparison(
 	v *memo.VariableExpr, cnst *memo.ConstExpr,
 ) (_ opt.ScalarExpr, ok bool) {
@@ -132,6 +136,18 @@ func (c *CustomFuncs) UnifyComparison(
 
 	if !isMonotonicConversion(originalType, desiredType) {
 		return nil, false
+	}
+	if !isInjectiveConversion(desiredType, originalType) {
+		return nil, false
+	}
+
+	// Do not fold stable casts into a reusable memo. In particular, converting a
+	// TIMESTAMP constant to TIMESTAMPTZ depends on the session time zone.
+	for _, conversion := range [][2]*types.T{{originalType, desiredType}, {desiredType, originalType}} {
+		volatility, ok := cast.LookupCastVolatility(conversion[0], conversion[1])
+		if !ok || !c.CanFoldOperator(volatility) {
+			return nil, false
+		}
 	}
 
 	// Check that the datum can round-trip between the types. If this is true, it
@@ -155,6 +171,29 @@ func (c *CustomFuncs) UnifyComparison(
 	}
 
 	return c.f.ConstructConst(convertedDatum, desiredType), true
+}
+
+// isInjectiveConversion returns true if converting every value from FROM to TO
+// preserves its identity. This is required because comparison overloads cast
+// the variable to the constant's type before comparing it to the constant.
+//
+// Keep this list deliberately narrow. The round-trip test in UnifyComparison
+// proves only that the constant is representable in the variable's type; it
+// says nothing about other variable values. For example, INT8 to FLOAT8 is not
+// injective above 2^53, even when the FLOAT8 constant round-trips to INT8.
+func isInjectiveConversion(from, to *types.T) bool {
+	switch from.Family() {
+	case types.IntFamily:
+		return to.Family() == types.DecimalFamily
+	case types.DateFamily:
+		switch to.Family() {
+		case types.TimestampFamily, types.TimestampTZFamily:
+			return true
+		}
+	case types.TimestampFamily:
+		return to.Family() == types.TimestampTZFamily
+	}
+	return false
 }
 
 // SimplifyWhens removes known unreachable WHEN cases and constructs a new CASE


### PR DESCRIPTION
## Summary

Fixes #172978.

`UnifyComparison` could replace a mixed-type comparison with one against a converted constant even when the comparison's implicit cast collapses distinct column values. This caused INT8 values above 2^53 to be missed when compared to a FLOAT8 constant. It also performed stable casts without consulting `FoldingControl`, allowing session-time-zone-dependent TIMESTAMP to TIMESTAMPTZ conversions to be baked into prepared plans.

This change only permits the rewrite when the variable-to-original conversion is injective, and consults cast volatility through `FoldingControl` before evaluating either cast. It adds logic tests for scalar and ANY comparisons and for prepared statements across a time-zone change.

## Validation

- `git diff --check`
- Full Bazel logic-test generation was not run locally: WSL fails to start because its Docker disk path is missing.
- Direct `go test ./pkg/sql/opt/norm` is not supported in this checkout without Bazel-generated protobuf packages.