### PR TITLE
docgen: add regression test for unimplemented/SKIP DOC markers

### DIFF
--- a/pkg/cmd/docgen/extract/extract_test.go
+++ b/pkg/cmd/docgen/extract/extract_test.go
@@ -6,8 +6,11 @@ package extract
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSplitGroup(t *testing.T) {
@@ -56,4 +59,52 @@ b ::=
 		t.Fatal(err)
 	}
 	fmt.Println(string(b))
+}
+
+// TestGenerateBNFSkipMarkers verifies that branches annotated with
+// "unimplemented" or "SKIP DOC" are omitted from the generated BNF, and that
+// "FORCE DOC" overrides the "unimplemented" exclusion.
+func TestGenerateBNFSkipMarkers(t *testing.T) {
+	const grammar = `
+%%
+
+stmt:
+  documented_stmt
+| unimplemented_stmt
+| skipped_stmt
+| forced_stmt
+
+documented_stmt:
+  DOCUMENTED { }
+
+unimplemented_stmt:
+  UNIMPL { return unimplemented(sqllex, "unimpl") }
+
+skipped_stmt:
+  SKIPPED { /* SKIP DOC */ }
+
+forced_stmt:
+  FORCED { /* FORCE DOC */ return unimplementedWithIssue(sqllex, 1) }
+
+%%
+`
+	path := filepath.Join(t.TempDir(), "test.y")
+	if err := os.WriteFile(path, []byte(grammar), 0644); err != nil {
+		t.Fatal(err)
+	}
+	bnf, err := GenerateBNF(path, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(bnf)
+	for _, want := range []string{"documented_stmt", "forced_stmt"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in generated BNF, got:\n%s", want, out)
+		}
+	}
+	for _, notWant := range []string{"unimplemented_stmt", "skipped_stmt"} {
+		if strings.Contains(out, notWant) {
+			t.Errorf("expected %q to be excluded from generated BNF, got:\n%s", notWant, out)
+		}
+	}
 }


### PR DESCRIPTION
Informs #45464.

While looking at #45464 I found that the requested behavior is already implemented: `extract.GenerateBNF` drops any grammar branch whose action contains `unimplemented` or `SKIP DOC`, with `FORCE DOC` overriding the `unimplemented` exclusion ([extract.go#L123-L136](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/docgen/extract/extract.go#L123-L136)). This matches what @kovan noted on the issue.

None of that filtering was covered by a test, so this PR adds one: it runs `GenerateBNF` over a small synthetic `.y` grammar with four rules (plain, `unimplemented`, `SKIP DOC`, and `unimplemented` + `FORCE DOC`) and asserts which ones survive into the generated BNF. I verified the test fails if the `unimplemented` filter is removed.

If maintainers agree the original request is satisfied, #45464 can be closed once this lands.

Release note: None