### PR TITLE
sql: fix float exp/degrees overflow to return PG error instead of Inf/0

### DIFF
--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -214,7 +214,7 @@ var mathBuiltins = map[string]builtinDefinition{
 
 	"degrees": makeBuiltin(defProps(),
 		floatOverload1(func(x float64) (tree.Datum, error) {
-			return tree.NewDFloat(tree.DFloat(radToDeg * x)), nil
+			return eval.FloatDegrees(x)
 		}, "Converts `val` as a radian value to a degree value.", volatility.Immutable),
 	),
 
@@ -260,7 +260,7 @@ var mathBuiltins = map[string]builtinDefinition{
 
 	"exp": makeBuiltin(defProps(),
 		floatOverload1(func(x float64) (tree.Datum, error) {
-			return tree.NewDFloat(tree.DFloat(math.Exp(x))), nil
+			return eval.FloatExp(x)
 		}, "Calculates *e* ^ `val`.", volatility.Immutable),
 		decimalOverload1(func(x *apd.Decimal) (tree.Datum, error) {
 			dd := &tree.DDecimal{}

--- a/pkg/sql/sem/eval/math.go
+++ b/pkg/sql/sem/eval/math.go
@@ -118,6 +118,37 @@ func DecimalCbrt(x *apd.Decimal) (*tree.DDecimal, error) {
 	return dd, err
 }
 
+// FloatExp computes e^x for float64 arguments, returning errors for cases
+// that PostgreSQL rejects rather than returning Inf or 0.
+func FloatExp(x float64) (*tree.DFloat, error) {
+	result := math.Exp(x)
+	// Check for overflow and underflow, matching PostgreSQL behavior. If
+	// the input is not Inf or NaN, an Inf result means overflow and a zero
+	// result means underflow.
+	if !math.IsInf(x, 0) && !math.IsNaN(x) {
+		if math.IsInf(result, 0) {
+			return nil, errFloatOverflow
+		}
+		if result == 0 {
+			return nil, errFloatUnderflow
+		}
+	}
+	return tree.NewDFloat(tree.DFloat(result)), nil
+}
+
+// FloatDegrees converts x from radians to degrees, returning an error when
+// the conversion overflows rather than returning Inf, matching PostgreSQL
+// behavior.
+func FloatDegrees(x float64) (*tree.DFloat, error) {
+	result := (180.0 / math.Pi) * x
+	// Check for overflow, matching PostgreSQL behavior. If the input is not
+	// Inf or NaN, an Inf result means overflow.
+	if !math.IsInf(x, 0) && !math.IsNaN(x) && math.IsInf(result, 0) {
+		return nil, errFloatOverflow
+	}
+	return tree.NewDFloat(tree.DFloat(result)), nil
+}
+
 func isOne(d *apd.Decimal) bool {
 	return d.Cmp(one) == 0
 }

--- a/pkg/sql/sem/eval/testdata/eval/exp
+++ b/pkg/sql/sem/eval/testdata/eval/exp
@@ -1,0 +1,71 @@
+# Float exp/degrees overflow/underflow tests (regression for #173609).
+
+# exp overflow
+eval
+exp(710::FLOAT8)
+----
+value out of range: overflow
+
+# exp underflow
+eval
+exp(-746::FLOAT8)
+----
+value out of range: underflow
+
+# exp normal values
+eval
+exp(0::FLOAT8)
+----
+1.0
+
+eval
+exp(1::FLOAT8)
+----
+2.718281828459045
+
+# exp with +Inf input (should be accepted)
+eval
+exp('Infinity'::FLOAT8)
+----
++Inf
+
+# exp with -Inf input (should be accepted)
+eval
+exp('-Infinity'::FLOAT8)
+----
+0.0
+
+# exp with NaN input
+eval
+exp('NaN'::FLOAT8)
+----
+NaN
+
+# degrees overflow
+eval
+degrees(1e308::FLOAT8)
+----
+value out of range: overflow
+
+# degrees normal values
+eval
+degrees(0::FLOAT8)
+----
+0.0
+
+eval
+degrees(3.141592653589793::FLOAT8)
+----
+180.0
+
+# degrees with +Inf input (should be accepted)
+eval
+degrees('Infinity'::FLOAT8)
+----
++Inf
+
+# degrees with NaN input
+eval
+degrees('NaN'::FLOAT8)
+----
+NaN


### PR DESCRIPTION
Fixes: #173609

## Problem

`exp(710::FLOAT8)` returns `+Inf`, `exp(-746::FLOAT8)` returns `0`, and `degrees(1e308::FLOAT8)` returns `+Inf`. PostgreSQL returns `value out of range: overflow/underflow` errors for these cases.

## Root cause

`exp()` and `degrees()` use bare `math.Exp()` / `radToDeg * x` with no overflow/underflow check, unlike `FloatPow()` which was fixed in PR #169869.

## Fix

- Added `FloatExp` and `FloatDegrees` in `pkg/sql/sem/eval/math.go` following the same pattern as `FloatPow`
- Updated `exp()` and `degrees()` builtins to use the new helpers
- Added regression tests for overflow, underflow, Inf, and NaN cases