### PR TITLE
sql: reject NULL thresholds in width_bucket(s, thresholds[]) (#173598)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2558,5 +2558,20 @@ SELECT width_bucket(true, '{}'::BOOL[]);
 query error pgcode 42804 could not determine polymorphic type because input has type unknown
 SELECT width_bucket(true, '{}');
 
+query error thresholds array must not contain NULLs
+SELECT width_bucket(5, ARRAY[1, NULL::int, 7])
+
+query error thresholds array must not contain NULLs
+SELECT width_bucket(5, ARRAY[NULL::int])
+
+query error thresholds array must not contain NULLs
+SELECT width_bucket(5.5, ARRAY[1.5, NULL::float8, 7.5]::float8[])
+
+query I
+SELECT width_bucket(5, ARRAY[1, 3, 7]);
+----
+2
+
 query error pgcode 42804 could not determine polymorphic type because input has type unknown
 SELECT array_to_string('{}', 'foo');
+

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -803,6 +803,12 @@ var mathBuiltins = map[string]builtinDefinition{
 				}
 
 				for i, v := range thresholds.Array {
+					if v == tree.DNull {
+						return nil, pgerror.New(
+							pgcode.InvalidArgumentForWidthBucketFunction,
+							"thresholds array must not contain NULLs",
+						)
+					}
 					if cmp, err := operand.Compare(ctx, evalCtx, v); err != nil {
 						return tree.NewDInt(0), err
 					} else if cmp < 0 {


### PR DESCRIPTION
The array overload of `width_bucket` was silently accepting NULL elements in the thresholds array and returning a bucket index. PostgreSQL rejects this with:

```
ERROR: thresholds array must not contain NULLs
```

This aligns the CockroachDB behavior with PostgreSQL: `width_bucket(5, ARRAY[1, NULL::int, 7])` now returns `thresholds array must not contain NULLs` instead of silently returning an incorrect bucket index.

The `O-community` issue #171234/#171263 already hardened the 4-argument overloads; this applies the same style of validation to the array overload.

Fixes #173598
