### PR TITLE
.github: use global Vertex endpoint for Opus 4.8 autosolver workflows

### DIFF
--- a/.github/workflows/issue-autosolve.yml
+++ b/.github/workflows/issue-autosolve.yml
@@ -80,7 +80,7 @@ jobs:
         uses: cockroachdb/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1.0.180
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
-          CLOUD_ML_REGION: us-east5
+          CLOUD_ML_REGION: global
           # Pass user-controlled content via env vars to prevent prompt injection
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -176,7 +176,7 @@ jobs:
         env:
           CLAUDE_CODE_USE_VERTEX: "1"
           ANTHROPIC_VERTEX_PROJECT_ID: vertex-model-runners
-          CLOUD_ML_REGION: us-east5
+          CLOUD_ML_REGION: global
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           AUTOMATION: "1"


### PR DESCRIPTION
The autosolver workflows set CLOUD_ML_REGION: us-east5 while requesting
claude-opus-4-8. Vertex AI's regional endpoints only serve Claude Sonnet
4.6 and earlier; newer models such as Opus 4.8 are available only through
the global (or multi-region) endpoints. As a result, the first model
request hung for roughly three minutes and then failed, so the autosolver
could not address feedback.

Switch these workflows to CLOUD_ML_REGION: global, matching investigate.yml.

Release note: None
Epic: none

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>
