### PR TITLE
fix(sql): restore advisory lock manager state on read-committed statement retry

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/advisorylock"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -2773,6 +2774,15 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 	if err != nil {
 		return err
 	}
+	// Capture the advisory lock manager state so it can be restored
+	// on retry. The KV savepoint rollback correctly releases the
+	// advisory locks, but the manager's in-memory stack is not
+	// notified of the read-committed savepoint since it is not a
+	// SQL savepoint.
+	var advisoryLockSnap advisorylock.RewindSnapshot
+	if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+		advisoryLockSnap = mgr.ExportRewindSnapshot()
+	}
 
 	// Use retry with exponential backoff and full jitter to reduce collisions for
 	// high-contention workloads. See https://en.wikipedia.org/wiki/Exponential_backoff and
@@ -2854,6 +2864,12 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 		res.SetError(nil)
 		if err := ex.state.mu.txn.RollbackToSavepoint(ctx, readCommittedSavePointToken); err != nil {
 			return err
+		}
+		// Restore the advisory lock manager state to what it was before
+		// the statement executed, since the KV savepoint rollback has
+		// released the advisory locks but the manager was not notified.
+		if mgr := ex.extraTxnState.advisoryLockManager.Load(); mgr != nil {
+			mgr.ApplyRewindSnapshot(advisoryLockSnap)
 		}
 		if err := ex.state.mu.txn.PrepareForPartialRetry(ctx); err != nil {
 			return err


### PR DESCRIPTION
Fixes: #173169

The read-committed per-statement retry loop in `dispatchReadCommittedStmtToExecutionEngine` creates and rolls back its savepoint directly at the KV layer without notifying the advisory lock manager. The manager hooks are only wired into the SQL SAVEPOINT statements.

When a statement acquires a `pg_advisory_xact_lock` and then hits a retryable error in the same statement, KV correctly rolls back the lock but the manager's stack entry survives. If the retry does not re-acquire the same lock, `pg_locks` reports a granted advisory lock the session does not hold for the rest of the transaction.

This fix:
1. Captures a snapshot of the advisory lock manager state alongside the KV savepoint creation (using the existing `ExportRewindSnapshot` primitive).
2. Restores the snapshot after each read-committed statement retry rollback (using `ApplyRewindSnapshot`), keeping `pg_locks` consistent with KV.

The existing rewind primitives (`ExportRewindSnapshot` / `ApplyRewindSnapshot` in `pkg/sql/advisorylock/manager.go`) are reused as suggested in the issue. `OnSQLRollbackToSavepoint` cannot be used directly since the read-committed savepoint is not a SQL savepoint.