### PR TITLE
fix: apply locality filter in statsForSpan to prevent ApproximateTotalStats over-count

### DIFF
--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -315,6 +315,21 @@ func (s *systemStatusServer) statsForSpan(
 			storeIDs[repl.StoreID] = struct{}{}
 		}
 
+		// Only collect MVCC stats for ranges where this node holds a replica.
+		// Without this filter, every node reports the full logical size for all
+		// ranges, and the fan-out coordinator's sum across nodes gives
+		// numNodes × logical instead of RF × logical. See #173182.
+		hasReplica := false
+		for _, repl := range voterAndNonVoterReplicas {
+			if s.stores.HasStore(repl.StoreID) {
+				hasReplica = true
+				break
+			}
+		}
+		if !hasReplica {
+			continue
+		}
+
 		// Is the descriptor fully contained by the request span?
 		if rSpan.ContainsKeyRange(descSpan.Key, desc.EndKey) {
 			// Collect into fullyContainedKeys batch.


### PR DESCRIPTION
## Summary

`SpanStats.ApproximateTotalStats` is intended to approximate the post-replication (physical) MVCC size of a span — roughly `logical_size × replication_factor`. Instead, it scales with the **number of nodes** the span's ranges live on, not the replication factor. For a span that occupies more nodes than RF, `ApproximateTotalStats` over-reports by `numNodesContacted / RF`.

## Root cause

In `statsForSpan`, every fanned-out node iterates **all** range descriptors overlapping the span and collects MVCC stats for every range — regardless of whether the node holds a replica of that range. The coordinator's `collectSpanStatsResponses` then sums each node's full logical `TotalStats` into `ApproximateTotalStats`:

```go
res.SpanToStats[spanStr].ApproximateTotalStats.Add(spanStats.TotalStats)
```

Since each node returns the **full logical size** for all ranges, the sum equals `numNodes × logical` instead of `RF × logical`. The bug is masked for spans confined to exactly RF nodes (where `numNodes == RF`) and only appears once a span is wide enough to live on more than RF nodes.

## Fix

Apply a locality filter in `statsForSpan`: only collect MVCC stats for ranges where the current node holds a replica. This makes each node's contribution its actual share of the span, so the coordinator's sum across nodes yields the true replicated (`RF × logical`) total.

The metadata (`RangeCount`, `ReplicaCount`, `StoreIDs`) is still recorded for every range so the coordinator retains complete span-wide information.

Fixes #173182