### PR TITLE
jsonpath: report trailing junk for keys that start with a digit

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/jsonpath.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/jsonpath.diffs
@@ -679,7 +679,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 -ERROR:  trailing junk after numeric literal at or near "1e" of jsonpath input
 -LINE 1: select '1e'::jsonpath;
 -               ^
-+ERROR:  could not parse "1e" as type jsonpath: lexical error: invalid floating point literal
++ERROR:  could not parse "1e" as type jsonpath: lexical error: trailing junk after numeric literal at or near "1e"
 +DETAIL:  source SQL:
 +1e
 +^
@@ -687,7 +687,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 -ERROR:  trailing junk after numeric literal at or near "1.e" of jsonpath input
 -LINE 1: select '1.e'::jsonpath;
 -               ^
-+ERROR:  could not parse "1.e" as type jsonpath: lexical error: invalid floating point literal
++ERROR:  could not parse "1.e" as type jsonpath: lexical error: trailing junk after numeric literal at or near "1.e"
 +DETAIL:  source SQL:
 +1.e
 +^
@@ -703,7 +703,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 -ERROR:  trailing junk after numeric literal at or near "1.2e" of jsonpath input
 -LINE 1: select '1.2e'::jsonpath;
 -               ^
-+ERROR:  could not parse "1.2e" as type jsonpath: lexical error: invalid floating point literal
++ERROR:  could not parse "1.2e" as type jsonpath: lexical error: trailing junk after numeric literal at or near "1.2e"
 +DETAIL:  source SQL:
 +1.2e
 +^

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -6,6 +6,7 @@
 package scanner
 
 import (
+	"fmt"
 	"strings"
 
 	sqllexbase "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
@@ -25,7 +26,6 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 		return
 	}
 
-	// TODO(#144258): We still need to handle $.Xc where X is any digit and c is any character.
 	switch ch {
 	case '$':
 		// Root path ($)
@@ -146,5 +146,33 @@ func (s *JSONPathScanner) scanIdent(lval ScanSymType) {
 
 // scanNumber is similar to Scanner.scanNumber, but uses Jsonpath tokens.
 func (s *JSONPathScanner) scanNumber(lval ScanSymType, ch int) {
+	start := s.pos - 1
 	s.scanNumberImpl(lval, ch, lexbase.ERROR, lexbase.FCONST, lexbase.ICONST)
+	if lval.ID() != lexbase.ERROR {
+		return
+	}
+
+	// scanNumberImpl explains a malformed literal in terms of the numeric
+	// syntax it was trying to read, so `2x` is reported as a bad hexadecimal
+	// literal and `2e` as a bad floating point literal. Neither reads well for
+	// a jsonpath, where such a token is an accessor key that was written
+	// without quotes. Postgres reports the numeric prefix together with the
+	// first identifier character that follows it as trailing junk, which is
+	// already how scanNumberImpl describes `2a`. Describe the remaining
+	// digit-then-identifier cases the same way.
+	junk := s.pos
+	switch lval.Str() {
+	case errInvalidHexNumeric:
+		// s.pos is on the character that could not continue the literal.
+	case errInvalidFloatLiteral:
+		// s.pos is past the exponent marker, which is itself the junk unless a
+		// sign follows it. A sign cannot appear in an identifier, so leaving
+		// junk pointing at it keeps the more specific diagnostic below.
+		junk--
+	default:
+		return
+	}
+	if junk < len(s.in) && isIdentMiddle(int(s.in[junk])) {
+		lval.SetStr(fmt.Sprintf("trailing junk after numeric literal at or near %q", s.in[start:junk+1]))
+	}
 }

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -21,6 +21,7 @@ const eof = -1
 const errUnterminated = "unterminated string"
 const errInvalidUTF8 = "invalid UTF-8 byte sequence"
 const errInvalidHexNumeric = "invalid hexadecimal numeric literal"
+const errInvalidFloatLiteral = "invalid floating point literal"
 const singleQuote = '\''
 const identQuote = '"'
 
@@ -789,7 +790,7 @@ func (s *Scanner) scanNumberImpl(lval ScanSymType, ch int, errorID, fconstID, ic
 			}
 			if !lexbase.IsDigit(ch) {
 				lval.SetID(errorID)
-				lval.SetStr("invalid floating point literal")
+				lval.SetStr(errInvalidFloatLiteral)
 				return
 			}
 			continue

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -134,7 +134,7 @@ word $
 error
 $.1e
 ----
-lexical error: invalid floating point literal
+lexical error: trailing junk after numeric literal at or near "1e"
 DETAIL: source SQL:
 $.1e
   ^
@@ -162,10 +162,68 @@ $."2e"
 error
 $.2e
 ----
-lexical error: invalid floating point literal
+lexical error: trailing junk after numeric literal at or near "2e"
 DETAIL: source SQL:
 $.2e
   ^
+
+# An unquoted key that starts with a digit is read as a number, so the rest of
+# the key is trailing junk. Postgres reports these the same way, naming the
+# numeric prefix and the first character that follows it.
+error
+$.2ee
+----
+lexical error: trailing junk after numeric literal at or near "2e"
+DETAIL: source SQL:
+$.2ee
+  ^
+
+error
+$.2f
+----
+lexical error: trailing junk after numeric literal at or near "2f"
+DETAIL: source SQL:
+$.2f
+  ^
+
+error
+$.2x
+----
+lexical error: trailing junk after numeric literal at or near "2x"
+DETAIL: source SQL:
+$.2x
+  ^
+
+error
+$.2e5x
+----
+lexical error: trailing junk after numeric literal at or near "2e5x"
+DETAIL: source SQL:
+$.2e5x
+  ^
+
+error
+$.12abc
+----
+lexical error: trailing junk after numeric literal at or near "12a"
+DETAIL: source SQL:
+$.12abc
+  ^
+
+# A bare 0x is a malformed hexadecimal literal rather than a key, and keeps the
+# diagnostic that says so. Postgres also accepts 0x2 as a number here.
+error
+$[0x]
+----
+at or near "invalid hexadecimal numeric literal": syntax error
+DETAIL: source SQL:
+$[0x]
+  ^
+
+parse
+$.abc[0x2]
+----
+$."abc"[2] -- normalized!
 
 parse
 $var


### PR DESCRIPTION
An unquoted jsonpath key that starts with a digit gets scanned as a number, so the rest of the key is trailing junk. We were reporting that in terms of whatever literal the scanner thought it was reading, so `$.2x` came back as an invalid hexadecimal literal and `$.2e` as an invalid floating point literal, while `$.2a` already said trailing junk. Same mistake, three different explanations depending on which character followed the digit.

This reports them all the same way, naming the numeric prefix plus the first identifier character after it, which is what Postgres does. jsonpath.diffs already recorded Postgres returning `trailing junk after numeric literal at or near "1e"` where we returned the floating point message, so those three entries are updated as well.

`$[0x]` keeps the hexadecimal message, since jsonpath does accept hex (`$[0x2]` is `$[2]`) and it's accurate there. Valid literals are unchanged, and SQL scanning is untouched - the only edit outside the jsonpath scanner is lifting an existing error string into a constant.

I've left #144258 open rather than closing it. It asks for `$.2ee` and `$.2f` to parse as string keys and shows Postgres doing that, but that was Postgres 14 - 15 and later reject them as trailing junk. Accepting them now would move us away from current Postgres, so I've only fixed the diagnostics. Happy to take it the other way if you'd rather match 14.

Tested with `go test ./pkg/util/jsonpath/... ./pkg/sql/scanner/... ./pkg/sql/parser/`.
