### PR TITLE
fix: return proper error instead of assertion when portal format codes are too short (#173071)

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4629,7 +4629,8 @@ func (ex *connExecutor) initStatementResult(
 	for i, c := range cols {
 		fmtCode, err := res.GetFormatCode(i)
 		if err != nil {
-			return err
+			return pgerror.New(pgcode.FeatureNotSupported,
+				"cached plan must not change result type")
 		}
 		if err = checkResultType(c.Typ, fmtCode); err != nil {
 			return err

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -228,7 +228,7 @@ func (r *commandResult) GetFormatCode(colIdx int) (pgwirebase.FormatCode, error)
 				// doesn't matter.
 				return fmtCode, nil
 			}
-			return 0, errors.AssertionFailedf("could not find format code for column %d in %v", colIdx, r.formatCodes)
+			return 0, errors.Newf("could not find format code for column %d in %v", colIdx, r.formatCodes)
 		}
 		fmtCode = r.formatCodes[colIdx]
 	}


### PR DESCRIPTION
## Summary

Fixes #173071

When a portal prepared from an `EXECUTE` wrapper outlives a result-shape change, the format codes sized at Bind time (from the wrapper's frozen column count) may not cover the columns the plan actually produces at Execute time. This causes an assertion failure in `GetFormatCode()`:

```
SQLSTATE[XX000]: Internal error: ERROR: internal error: could not find format code for column 1 in [FormatText]
```

### Root Cause

The `EXECUTE` handler in `execStmtInOpenState` replaces the wrapper statement with the inner prepared statement's data. The inner statement's `ExpectedTypes` is refreshed from the re-prepared inner statement, so the plan-time guard passes. However, the format codes on the portal were sized at Bind time from the wrapper's frozen `Columns`, which may still reflect the old schema.

### Changes

1. **`pkg/sql/pgwire/command_result.go`**: Changed `errors.AssertionFailedf` to `errors.Newf` in `GetFormatCode()` — the mismatch is a recoverable error, not an assertion violation.

2. **`pkg/sql/conn_executor.go`**: In `initStatementResult()`, when `GetFormatCode()` returns an error (format codes too short for the result columns), convert it to a `pgcode.FeatureNotSupported` error (`0A000 cached plan must not change result type`) — matching the error code returned by the non-`EXECUTE` Bind-time guard.

### Reproduction

See the test case in the issue: `PREPARE bar AS SELECT * FROM v WHERE id = 1` → `ALTER TABLE v ADD COLUMN b INT` → `DEALLOCATE bar; PREPARE bar AS SELECT * FROM v, b` → `EXECUTE bar` on a portal bound before the DDL.

### Impact

Intermittent `XX000` internal errors surfaced to application clients using the extended query protocol (server-side prepared statements) on long-lived pooled connections after schema migrations.
