### PR TITLE
fix: DJSON.IsMin() should check for empty array, not JSON null [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3956,7 +3956,7 @@ func (d *DJSON) IsMax(ctx context.Context, cmpCtx CompareContext) bool {
 
 // IsMin implements the Datum interface.
 func (d *DJSON) IsMin(ctx context.Context, cmpCtx CompareContext) bool {
-	return d.JSON == json.NullJSONValue
+	return d.JSON.Type() == json.ArrayJSONType && d.JSON.Len() == 0
 }
 
 // Max implements the Datum interface.
@@ -3966,7 +3966,7 @@ func (d *DJSON) Max(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
 
 // Min implements the Datum interface.
 func (d *DJSON) Min(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
-	return &DJSON{json.NullJSONValue}, true
+	return &DJSON{json.NewArrayBuilder(0).Build()}, true
 }
 
 // AmbiguousFormat implements the Datum interface.


### PR DESCRIPTION
In CockroachDB's JSONB ordering, the empty array `[]` sorts below JSON
`null` — `jsonNull.Compare` returns `1` (meaning `null > []`) when the
other value is an empty array.

`DJSON.IsMin()` was checking for `json.NullJSONValue`, which made the
index constraint builder believe that `'null'` is the minimum JSONB value.
When a predicate like `c != 'null'::JSONB` hits a JSONB primary key, the
optimizer generates a single-sided span `(/'null' - ]`, omitting the lower
span `[-inf, /'null')` because `IsMin('null')` returns `true`. Rows whose
JSONB value is the empty array `[]` (which sorts below `null` in the key
encoding) are silently dropped.

**Fix**: Change `DJSON.IsMin()` to check for an empty array instead of
JSON null. Also update `DJSON.Min()` to return the empty array for
consistency.

Fixes #173582
