### PR TITLE
server/span_stats: fix SkipApproxTotalStats empty-ambiguity opt-out [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -134,11 +134,22 @@ func (s *systemStatusServer) spanStatsFanOut(
 			}
 		}
 
+		// When a node is designated the MVCC collector for none of its spans,
+		// we must still tell it to skip MVCC collection entirely. An empty
+		// SpansRequiringMvcc is indistinguishable from "field not set" in
+		// proto3 (both serialize to an empty, non-nil list on the receiving
+		// side), so without SkipMvccStats the node would fall through and
+		// compute MVCC stats for every span it holds -- the opposite of the
+		// SkipApproxTotalStats intent. Setting SkipMvccStats makes the
+		// opt-out unambiguous.
+		skipMvcc := req.SkipApproxTotalStats && len(spansRequiringMvcc) == 0
+
 		resp, err := client.(serverpb.RPCStatusClient).SpanStats(ctx,
 			&roachpb.SpanStatsRequest{
 				NodeID:             nodeID.String(),
 				Spans:              nodeSpans,
 				SpansRequiringMvcc: spansRequiringMvcc,
+				SkipMvccStats:      skipMvcc,
 			})
 		return resp, err
 	}


### PR DESCRIPTION
Fixes #173200

## Problem

`SkipApproxTotalStats` (added in #161819, fixing #138792) is meant to ensure that during a `SpanStats` fan-out, only **one** node per span collects logical MVCC stats. The coordinator picks a designated MVCC node per span and populates `SpansRequiringMvcc` on that node's per-node request.

The mechanism relies on a non-empty `SpansRequiringMvcc` list to signal "restrict MVCC collection to this subset." But a replica-holding node that is designated for *none* of its spans receives an **empty** `SpansRequiringMvcc`, which is indistinguishable from "field not set" in proto3. Such a node falls through and computes MVCC stats for **all** of its spans — the opposite of the intended behavior.

In `getLocalStats`, the skip decision is gated on the list being non-empty:

```go
skipMvcc := req.SkipMvccStats
if !skipMvcc && len(req.SpansRequiringMvcc) > 0 {
    _, requiresMvcc := spansRequiringMvcc[span.String()]
    skipMvcc = !requiresMvcc
}
```

Because the coordinator sets only `SpansRequiringMvcc` (never `SkipMvccStats`), a node with an empty computed list sees `SkipMvccStats == false` and `len(SpansRequiringMvcc) == 0`, and computes MVCC for every span it holds.

## Fix

When `SkipApproxTotalStats` is set and the computed `spansRequiringMvcc` for a node is empty (the node is the designated MVCC collector for none of its spans), set `SkipMvccStats: true` on the per-node request so the receiving node skips MVCC collection entirely and reports physical bytes only.

This makes the per-node request unambiguous: `SkipApproxTotalStats` now guarantees exactly one node per span computes MVCC stats, and `ApproximateTotalStats` equals `TotalStats` regardless of the spans-to-nodes ratio — restoring the invariant documented in `roachpb/span_stats.proto`.

## Test plan

- Logic is a single gating change in the coordinator fan-out (`nodeFn`).
