### PR TITLE
sql: report RevalidateCachedQuery as the cached-plan error's routine

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "buffer.go",
         "buffer_util.go",
         "bulk_bridge.go",
+        "cached_plan_error.go",
         "cancel_queries.go",
         "cancel_sessions.go",
         "check.go",

--- a/pkg/sql/cached_plan_error.go
+++ b/pkg/sql/cached_plan_error.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+)
+
+// RevalidateCachedQuery constructs the "cached plan must not change result
+// type" error raised when a prepared statement's result columns no longer
+// match its cached plan after a schema change.
+//
+// The error is deliberately constructed inside a function with this exact
+// name: clients receive the constructing function's name as the error's
+// Routine field (PG_DIAG_SOURCE_FUNCTION), and PostgreSQL reports
+// "RevalidateCachedQuery" for this error (its plancache.c function).
+// Drivers and ORMs key on that field to detect a stale prepared statement
+// and self-heal by re-preparing — ActiveRecord's PostgreSQL adapter matches
+// it verbatim, and the activerecord-cockroachdb-adapter previously matched
+// the internal function names that happened to appear here, which broke
+// when the raising site moved in #164406. Do not rename this function or
+// inline the construction into a caller; TestPGTest's
+// prepared_stmt_invalidation datadriven test asserts the wire field.
+func RevalidateCachedQuery() error {
+	return pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type")
+}

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -623,7 +623,7 @@ func (ex *connExecutor) execBind(
 					currentCols[i].Typ = colMeta.Type
 				}
 				if !ps.Columns.TypesEqual(currentCols) {
-					return retErr(pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type"))
+					return retErr(RevalidateCachedQuery())
 				}
 			}
 		}

--- a/pkg/sql/pgwire/testdata/pgtest/prepared_stmt_invalidation
+++ b/pkg/sql/pgwire/testdata/pgtest/prepared_stmt_invalidation
@@ -78,16 +78,22 @@ ReadyForQuery
 # Re-bind the same prepared statement. This should fail with
 # "cached plan must not change result type" during Bind (ErrorResponse
 # instead of BindComplete), matching PostgreSQL behavior.
+#
+# The error's Message and Routine fields are asserted because clients
+# (e.g. ActiveRecord and its cockroachdb adapter) key on them to detect a
+# stale prepared statement and recover by re-preparing. Routine must read
+# "RevalidateCachedQuery", the same value PostgreSQL reports, so that
+# detection heuristics written against PostgreSQL work unchanged.
 send
 Bind {"DestinationPortal": "p1", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [{"text":"1"}]}
 Execute {"Portal": "p1"}
 Sync
 ----
 
-until
+until keepErrMessage keepErrRoutine
 ErrorResponse
 ----
-{"Type":"ErrorResponse","Code":"0A000"}
+{"Type":"ErrorResponse","Code":"0A000","Message":"cached plan must not change result type","Routine":"RevalidateCachedQuery"}
 
 until
 ReadyForQuery

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -1146,7 +1146,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	if stmt.ExpectedTypes != nil {
 		cols := result.main.planColumns()
 		if !stmt.ExpectedTypes.TypesEqual(cols) {
-			return pgerror.New(pgcode.FeatureNotSupported, "cached plan must not change result type")
+			return RevalidateCachedQuery()
 		}
 	}
 

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -63,7 +63,10 @@ func WalkWithNewServer(
 // can be used to specify types to ignore. ErrorResponse messages are
 // immediately returned as errors unless they are the expected type, in which
 // case they will marshal to an empty ErrorResponse message since our error
-// detail specifics differ from Postgres.
+// detail specifics differ from Postgres. The keepErrMessage option preserves
+// the error's message fields, and the keepErrRoutine option preserves the
+// error's Routine field (the raising function), for errors where those are
+// part of the wire contract clients depend on.
 //
 // "receive": Like "until", but only output matching messages instead of all
 // messages.
@@ -208,9 +211,12 @@ var issueRE = regexp.MustCompile(`(https://go.crdb.dev/issue-v/\d+/)[^/]+`)
 func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestData) string {
 	ignore := map[string]bool{}
 	errs := map[string]string{}
+	keepErrRoutine := false
 	for _, arg := range args.CmdArgs {
 		switch arg.Key {
 		case "keepErrMessage":
+		case "keepErrRoutine":
+			keepErrRoutine = true
 		case "crdb_only":
 		case "noncrdb_only":
 		case "ignore_table_oids":
@@ -267,6 +273,10 @@ func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestD
 			// Sanitize the error hint to remove the binary version from the
 			// issue link.
 			errHintSanitized := issueRE.ReplaceAllString(errmsg.Hint, "$1...")
+			routine := ""
+			if keepErrRoutine {
+				routine = errmsg.Routine
+			}
 			if err := enc.Encode(struct {
 				Type           string
 				Code           string
@@ -274,6 +284,7 @@ func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestD
 				ConstraintName string `json:",omitempty"`
 				Detail         string `json:",omitempty"`
 				Hint           string `json:",omitempty"`
+				Routine        string `json:",omitempty"`
 			}{
 				Type:           "ErrorResponse",
 				Code:           code,
@@ -281,6 +292,7 @@ func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestD
 				ConstraintName: errmsg.ConstraintName,
 				Detail:         errmsg.Detail,
 				Hint:           errHintSanitized,
+				Routine:        routine,
 			}); err != nil {
 				panic(err)
 			}

--- a/pkg/testutils/pgtest/pgtest.go
+++ b/pkg/testutils/pgtest/pgtest.go
@@ -209,6 +209,7 @@ func (p *PGTest) Until(
 				ConstraintName: errmsg.ConstraintName,
 				Detail:         detail,
 				Hint:           hint,
+				Routine:        errmsg.Routine,
 			})
 			typs = typs[1:]
 			continue


### PR DESCRIPTION
During the Bind phase of the extended pgwire protocol (and Execute for the simple protocol), the "cached plan must not change result type" error is detected by clients via its Routine field (`PG_DIAG_SOURCE_FUNCTION`). PostgreSQL reports `RevalidateCachedQuery`, its plancache.c function. CockroachDB reported whichever internal function constructed the error - `runExecBuilder` until #164406 moved the extended-protocol check to Bind, which changed the value to `execBind` and silently broke clients matching the old name (e.g. activerecord-cockroachdb-adapter's `is_cached_plan_failure?`, which stopped translating the error into ActiveRecord's evict-and-retry recovery; we hit this in production).

This PR constructs the error in a dedicated function named `RevalidateCachedQuery`, so the reported routine is stable across refactors and identical to PostgreSQL's - detection heuristics written against PostgreSQL (ActiveRecord upstream matches exactly this name) work unchanged. The pgtest datadriven test now asserts Code, Message, and Routine (new `keepErrRoutine` option), making the fields clients key on a tested contract rather than an accident of the call stack. The assertion also holds when the suite runs against real PostgreSQL.

Compatibility note: this is itself a wire-behavior change, and it breaks two client classes once. (1) Clients that adapted to 26.2 by matching `execBind` stop matching when the pin ships. (2) Simple-protocol clients (SQL-level PREPARE/EXECUTE, no wire Bind) matching `runExecBuilder` work on every released version and break only here. Every alternative to freezing the accidental value breaks one of these groups eventually; the pin breaks them onto the value PostgreSQL has reported since 8.3, making it the last such break. Flagged in the release note; deferring to you on which release it rides.

Companion adapter fix: cockroachdb/activerecord-cockroachdb-adapter#403 switches detection to the error message, which works on pre- and post-#164406 servers. The two are complementary: the adapter fix covers existing versions, this makes the field reliable going forward.

Resolves the detection half of the issue behind #164406's driver-compat work.
