### PR TITLE
fix: clamp decimal sqrDiff to zero in variance aggregation to prevent negative results from precision loss [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -4174,6 +4174,11 @@ func (a *decimalSqrDiffAggregate) intermediateResult() (tree.Datum, error) {
 	if a.count.Cmp(decimalOne) < 0 {
 		return tree.DNull, nil
 	}
+	// sqrDiff is mathematically always >= 0. Clamp to 0 to guard against
+	// negative values from precision loss in the apd decimal arithmetic.
+	if a.sqrDiff.Cmp(decimalZero) < 0 {
+		a.sqrDiff.SetInt64(0)
+	}
 	dd := &tree.DDecimal{}
 	dd.Set(&a.sqrDiff)
 	// Remove trailing zeros. Depending on the order in which the input
@@ -4391,6 +4396,11 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 func (a *decimalSumSqrDiffsAggregate) intermediateResult() (tree.Datum, error) {
 	if a.count.Cmp(decimalOne) < 0 {
 		return tree.DNull, nil
+	}
+	// sqrDiff is mathematically always >= 0. Clamp to 0 to guard against
+	// negative values from precision loss in the apd decimal arithmetic.
+	if a.sqrDiff.Cmp(decimalZero) < 0 {
+		a.sqrDiff.SetInt64(0)
 	}
 	dd := &tree.DDecimal{Decimal: a.sqrDiff}
 	return dd, nil


### PR DESCRIPTION
Fixes #173063

## Description

The `decimalSqrDiffAggregate` and `decimalSumSqrDiffsAggregate`
`intermediateResult()` methods can return negative values due to
precision loss in the `apd` decimal arithmetic during distributed
merge operations. This causes `VARIANCE` to return large negative
values for all-equal large `DECIMAL` inputs.

The issue is that the intermediate result serialization loses
low-order digits, preventing exact cancellation of the squared
difference terms. Since sqrDiff is mathematically guaranteed to be
non-negative (`SUM((x - mean)^2)`), this patch clamps the result
to zero when precision loss produces a negative value.

## Root Cause

The underlying aggregation formula is:
`sqrDiff = SUM(x^2) - (SUM(x))^2 / COUNT`

This is mathematically non-negative, but the `apd` decimal library
has limited precision. When the two terms are very close (e.g. all
input values are equal), low-order digits lost during serialization
prevent exact cancellation, producing a small negative value.

The VARIANCE issue described in #173063 is the same root cause as
the SQRDIFF issue in #173065 — both use the same `sqrDiff`
intermediate result. The fix is identical: clamp sqrDiff to 0.

## Changes

- `pkg/sql/sem/builtins/aggregate_builtins.go`:
  - `decimalSqrDiffAggregate.intermediateResult()`: clamp `sqrDiff` to 0
  - `decimalSumSqrDiffsAggregate.intermediateResult()`: clamp `sqrDiff` to 0
