### PR TITLE
sctest: fix three defects in Rollback/Pause cumulative stage discovery

### DIFF
--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -62,24 +62,35 @@ type rollbackStageTracker struct {
 	checkedExplainInRollback bool
 }
 
-// stageDiscovery counts post-commit stages during the first schema change
-// execution. It is populated from the BeforeStage knob under its mutex.
+// stageDiscovery counts post-commit stages during the discovery pass of a
+// schema change execution. It is populated from the BeforeStage knob under its
+// mutex. Unlike a "count once" tracker, it overwrites the counts on every
+// observed plan until frozen, so the last-observed (job) plan wins. This
+// matters because the BeforeStage knob is installed at cluster creation and
+// observes plans for setup statements (e.g. CREATE SEQUENCE, CREATE INDEX) that
+// run through the declarative schema changer and plan with zero post-commit
+// stages. Recording only the first plan would lock in 0 and cause the
+// per-stage cases to skip. Overwriting until the discovery pass completes (and
+// then freezing) ensures the schema change job's plan is the one counted. It
+// also enables multi-statement test definitions, where only the final job plan
+// carries the post-commit stages.
 type stageDiscovery struct {
 	syncutil.Mutex
-	counted                      bool
+	frozen                       bool
 	postCommitCount              int
 	postCommitNonRevertibleCount int
 }
 
-// countStagesOnce records stage counts from p on the first call; subsequent
-// calls are no-ops.
-func (d *stageDiscovery) countStagesOnce(p scplan.Plan) {
+// observe overwrites the stage counts from p. It is a no-op once the discovery
+// is frozen.
+func (d *stageDiscovery) observe(p scplan.Plan) {
 	d.Lock()
 	defer d.Unlock()
-	if d.counted {
+	if d.frozen {
 		return
 	}
-	d.counted = true
+	d.postCommitCount = 0
+	d.postCommitNonRevertibleCount = 0
 	for _, s := range p.Stages {
 		switch s.Phase {
 		case scop.PostCommitPhase:
@@ -88,6 +99,15 @@ func (d *stageDiscovery) countStagesOnce(p scplan.Plan) {
 			d.postCommitNonRevertibleCount++
 		}
 	}
+}
+
+// freeze stops the discovery from overwriting the stage counts. It is called
+// once the discovery pass completes so that subsequent per-stage executions
+// (which observe plans with injected failures) do not clobber the counts.
+func (d *stageDiscovery) freeze() {
+	d.Lock()
+	defer d.Unlock()
+	d.frozen = true
 }
 
 // counts returns the discovered stage counts.
@@ -112,11 +132,11 @@ func Rollback(t *testing.T, relPath string, factory TestServerFactory) {
 	skip.UnderDeadlock(t)
 
 	var prepData rollbackPrepData
-	t.Cleanup(func() {
+	defer func() {
 		if prepData.server.Stopper != nil {
 			prepData.server.Stopper(t)
 		}
-	})
+	}()
 	cumulativeTestForEachPostCommitStage(t, relPath, factory,
 		func(t *testing.T, spec CumulativeTestSpec) PrepResult[rollbackPrepData] {
 			result := rollbackPrepare(t, factory, spec)
@@ -143,7 +163,7 @@ func rollbackPrepare(
 
 	knobs := &scexec.TestingKnobs{
 		BeforeStage: func(p scplan.Plan, stageIdx int) error {
-			discovery.countStagesOnce(p)
+			discovery.observe(p)
 
 			// Read scenario state under the lock, then perform expensive
 			// work (explain diagrams, assertions) outside it so we don't
@@ -260,6 +280,7 @@ func rollbackPrepare(
 	require.NoError(t, setupSchemaChange(ctx, t, spec, db))
 	maybeSkipUnderSecondaryTenant(t, spec, args.server.Server)
 	require.NoError(t, executeSchemaChangeTxn(ctx, t, spec, db))
+	discovery.freeze()
 
 	switchToSystemForDropDB(t, tdb, spec)
 	waitForSchemaChangesToFinish(t, tdb)
@@ -297,6 +318,9 @@ func rollbackCase(t *testing.T, args rollbackPrepData, cs CumulativeTestCaseSpec
 	tdb.Exec(t, "USE system")
 	tdb.Exec(t, "SET use_declarative_schema_changer = 'on'")
 	tdb.Exec(t, fmt.Sprintf("DROP DATABASE IF EXISTS %q CASCADE", cs.DatabaseName))
+	if cs.CreateDatabaseStmt != "" {
+		tdb.Exec(t, cs.CreateDatabaseStmt)
+	}
 
 	require.NoError(t, setupSchemaChange(ctx, t, cs.CumulativeTestSpec, db))
 	tdb.Exec(t, fmt.Sprintf("USE %q", cs.DatabaseName))
@@ -689,7 +713,7 @@ func pausePrepare(
 
 	knobs := &scexec.TestingKnobs{
 		BeforeStage: func(p scplan.Plan, stageIdx int) error {
-			discovery.countStagesOnce(p)
+			discovery.observe(p)
 
 			// Check if a pause scenario is active.
 			scenario.Lock()
@@ -736,6 +760,7 @@ func pausePrepare(
 	require.NoError(t, setupSchemaChange(ctx, t, spec, db))
 	maybeSkipUnderSecondaryTenant(t, spec, args.server.Server)
 	require.NoError(t, executeSchemaChangeTxn(ctx, t, spec, db))
+	discovery.freeze()
 
 	switchToSystemForDropDB(t, tdb, spec)
 	waitForSchemaChangesToFinish(t, tdb)
@@ -776,6 +801,9 @@ func pauseCase(t *testing.T, args pausePrepData, cs CumulativeTestCaseSpec) {
 			"DROP DATABASE IF EXISTS %q CASCADE", cs.DatabaseName,
 		),
 	)
+	if cs.CreateDatabaseStmt != "" {
+		tdb.Exec(t, cs.CreateDatabaseStmt)
+	}
 
 	require.NoError(t, setupSchemaChange(ctx, t, cs.CumulativeTestSpec, db))
 


### PR DESCRIPTION
## Summary

The shared-cluster refactor of the cumulative schema changer test suites (commit `15081f2cf3c`) introduced three defects in `pkg/sql/schemachanger/sctest/cumulative.go`. Their combined effect is that a large portion of the generated `TestRollback_*` and `TestPause_*` tests have been silently skipping since the refactor, and once the skipping is fixed, two further defects cause failures for tests that then actually run.

### Defect 1: Stage discovery is poisoned by setup statements (tests silently skip)

`stageDiscovery.countStagesOnce` recorded post-commit stage counts from the *first* plan the `BeforeStage` knob observed. Because the knob is installed at cluster creation, any setup statement that runs through the declarative schema changer (e.g. `CREATE SEQUENCE`, `CREATE INDEX`) plans with zero post-commit stages, locking in 0 and causing `cumulativeTestForEachPostCommitStage` to skip with `"test case has no post-commit stages"`.

**Fix:** Replace `countStagesOnce` (first-plan-wins) with `observe`, which overwrites the counts on every observed plan until `freeze` is called after the discovery pass completes. The last-observed (job) plan therefore wins, and multi-statement test definitions are also enabled.

### Defect 2: `rollbackCase`/`pauseCase` drop the database but never recreate it

Both drop the test database and re-run setup without recreating it. Definitions that implicitly use `defaultdb` re-run their setup against `system` and fail with `pq: user root does not have CREATE privilege on database system`. The Backup flavor already handles this correctly by executing `cs.CreateDatabaseStmt` after the drop.

**Fix:** Recreate the database via `cs.CreateDatabaseStmt` after the drop in both `rollbackCase` and `pauseCase`, matching the Backup behavior.

### Defect 3: `Rollback()` stops its shared server via `t.Cleanup`, causing spurious "leaked stopper" failures

`t.Cleanup` runs after the generated caller's `defer log.Scope(t).Close(t)`, so the log scope teardown observes the still-running server and fails the test with `leaked stopper`. `Pause()` uses a plain `defer` and does not have this problem.

**Fix:** Stop the Rollback server with `defer` instead of `t.Cleanup`, matching `Pause()`.

## How to verify

- `dev test pkg/sql/schemachanger -f 'TestRollback_add_column$' -v` — previously completed in ~2s having skipped with "test case has no post-commit stages"; now runs the rollback scenarios.
- `dev test pkg/sql/schemachanger -f 'TestRollback_alter_table_add_check_vanilla$' -v` — previously failed with `user root does not have CREATE privilege on database system` and `leaked stopper`; now succeeds.

Closes #173199