### PR TITLE
docs: fix duplicated words and typo in RFCS

### DIFF
--- a/docs/RFCS/20170608_decommission.md
+++ b/docs/RFCS/20170608_decommission.md
@@ -148,7 +148,7 @@ No changes required. The existing CockroachDB process, described below, is
 sufficient.
 
 During a temporary removal, `server.time_until_store_dead` could be updated
-to to the length of the downtime to avoid unnecessary movement of ranges.
+to the length of the downtime to avoid unnecessary movement of ranges.
 However, it is difficult to predict the length of downtime. This is an
 optimization which could be implemented later.
 

--- a/docs/RFCS/20180603_follower_reads.md
+++ b/docs/RFCS/20180603_follower_reads.md
@@ -45,7 +45,7 @@ written at some timestamp well in the past *should* be servable from all
 replicas (assuming normal operation), as replication typically catches up all
 the followers quickly, and most writes happen at "newer" timestamps. Clearly
 neither of these two properties are guaranteed though, so replicas have to be
-provided with a a way of deciding whether a given read request can be served
+provided with a way of deciding whether a given read request can be served
 consistently.
 
 The closed timestamp mechanism provides between each pair of stores a regular

--- a/docs/RFCS/20200513_long_running_migrations.md
+++ b/docs/RFCS/20200513_long_running_migrations.md
@@ -519,7 +519,7 @@ This basically "pretends" that we start the version bump earlier than we
 actually do, and all tenants receive it before any nodes in the KV layer do.
 ```
 
-There's no new machinery being relied on in this kind of of upgrade procedure,
+There's no new machinery being relied on in this kind of upgrade procedure,
 and there's nothing presented in the rest of the infrastructure here that would
 prevent the kind of upgrade procedure described above (we'd have to expose the
 KV version APIs and such to SQL pods, but that's a minor lift).

--- a/docs/RFCS/20211207_graceful_draining.md
+++ b/docs/RFCS/20211207_graceful_draining.md
@@ -254,7 +254,7 @@ timeline for the draining:
   (Which means the total duration of the lease transfer stage is not totally
   determined by the value of `server.shutdown.lease_transfer_iteration.timeout"`.
   We [propose][Lease Transfer Issue] to rename this cluster setting with
-  `server.shutdown.lease_transfer_iteration.timeout"`, and document it seperately with
+  `server.shutdown.lease_transfer_iteration.timeout"`, and document it separately with
   the other three waiting periods.)
 
 # Demo with changes from Technical Design


### PR DESCRIPTION
### WHY

Several RFC documents under `docs/RFCS/` contain duplicated words (`to to`, `a a`, `of of`) and a misspelling (`seperately`).

### WHAT

| File | Before | After |
|------|--------|-------|
| `docs/RFCS/20170608_decommission.md` | `to to the length` | `to the length` |
| `docs/RFCS/20211207_graceful_draining.md` | `seperately` | `separately` |
| `docs/RFCS/20180603_follower_reads.md` | `a a way` | `a way` |
| `docs/RFCS/20200513_long_running_migrations.md` | `kind of of upgrade` | `kind of upgrade` |

Docs only; no code or behavior change.