### PR TITLE
sql: include column expression dependencies in bundles

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -683,6 +683,8 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	var triggerInfos []triggerInfo
 	var triggerFuncIDs intsets.Fast
 	var triggerDepTypeOIDs intsets.Fast
+	var columnExprSequenceIDs intsets.Fast
+	var columnExprFuncIDs intsets.Fast
 	isProcedure := make(map[oid.Oid]bool)
 	err := b.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Catalog objects can show up multiple times in our lists, so
@@ -862,11 +864,15 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 				include = hasDelete || hasUpdate || hasUpsert
 			},
 		)
-		// Collect trigger information from all referenced tables. For each
-		// trigger, we record its name (for CREATE TRIGGER output later),
-		// the trigger function, and any tables/types/routines it depends on.
-		// We iterate using an index because refTables may grow during
-		// iteration as we discover trigger-dependent tables.
+		// Collect dependencies stored in all referenced table descriptors.
+		// Column expressions are printed by SHOW CREATE TABLE, so their
+		// sequences and functions must be printed first to make schema.sql
+		// recreatable. Identity sequences are created implicitly by the table
+		// definition and must not be printed separately.
+		// For each trigger, we record its name (for CREATE TRIGGER output
+		// later), the trigger function, and any tables/types/routines it
+		// depends on. We iterate using an index because refTables may grow
+		// during iteration as we discover trigger-dependent tables.
 		// TODO(sql-queries): consider skipping trigger collection for SELECT
 		// statements, since triggers only fire on INSERT/UPDATE/DELETE.
 		for i := 0; i < len(refTables); i++ {
@@ -874,6 +880,16 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 			desc, err := getDescForDataSource(table)
 			if err != nil {
 				return err
+			}
+			for _, col := range desc.PublicColumns() {
+				if !col.IsGeneratedAsIdentity() {
+					for j := 0; j < col.NumUsesSequences(); j++ {
+						columnExprSequenceIDs.Add(int(col.GetUsesSequenceID(j)))
+					}
+				}
+				for j := 0; j < col.NumUsesFunctions(); j++ {
+					columnExprFuncIDs.Add(int(col.GetUsesFunctionID(j)))
+				}
 			}
 			triggers := desc.GetTriggers()
 			for j := range triggers {
@@ -933,8 +949,22 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 		if err != nil {
 			return err
 		}
-		sequences, err = getNames(len(mem.Metadata().AllSequences()), func(i int) cat.DataSource {
-			return mem.Metadata().AllSequences()[i]
+		metadataSequences := mem.Metadata().AllSequences()
+		columnExprSequences := make([]cat.DataSource, 0, columnExprSequenceIDs.Len())
+		for _, id := range columnExprSequenceIDs.Ordered() {
+			ds, _, err := b.plan.catalog.ResolveDataSourceByID(
+				ctx, cat.Flags{}, cat.StableID(id),
+			)
+			if err != nil {
+				return err
+			}
+			columnExprSequences = append(columnExprSequences, ds)
+		}
+		sequences, err = getNames(len(metadataSequences)+len(columnExprSequences), func(i int) cat.DataSource {
+			if i < len(metadataSequences) {
+				return metadataSequences[i]
+			}
+			return columnExprSequences[i-len(metadataSequences)]
 		})
 		if err != nil {
 			return err
@@ -1026,6 +1056,9 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 				isProcedure[ol.Oid] = ol.Type == tree.ProcedureRoutine
 			})
 		}
+		columnExprFuncIDs.ForEach(func(descID int) {
+			ids.Add(int(catid.FuncIDToOID(descpb.ID(descID))))
+		})
 		// Also include trigger functions and routines they depend on.
 		// Trigger functions (trig.FuncID) are always functions, but
 		// DependsOnRoutines entries may be procedures, so we use

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -826,6 +826,52 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			"distsql.html vec-v.txt vec.txt")
 	})
 
+	t.Run("column default dependencies", func(t *testing.T) {
+		r.Exec(t, "CREATE FUNCTION bundle_default_f(id INT8) RETURNS INT8 LANGUAGE SQL AS 'SELECT id';")
+		r.Exec(t, "CREATE SEQUENCE bundle_default_s;")
+		r.Exec(t, `CREATE TABLE bundle_default_t (
+			id INT8 PRIMARY KEY DEFAULT bundle_default_f(nextval('bundle_default_s'))
+		);`)
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM bundle_default_t;")
+		checkBundle(
+			t, fmt.Sprint(rows), "bundle_default_t", func(name, contents string) error {
+				if name == "schema.sql" {
+					for _, expected := range []string{
+						"CREATE SEQUENCE public.bundle_default_s",
+						"CREATE FUNCTION public.bundle_default_f",
+					} {
+						if !strings.Contains(contents, expected) {
+							return errors.Errorf("could not find %q in schema.sql:\n%s", expected, contents)
+						}
+					}
+				}
+				return nil
+			}, false /* expectErrors */, base, plans,
+			"distsql.html vec-v.txt vec.txt stats-defaultdb.public.bundle_default_t.sql",
+		)
+	})
+
+	t.Run("identity column dependencies", func(t *testing.T) {
+		r.Exec(t, `CREATE TABLE bundle_identity_t (
+			id INT8 PRIMARY KEY GENERATED ALWAYS AS IDENTITY
+		);`)
+		rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM bundle_identity_t;")
+		checkBundle(
+			t, fmt.Sprint(rows), "bundle_identity_t", func(name, contents string) error {
+				if name == "schema.sql" {
+					if strings.Contains(contents, "CREATE SEQUENCE") {
+						return errors.Errorf("found separately-created identity sequence in schema.sql:\n%s", contents)
+					}
+					if !strings.Contains(contents, "GENERATED ALWAYS AS IDENTITY") {
+						return errors.Errorf("could not find identity definition in schema.sql:\n%s", contents)
+					}
+				}
+				return nil
+			}, false /* expectErrors */, base, plans,
+			"distsql.html vec-v.txt vec.txt stats-defaultdb.public.bundle_identity_t.sql",
+		)
+	})
+
 	t.Run("procedures", func(t *testing.T) {
 		r.Exec(t, "CREATE PROCEDURE add_proc(a INT, b INT) LANGUAGE SQL AS 'SELECT a + b';")
 		r.Exec(t, "CREATE PROCEDURE subtract_proc(a INT, b INT) LANGUAGE SQL AS 'SELECT a - b';")


### PR DESCRIPTION
Statement diagnostics bundles print stored column expressions through `SHOW CREATE TABLE`, but the dependency lists were populated only from optimizer metadata. A read-only statement could therefore omit sequences and user-defined functions used only by a column default, leaving `schema.sql` impossible to recreate.

This collects sequence and function dependencies from the public column descriptors, merges them with the optimizer metadata, and keeps identity sequences implicit because the table definition creates them. The regression coverage includes both the reported sequence-plus-UDF default and the identity-column case.

Fixes #125462
Epic: CRDB-39474

Release note: None