### PR TITLE
sql: clamp decimal sqrDiff to zero to prevent negative results from precision loss

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -4174,6 +4174,11 @@ func (a *decimalSqrDiffAggregate) intermediateResult() (tree.Datum, error) {
 	if a.count.Cmp(decimalOne) < 0 {
 		return tree.DNull, nil
 	}
+	// sqrDiff is mathematically always >= 0. Clamp to 0 to guard against
+	// negative values from precision loss in the apd decimal arithmetic.
+	if a.sqrDiff.Cmp(decimalZero) < 0 {
+		a.sqrDiff.SetInt64(0)
+	}
 	dd := &tree.DDecimal{}
 	dd.Set(&a.sqrDiff)
 	// Remove trailing zeros. Depending on the order in which the input
@@ -4391,6 +4396,11 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 func (a *decimalSumSqrDiffsAggregate) intermediateResult() (tree.Datum, error) {
 	if a.count.Cmp(decimalOne) < 0 {
 		return tree.DNull, nil
+	}
+	// sqrDiff is mathematically always >= 0. Clamp to 0 to guard against
+	// negative values from precision loss in the apd decimal arithmetic.
+	if a.sqrDiff.Cmp(decimalZero) < 0 {
+		a.sqrDiff.SetInt64(0)
 	}
 	dd := &tree.DDecimal{Decimal: a.sqrDiff}
 	return dd, nil


### PR DESCRIPTION
## Description

Fixes #173065
Fixes #173063

The decimalSqrDiffAggregate and decimalSumSqrDiffsAggregate
intermediateResult() methods can return negative values due to
precision loss in the apd decimal arithmetic during distributed
merge operations. This causes SQRDIFF and downstream functions
(such as VARIANCE, which uses decimalSqrDiffAggregate internally)
to return large negative values for all-equal large DECIMAL inputs.

The issue is that the intermediate result serialization loses
low-order digits, preventing exact cancellation of the squared
difference terms. Since sqrDiff is mathematically always >= 0,
clamping to zero is the correct guard against precision artifacts.

The float variant already has this guard via
ensureNonNegativeFloatResult(). This change adds the equivalent
for decimal aggregates.

## Changes
- In decimalSqrDiffAggregate.intermediateResult(): clamp sqrDiff to 0 if negative
- In decimalSumSqrDiffsAggregate.intermediateResult(): clamp sqrDiff to 0 if negative
