### PR TITLE
fix(cli): use HasPrefix for haproxy flag matching to avoid advertise-http-addr collision

### DIFF
--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -115,8 +115,10 @@ func nodeStatusesToNodeInfos(nodes *serverpb.NodesResponse) []haProxyNodeInfo {
 		// TODO(knz): this logic is horrendously broken and
 		// incorrect. Replace it.
 		for j, arg := range status.Args {
-			if strings.Contains(arg, cliflags.ListenHTTPPort.Name) ||
-				strings.Contains(arg, cliflags.ListenHTTPAddr.Name) {
+			if strings.HasPrefix(arg, "--"+cliflags.ListenHTTPPort.Name) ||
+				strings.HasPrefix(arg, "--"+cliflags.ListenHTTPAddr.Name) ||
+				strings.HasPrefix(arg, "-"+cliflags.ListenHTTPPort.Name) ||
+				strings.HasPrefix(arg, "-"+cliflags.ListenHTTPAddr.Name) {
 				_ = fs.Parse(status.Args[j:])
 				break
 			}

--- a/pkg/cli/haproxy_test.go
+++ b/pkg/cli/haproxy_test.go
@@ -108,6 +108,21 @@ func TestNodeStatusToNodeInfoConversion(t *testing.T) {
 				},
 			},
 		},
+		// Check that --advertise-http-addr is not mistaken for --http-addr.
+		{
+			serverpb.NodesResponse{Nodes: []statuspb.NodeStatus{
+				{
+					Desc: roachpb.NodeDescriptor{NodeID: 1},
+					Args: []string{"--advertise-http-addr=node.example:9999", "--http-addr=node.example:5678"},
+				},
+			}},
+			[]haProxyNodeInfo{
+				{
+					NodeID:    1,
+					CheckPort: "5678",
+				},
+			},
+		},
 		// Check that decommission{ing,ed} nodes are not considered for
 		// generating the configuration.
 		{


### PR DESCRIPTION
## Description

Fixes #172968

**Problem:** `nodeStatusesToNodeInfos()` in `pkg/cli/haproxy.go` uses `strings.Contains` to match `http-addr` and `http-port` flags in node startup arguments. This substring match incorrectly matches `--advertise-http-addr` as `--http-addr`, because "http-addr" is a substring of "advertise-http-addr".

When a node is started with `--advertise-http-addr` before `--http-addr`:
1. The sub-string match triggers on `--advertise-http-addr`
2. `fs.Parse()` is called but the `--advertise-http-addr` flag isn't registered in the local flag set
3. Parse returns an error (discarded with `_ =`)
4. The loop breaks, and the real `--http-addr` is never reached
5. The generated HAProxy config uses the default HTTP port (8080) instead of the configured port

**Fix:** Replace `strings.Contains` with `strings.HasPrefix` for exact flag name matching. This ensures `--advertise-http-addr` is not matched as `--http-addr`.

**Testing:** Added a test case that reproduces the exact scenario: `--advertise-http-addr=node.example:9999` followed by `--http-addr=node.example:5678`. The test verifies the correct port (5678) is used in the generated config.
