### PR TITLE
sql: add ST_ForceRHR geometry builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2407,6 +2407,8 @@ Bottom Left.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="st_forcepolygoncw"></a><code>st_forcepolygoncw(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry where all Polygon objects have exterior rings in the clockwise orientation and interior rings in the counter-clockwise orientation. Non-Polygon objects are unchanged.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="st_forcerhr"></a><code>st_forcerhr(geometry: geometry) &rarr; geometry</code></td><td><span class="funcdesc"><p>Returns a Geometry where all Polygon objects have exterior rings in the clockwise orientation and interior rings in the counter-clockwise orientation. Non-Polygon objects are unchanged.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="st_frechetdistance"></a><code>st_frechetdistance(geometry_a: geometry, geometry_b: geometry) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the Frechet distance between the given geometries.</p>
 <p>This function utilizes the GEOS module.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1523,28 +1523,29 @@ POLYGON ((-0.1 0, -0.1 1, 0 1, 0 0, -0.1 0))                                    
 POLYGON EMPTY                                                                                                 POLYGON EMPTY
 
 # CW/CCW predicates.
-query TBBTT
+query TBBTTT
 SELECT
   dsc,
   ST_IsPolygonCW(geom),
   ST_IsPolygonCCW(geom),
   ST_AsText(ST_ForcePolygonCW(geom)),
-  ST_AsText(ST_ForcePolygonCCW(geom))
+  ST_AsText(ST_ForcePolygonCCW(geom)),
+  ST_AsText(ST_ForceRHR(geom))
 FROM geom_operators_test
 ORDER BY dsc
 ----
-Empty GeometryCollection                  true   true  GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
-Empty LineString                          true   true  LINESTRING EMPTY                                       LINESTRING EMPTY
-Empty Point                               true   true  POINT EMPTY                                            POINT EMPTY
-Faraway point                             true   true  POINT (5 5)                                            POINT (5 5)
-Line going through left and right square  true   true  LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (-0.5 0.5, 0.5 0.5)
-NULL                                      NULL   NULL  NULL                                                   NULL
-Nested Geometry Collection                true   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
-Point middle of Left Square               true   true  POINT (-0.5 0.5)                                       POINT (-0.5 0.5)
-Point middle of Right Square              true   true  POINT (0.5 0.5)                                        POINT (0.5 0.5)
-Square (left)                             false  true  POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))                 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))
-Square (right)                            false  true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
-Square overlapping left and right square  false  true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))           POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
+Empty GeometryCollection                  true   true  GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY                               GEOMETRYCOLLECTION EMPTY
+Empty LineString                          true   true  LINESTRING EMPTY                                       LINESTRING EMPTY                                       LINESTRING EMPTY
+Empty Point                               true   true  POINT EMPTY                                            POINT EMPTY                                            POINT EMPTY
+Faraway point                             true   true  POINT (5 5)                                            POINT (5 5)                                            POINT (5 5)
+Line going through left and right square  true   true  LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (-0.5 0.5, 0.5 0.5)                         LINESTRING (-0.5 0.5, 0.5 0.5)
+NULL                                      NULL   NULL  NULL                                                   NULL                                                   NULL
+Nested Geometry Collection                true   true  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))  GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (0 0)))
+Point middle of Left Square               true   true  POINT (-0.5 0.5)                                       POINT (-0.5 0.5)                                       POINT (-0.5 0.5)
+Point middle of Right Square              true   true  POINT (0.5 0.5)                                        POINT (0.5 0.5)                                        POINT (0.5 0.5)
+Square (left)                             false  true  POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))                 POLYGON ((-1 0, 0 0, 0 1, -1 1, -1 0))                 POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+Square (right)                            false  true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))                    POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+Square overlapping left and right square  false  true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))           POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))           POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))
 
 # Functions which take in strings as input as well.
 query TT

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2961,6 +2961,7 @@ var builtinOidsArray = []string{
 	3006: `pg_indexes_size(relation_oid: oid) -> int`,
 	3007: `crdb_internal.tsdb_query(name: string, start_time: timestamptz, end_time: timestamptz) -> tuple{timestamptz AS timestamp, float AS value, string AS source}`,
 	3008: `crdb_internal.tsdb_query(name: string, start_time: timestamptz, end_time: timestamptz, options: jsonb) -> tuple{timestamptz AS timestamp, float AS value, string AS source}`,
+	3010: `st_forcerhr(geometry: geometry) -> geometry`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7898,6 +7898,7 @@ func init() {
 		{"st_coorddim", "st_ndims"},
 		{"st_geogfromtext", "st_geographyfromtext"},
 		{"st_geomfromtext", "st_geometryfromtext"},
+		{"st_forcerhr", "st_forcepolygoncw"},
 		{"st_numinteriorring", "st_numinteriorrings"},
 		{"st_symmetricdifference", "st_symdifference"},
 		{"st_force3d", "st_force3dz"},


### PR DESCRIPTION
Register ST_ForceRHR as an alias of ST_ForcePolygonCW, matching
PostGIS semantics: exterior rings clockwise and interior rings
counter-clockwise. Add a fixed function OID and cover the alias
across the existing geospatial logic-test corpus, including
non-polygon geometries and NULL.

A previous draft (#150698) was closed without review. This version
uses the existing builtin alias table instead of adding a redundant
geometry helper.

Resolves: #60883
Epic: none

Release note (sql change): Added the PostGIS-compatible ST_ForceRHR
geometry function as a synonym for ST_ForcePolygonCW.