### PR TITLE
sql: validate month/day/time ranges in make_date/make_timestamp/make_timestamptz (#173599)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -2064,6 +2064,14 @@ make_date
 statement error pgcode 22008 pq: year value of 0 is not valid
 SELECT make_date(0, 11, 11)
 
+# Out-of-range month/day components must be rejected, matching PostgreSQL
+# (Go's time.Date silently normalizes them).
+statement error pgcode 22008 pq: date field value out of range
+SELECT make_date(2020, 13, 1)
+
+statement error pgcode 22008 pq: date field value out of range
+SELECT make_date(2020, 1, 32)
+
 subtest end
 
 subtest make_timestamp
@@ -2107,6 +2115,14 @@ select make_timestamp(1, 1, 1, 0, 0, 0.1234);
 
 statement error pgcode 22008 pq: year value of 0 is not valid
 SELECT make_timestamp(0, 7, 15, 8, 15, 23.5);
+
+# Out-of-range month/day/time components must be rejected, matching
+# PostgreSQL (Go's time.Date silently normalizes them).
+statement error pgcode 22008 pq: date field value out of range
+SELECT make_timestamp(2020, 13, 1, 0, 0, 0)
+
+statement error pgcode 22008 pq: time field value out of range
+SELECT make_timestamp(2020, 1, 1, 0, 60, 0)
 
 subtest end
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2727,6 +2727,14 @@ var regularBuiltins = map[string]builtinDefinition{
 				if year == 0 {
 					return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "year value of 0 is not valid")
 				}
+				// Validate month/day ranges, matching PostgreSQL. Go's
+				// time.Date silently normalizes out-of-range values (e.g.
+				// month 13 rolls over to the next year); PostgreSQL rejects
+				// them with an error.
+				if month < 1 || month > 12 || day < 1 || day > 31 {
+					return nil, pgerror.Newf(pgcode.DatetimeFieldOverflow,
+						"date field value out of range: %04d-%02d-%02d", year, month, day)
+				}
 				// PostgreSQL's make_date treats a negative year argument as
 				// "N BC" (no year zero in SQL semantics), but Go's time.Date
 				// uses astronomical numbering (year 0 = 1 BC). Shift negative
@@ -13138,6 +13146,14 @@ func makeTimestampStatementBuiltinOverload(withOutputTZ bool, withInputTZ bool) 
 			if year == 0 {
 				return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "year value of 0 is not valid")
 			}
+			// Validate month/day/hour/minute/second ranges, matching
+			// PostgreSQL. Go's time.Date silently normalizes out-of-range
+			// values (e.g. month 13 rolls over to the next year); PostgreSQL
+			// rejects them with an error.
+			if month < 1 || month > 12 || day < 1 || day > 31 {
+				return nil, pgerror.Newf(pgcode.DatetimeFieldOverflow,
+					"date field value out of range: %04d-%02d-%02d", year, month, day)
+			}
 			// PostgreSQL's make_timestamp(tz) treats a negative year argument
 			// as "N BC" (no year zero in SQL semantics), but Go's time.Date
 			// uses astronomical numbering (year 0 = 1 BC). Shift negative
@@ -13149,6 +13165,12 @@ func makeTimestampStatementBuiltinOverload(withOutputTZ bool, withInputTZ bool) 
 			hour := int(tree.MustBeDInt(args[3]))
 			min := int(tree.MustBeDInt(args[4]))
 			sec := float64(tree.MustBeDFloat(args[5]))
+			// PG accepts hour == 24 (it normalizes to the next day), but
+			// rejects minute/second values outside [0, 60). See #173599.
+			if hour < 0 || hour > 24 || min < 0 || min > 59 || sec < 0 || sec >= 60 {
+				return nil, pgerror.Newf(pgcode.DatetimeFieldOverflow,
+					"time field value out of range: %02d:%02d:%02d", hour, min, int(sec))
+			}
 			truncatedSec, remainderSec := math.Modf(sec)
 			nsec := remainderSec * float64(time.Second)
 			t := time.Date(year, month, day, hour, min, int(truncatedSec), int(nsec), location)


### PR DESCRIPTION
Fixes #173599

**Problem**: `make_date`, `make_timestamp`, and `make_timestamptz` silently accept out-of-range month/day/minute/second values and return a different date/time than requested. For example:
- `make_date(2020, 13, 1)` returns `2021-01-01` instead of erroring
- `make_date(2020, 1, 32)` returns `2020-02-01` instead of erroring
- `make_timestamp(2020, 1, 1, 0, 60, 0)` returns `2020-01-01 01:00:00` instead of erroring

PostgreSQL rejects all of these with `date/time field value out of range`.

**Root cause**: Go's `time.Date` silently normalizes out-of-range values (e.g. month 13 rolls over to the next year). The existing code only guarded against `year == 0`.

**Fix**: Added validation in both `make_date` and `makeTimestampStatementBuiltinOverload` (shared by `make_timestamp` and `make_timestamptz`) before calling `time.Date`:
- Month: 1-12, Day: 1-31 → `pgcode.DatetimeFieldOverflow`
- Hour: 0-24 (PG accepts 24, which normalizes to next day), Minute: 0-59, Second: 0 ≤ sec < 60 → same error

**Tests**: Added 4 logic test cases covering:
- `make_date(2020, 13, 1)` → date field value out of range
- `make_date(2020, 1, 32)` → date field value out of range
- `make_timestamp(2020, 13, 1, 0, 0, 0)` → date field value out of range
- `make_timestamp(2020, 1, 1, 0, 60, 0)` → time field value out of range

Release note (bug fix): `make_date`, `make_timestamp`, and `make_timestamptz` now reject out-of-range month/day/minute/second values with a clear error message, matching PostgreSQL behavior.
