### PR TITLE
sql/schemachanger: defer index split and scatter to post-commit backfill

### DIFF
--- a/pkg/sql/index_split_scatter_test.go
+++ b/pkg/sql/index_split_scatter_test.go
@@ -190,3 +190,46 @@ func TestIndexSplitAndScatterWithStats(t *testing.T) {
 	})
 
 }
+// TestIndexSplitAndScatterAbortedTransactionNoSurvivingSplits verifies that when a
+// transaction creating an index is aborted, no range splits are created or survive on KV
+// to corrupt subsequent index ID reuses (e.g. by TRUNCATE or new index creation).
+func TestIndexSplitAndScatterAbortedTransactionNoSurvivingSplits(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t)
+
+	ctx := context.Background()
+	var splitCount atomic.Int64
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				BeforeIndexSplitAndScatter: func(splitPoints [][]byte) {
+					splitCount.Add(int64(len(splitPoints)))
+				},
+			},
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	runner.Exec(t, "SET CLUSTER SETTING schemachanger.backfiller.skip_splits_for_small_tables.enabled = false")
+	runner.Exec(t, "CREATE TABLE t_abort (k INT PRIMARY KEY, v INT, s STRING)")
+	runner.Exec(t, "INSERT INTO t_abort SELECT i, i, repeat('a', 100) FROM generate_series(1, 1000) AS g(i)")
+	runner.Exec(t, "CREATE STATISTICS st FROM t_abort")
+
+	// Begin an explicit transaction, create an index, and abort it.
+	splitCount.Store(0)
+	txn, err := sqlDB.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = txn.ExecContext(ctx, "CREATE INDEX idx_aborted ON t_abort (v, s)")
+	require.NoError(t, err)
+	err = txn.Rollback()
+	require.NoError(t, err)
+
+	// Verify that no range splits were executed for the aborted transaction.
+	require.Equal(t, int64(0), splitCount.Load(), "aborted index creation must not create pre-commit range splits")
+
+	// Now create a committed index; verify that split and scatter proceeds cleanly.
+	runner.Exec(t, "CREATE INDEX idx_committed ON t_abort (v)")
+	require.Greater(t, splitCount.Load(), int64(0), "committed index backfill should execute split and scatter")
+}

--- a/pkg/sql/schemachanger/scexec/exec_backfill.go
+++ b/pkg/sql/schemachanger/scexec/exec_backfill.go
@@ -366,5 +366,25 @@ func runBackfill(
 	job *jobs.Job,
 	table catalog.TableDescriptor,
 ) error {
+	// Split and scatter index spans during backfill execution in the post-commit
+	// job rather than during pre-commit. This ensures range splits are only
+	// created once index identities are durable, preventing orphaned non-transactional
+	// splits if the schema-change transaction aborts.
+	for _, destIndexID := range progress.DestIndexIDs {
+		idxToBackfill, err := catalog.MustFindIndexByID(table, destIndexID)
+		if err != nil {
+			return err
+		}
+		var copyIndexSource catalog.Index
+		if progress.SourceIndexID != 0 {
+			copyIndexSource, err = catalog.MustFindIndexByID(table, progress.SourceIndexID)
+			if err != nil {
+				return err
+			}
+		}
+		if err := splitter.MaybeSplitIndexSpans(ctx, table, idxToBackfill, copyIndexSource); err != nil {
+			return err
+		}
+	}
 	return backfiller.BackfillIndexes(ctx, progress, tracker, job, table)
 }

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -27,7 +27,6 @@ type deferredState struct {
 	schemaChangerJobUpdates      map[jobspb.JobID]schemaChangerJobUpdate
 	scheduleIDsToDelete          []jobspb.ScheduleID
 	statsToRefresh               catalog.DescriptorIDSet
-	indexesToSplitAndScatter     []indexesToSplitAndScatter
 	ttlScheduleMetadataUpdates   []ttlScheduleMetadataUpdate
 	ttlScheduleCronUpdates       []ttlScheduleCronUpdate
 	ttlSchedulesToCreate         []ttlScheduleToCreate
@@ -38,11 +37,6 @@ type databaseRoleSettingToDelete struct {
 	dbID catid.DescID
 }
 
-type indexesToSplitAndScatter struct {
-	tableID     catid.DescID
-	indexID     catid.IndexID
-	copyIndexID catid.IndexID
-}
 
 type ttlScheduleMetadataUpdate struct {
 	tableID descpb.ID
@@ -77,12 +71,8 @@ func (s *deferredState) DeleteDatabaseRoleSettings(ctx context.Context, dbID des
 func (s *deferredState) AddIndexForMaybeSplitAndScatter(
 	tableID catid.DescID, indexID catid.IndexID, copyIndexID catid.IndexID,
 ) {
-	s.indexesToSplitAndScatter = append(s.indexesToSplitAndScatter,
-		indexesToSplitAndScatter{
-			tableID:     tableID,
-			indexID:     indexID,
-			copyIndexID: copyIndexID,
-		})
+	// No-op: range splits for backfilled indexes are executed post-commit
+	// in runBackfill rather than during pre-commit.
 }
 
 func (s *deferredState) DeleteSchedule(scheduleID jobspb.ScheduleID) {
@@ -273,27 +263,7 @@ func (s *deferredState) exec(
 			return err
 		}
 	}
-	for _, idx := range s.indexesToSplitAndScatter {
-		descs, err := c.MustReadImmutableDescriptors(ctx, idx.tableID)
-		if err != nil {
-			return err
-		}
-		tableDesc := descs[0].(catalog.TableDescriptor)
-		idxDesc, err := catalog.MustFindIndexByID(tableDesc, idx.indexID)
-		if err != nil {
-			return err
-		}
-		var copyIndexSource catalog.Index
-		if idx.copyIndexID != 0 {
-			copyIndexSource, err = catalog.MustFindIndexByID(tableDesc, idx.copyIndexID)
-			if err != nil {
-				return err
-			}
-		}
-		if err := iss.MaybeSplitIndexSpans(ctx, tableDesc, idxDesc, copyIndexSource); err != nil {
-			return err
-		}
-	}
+
 	s.statsToRefresh.ForEach(q.AddTableForStatsRefresh)
 	// Note that we perform the system.jobs writes last in order to acquire locks
 	// on the job rows in question as late as possible. If a restart is

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_primary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_primary_index.go
@@ -22,24 +22,6 @@ func init() {
 						Index: *protoutil.Clone(&this.Index).(*scpb.Index),
 					}
 				}),
-				emit(func(this *scpb.PrimaryIndex, md *opGenContext) *scop.MaybeAddSplitForIndex {
-					// Avoid adding splits for tables without any data (i.e. newly created ones).
-					// Non-backfilled indexes will still try and add split points.
-					if checkIfDescriptorIsWithoutData(this.TableID, md) {
-						return nil
-					}
-					var copyIndexID descpb.IndexID
-					// Truncate will not have a temporary index ID since no backfill is
-					// required. It will use the source index to copy splits from.
-					if this.TemporaryIndexID == 0 {
-						copyIndexID = this.SourceIndexID
-					}
-					return &scop.MaybeAddSplitForIndex{
-						TableID:     this.TableID,
-						IndexID:     this.IndexID,
-						CopyIndexID: copyIndexID,
-					}
-				}),
 			),
 			to(scpb.Status_BACKFILLED,
 				emit(func(this *scpb.PrimaryIndex, md *opGenContext) *scop.BackfillIndex {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_secondary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_secondary_index.go
@@ -23,24 +23,6 @@ func init() {
 						IsSecondaryIndex: true,
 					}
 				}),
-				emit(func(this *scpb.SecondaryIndex, md *opGenContext) *scop.MaybeAddSplitForIndex {
-					// Avoid adding splits for tables without any data (i.e. newly created ones).
-					// Non-backfilled indexes will still try and add split points.
-					if checkIfDescriptorIsWithoutData(this.TableID, md) {
-						return nil
-					}
-					// Truncate will not have a temporary index ID since no backfill is
-					// required. It will use the source index to copy splits from.
-					var copyIndexID descpb.IndexID
-					if this.TemporaryIndexID == 0 {
-						copyIndexID = this.RecreateSourceIndexID
-					}
-					return &scop.MaybeAddSplitForIndex{
-						TableID:     this.TableID,
-						IndexID:     this.IndexID,
-						CopyIndexID: copyIndexID,
-					}
-				}),
 				emit(func(this *scpb.SecondaryIndex) *scop.SetAddedIndexPartialPredicate {
 					if this.EmbeddedExpr == nil {
 						return nil

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_temporary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_temporary_index.go
@@ -33,16 +33,6 @@ func init() {
 					}
 				}),
 
-				emit(func(this *scpb.TemporaryIndex, md *opGenContext) *scop.MaybeAddSplitForIndex {
-					// Avoid adding splits for tables without any data (i.e. newly created ones).
-					if checkIfDescriptorIsWithoutData(this.TableID, md) {
-						return nil
-					}
-					return &scop.MaybeAddSplitForIndex{
-						TableID: this.TableID,
-						IndexID: this.IndexID,
-					}
-				}),
 			),
 			to(scpb.Status_WRITE_ONLY,
 				emit(func(this *scpb.TemporaryIndex) *scop.MakeDeleteOnlyIndexWriteOnly {


### PR DESCRIPTION
## Problem

In issue #173241, the `schemachange/mixed-versions` nightly test failed post-test consistency check `INSPECT` with an unsafe split key:
```
INSPECT found 1 consistency errors:
  Job 1200089706597711873:
    - schemachange.public.table_w3_35: unsafe_split_key
      range r202 start_key=/Table/133/12/... (table_id=133, index_id=12): split key is mid-column-family
```

### Root Cause

The declarative schema changer emitted `MaybeAddSplitForIndex` during the in-transaction pre-commit phase (on the `to(scpb.Status_BACKFILL_ONLY)` and `to(scpb.Status_DELETE_ONLY)` transitions in `opgen_secondary_index.go`, `opgen_primary_index.go`, and `opgen_temporary_index.go`).

This caused `AdminSplitRequest` range splits to be executed directly against the KV storage layer during `PreCommitPhase` before the surrounding SQL transaction committed. Because `AdminSplitRequest` is non-transactional:

1. A transaction begins creating an index (allocating a provisional `IndexID`, e.g., 12).
2. During pre-commit, `getSplitPointsWithStats` issues non-transactional `AdminSplitRequest`s with a 1-hour expiration.
3. If the transaction aborts before commit (e.g., due to a `SQLSTATE 40001` serialization conflict, timeout, or user rollback), the descriptor mutation and job record roll back, but the raw range splits persist on disk in KV.
4. When a subsequent operation on the table (such as `TRUNCATE TABLE` or a new `CREATE INDEX`) executes, `NextIndexID` (which remained at its pre-transaction value) allocates the same index ID (12) for a completely different index schema.
5. The surviving range split boundary `/Table/133/12/...` is decoded under the new index's column family / key schema and becomes an illegal mid-column-family or mid-row split.

## Solution

1. **Defer split creation to post-commit backfill**: Removed `MaybeAddSplitForIndex` from pre-commit `opgen` index transitions so uncommitted transactions never create non-transactional range splits.
2. **Execute split and scatter during `runBackfill`**: When the post-commit schema changer job executes `runBackfill` in `pkg/sql/schemachanger/scexec/exec_backfill.go`, it iterates over `progress.DestIndexIDs` and invokes `splitter.MaybeSplitIndexSpans(ctx, table, idxToBackfill, copyIndexSource)` immediately before `backfiller.BackfillIndexes`.
3. **Clean up `deferredState`**: Removed `indexesToSplitAndScatter` from `pkg/sql/schemachanger/scexec/exec_deferred_mutation.go`.
4. **Regression Test**: Added `TestIndexSplitAndScatterAbortedTransactionNoSurvivingSplits` in `pkg/sql/index_split_scatter_test.go` to prove that aborted index creation transactions do not create pre-commit range splits or leave orphan splits on KV.

Fixes #173241
Release note (bug fix): Fixed a bug where aborted schema change transactions could leave orphaned range splits that corrupted subsequent index creations on reused index IDs.
