### PR TITLE
fix: use NOT EXISTS instead of NOT IN to avoid cross join in pruneCache

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -172,8 +172,8 @@ DELETE FROM system.table_metadata
 WHERE table_id IN (
   SELECT table_id
   FROM system.table_metadata
-  WHERE table_id NOT IN (
-    SELECT id FROM system.namespace
+  WHERE NOT EXISTS (
+    SELECT 1 FROM system.namespace WHERE id = table_id
   )
   LIMIT $1
 )


### PR DESCRIPTION
## Summary

The `pruneCache` method in `table_metadata_updater.go` deletes orphaned rows from `system.table_metadata` with a `NOT IN (SELECT id FROM system.namespace)` predicate. Because `system.namespace.id` is nullable, the optimizer must preserve three-valued logic and lowers the predicate to `(table_id = id) IS NOT false`. That is not an equality, so it cannot be hash- or lookup-joined and the plan degrades to a `cross join (anti)` — costing O(rows(table_metadata) × rows(namespace)). On a 9-node cluster with 100k tables that is ~11.1B comparisons (~38 minutes per run).

## Fix

Replace the `NOT IN` subquery with a correlated `NOT EXISTS`, which the optimizer can lower to an equality anti-join:

```sql
WHERE table_id NOT IN (
  SELECT id FROM system.namespace
)
```
→
```sql
WHERE NOT EXISTS (
  SELECT 1 FROM system.namespace WHERE id = table_id
)
```

This changes the plan from `cross join (anti)` (~38 min) to `hash join (anti)` (~0.2s), verified by the reporter. `NOT EXISTS` also eliminates the NULL-hazard of `NOT IN`: a single NULL in `system.namespace.id` would otherwise cause `NOT IN` to return the empty set for every input, silently disabling pruning cluster-wide. `table_metadata.table_id` is `NOT NULL`, so the result set is identical.

Fixes #173143