### PR TITLE
fix(spanstats): set SkipMvccStats when node is designated for zero spans

### DIFF
--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -123,6 +123,7 @@ func (s *systemStatusServer) spanStatsFanOut(
 
 		nodeSpans := spansPerNode[nodeID]
 		var spansRequiringMvcc []roachpb.Span
+		skipMvcc := false
 
 		// If SkipApproxTotalStats is set, we only need MVCC stats from one node per span.
 		// Build the list of spans that this node should collect MVCC stats for.
@@ -132,6 +133,13 @@ func (s *systemStatusServer) spanStatsFanOut(
 					spansRequiringMvcc = append(spansRequiringMvcc, span)
 				}
 			}
+			// If this node is not the designated MVCC node for any of its spans,
+			// skip MVCC collection entirely. An empty SpansRequiringMvcc is
+			// ambiguous with the "not participating" case (proto3 zero-value).
+			// Disambiguate by setting SkipMvccStats explicitly.
+			if len(spansRequiringMvcc) == 0 {
+				skipMvcc = true
+			}
 		}
 
 		resp, err := client.(serverpb.RPCStatusClient).SpanStats(ctx,
@@ -139,6 +147,7 @@ func (s *systemStatusServer) spanStatsFanOut(
 				NodeID:             nodeID.String(),
 				Spans:              nodeSpans,
 				SpansRequiringMvcc: spansRequiringMvcc,
+				SkipMvccStats:       skipMvcc,
 			})
 		return resp, err
 	}


### PR DESCRIPTION
## Description

When `SkipApproxTotalStats` is set and a node is the designated MVCC node for **none** of its spans, `spansRequiringMvcc` is computed as an empty list. An empty list is indistinguishable from the proto3 zero-value "not participating" case, so the receiving node's `getLocalStats` falls through and computes MVCC stats for **all** its spans — the opposite of the intended behavior.

### Root cause

In `getLocalStats`, the skip decision is gated on `len(req.SpansRequiringMvcc) > 0`. When the list is empty (because this node is designated for zero spans), the guard fails silently and `skipMvcc` stays `false`, computing full MVCC for every span.

### Fix

In `nodeFn`, when `SkipApproxTotalStats` is set and the computed `spansRequiringMvcc` is empty, set `SkipMvccStats: true` on the per-node request. This disambiguates the empty-list case: the receiving node sees `SkipMvccStats == true` and skips MVCC collection entirely.

### Compatibility

`SkipMvccStats` is only set when `SpansRequiringMvcc` is empty, so `verifySpanStatsRequest`'s mutual exclusivity check (`len(SpansRequiringMvcc) > 0 && SkipMvccStats`) is satisfied. The `getLocalStats` handler already checks `req.SkipMvccStats` before `len(req.SpansRequiringMvcc)`, so this is backward compatible with older nodes.

### Impact

When `spansPerNode < nodes` (e.g. a single large span whose ranges are spread across many nodes), the bug causes ~M nodes each to do a full-span meta scan and return `TotalStats` that gets summed into `ApproximateTotalStats`, violating the documented invariant:
> When set ApproximateTotalStats will equal TotalStats since MVCC stats are collected from only one node rather than accumulated across all replicas.

Fixes #173200

Related: #161819, #138792