### PR TITLE
fix: guard Placeholder.Format against empty Placeholders slice in formatActiveQuery

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2497,7 +2497,7 @@ func formatActiveQuery(query serverpb.ActiveQuery) string {
 	var sb strings.Builder
 	sql := tree.AsStringWithFlags(parsed.AST, tree.FmtSimple,
 		tree.FmtPlaceholderFormat(func(ctx *tree.FmtCtx, p *tree.Placeholder) {
-			if int(p.Idx) > len(query.Placeholders) {
+			if int(p.Idx) >= len(query.Placeholders) {
 				ctx.Printf("$%d", p.Idx+1)
 				return
 			}


### PR DESCRIPTION
Fixes #173175

### Problem

`formatActiveQuery` in `pkg/sql/crdb_internal.go` panics with `index out of range [0] with length 0` when a query is parsed as having placeholders (`$1` etc.) but the `query.Placeholders` slice is empty. The guard condition `int(p.Idx) > len(query.Placeholders)` uses `>` instead of `>=`, so when `p.Idx` is 0 and `len(query.Placeholders)` is 0, the check `0 > 0` evaluates to `false` and the code falls through to `query.Placeholders[p.Idx]`, which panics on an empty slice.

### Root cause

The placeholder index `p.Idx` is 0-based. The valid range for a slice of length `n` is `[0, n)`. The guard should use `>=` (out of bounds when `idx >= len`) instead of `>` (which only catches `idx > len`, missing `idx == len` and the case where the slice is empty and `idx` is 0).

### Fix

Change `>` to `>=` in the bounds check:

```go
// Before
if int(p.Idx) > len(query.Placeholders) {

// After
if int(p.Idx) >= len(query.Placeholders) {
```

### Reproduction

Any query that has placeholders in the SQL text (`$1`, `$2`) but no corresponding placeholder values in `query.Placeholders` will trigger this panic when `formatActiveQuery` is called (e.g., via `crdb_internal.node_statement_statistics` or `crdb_internal.node_sessions`).

### Stack trace

```
catch.go:24: runtime error: index out of range [0] with length 0
  pkg/sql/crdb_internal.go:2484 formatActiveQuery.func1
  pkg/sql/sem/tree/expr.go:805 Placeholder.Format
  pkg/sql/sem/tree/adjust_constants.go:88
```