### PR TITLE
sql: render partition range bounds in interval notation

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5544,25 +5544,24 @@ func addPartitioningRows(
 		return err
 	}
 
-	// This produces the range_value column.
+	// This produces the range_value column. The bounds are rendered in
+	// interval notation ("[from, to)") to make it unambiguous that the
+	// lower bound is inclusive and the upper bound is exclusive, matching
+	// the actual range-partition semantics.
 	err = partitioning.ForEachRange(func(name string, from, to []byte) error {
-		var buf bytes.Buffer
 		fromTuple, _, err := rowenc.DecodePartitionTuple(
 			&datumAlloc, p.ExecCfg().Codec, table, index, partitioning, from, fakePrefixDatums,
 		)
 		if err != nil {
 			return err
 		}
-		buf.WriteString(fromTuple.String())
-		buf.WriteString(" TO ")
 		toTuple, _, err := rowenc.DecodePartitionTuple(
 			&datumAlloc, p.ExecCfg().Codec, table, index, partitioning, to, fakePrefixDatums,
 		)
 		if err != nil {
 			return err
 		}
-		buf.WriteString(toTuple.String())
-		partitionRange := tree.NewDString(buf.String())
+		partitionRange := tree.NewDString(fmt.Sprintf("[%s, %s)", fromTuple, toTuple))
 
 		// Figure out which zone and subzone this partition should correspond to.
 		zoneID, zone, subzone, err := zoneconfig.GetInTxn(

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_ccl
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_ccl
@@ -43,9 +43,9 @@ SELECT * FROM crdb_internal.partitions ORDER BY table_id, index_id, name
 106  1  p12    p12p3    1  b     (3)        NULL               0  0
 106  1  p12p3  p12p3p8  1  c     (8)        NULL               0  0
 106  1  NULL   p6       1  a     (6)        NULL               0  0
-106  1  p6     p6p7     1  b     NULL       (MINVALUE) TO (7)  0  0
-106  1  p6     p6p8     1  b     NULL       (7) TO (8)         0  0
-106  1  p6     p6px     1  b     NULL       (8) TO (MAXVALUE)  0  0
+106  1  p6     p6p7     1  b     NULL       [(MINVALUE), (7))  0  0
+106  1  p6     p6p8     1  b     NULL       [(7), (8))         0  0
+106  1  p6     p6px     1  b     NULL       [(8), (MAXVALUE))  0  0
 106  1  p12    pd       1  b     (DEFAULT)  NULL               0  0
 106  2  NULL   p00      2  a, b  (0, 0)     NULL               0  0
 107  1  NULL   pfoo     1  a     ('foo')    NULL               0  0
@@ -208,5 +208,30 @@ SELECT * FROM crdb_internal.node_tenant_capabilities_cache WHERE capability_name
 tenant_id  capability_name  capability_value
 1          can_view_node_info  true
 5          can_view_node_info  true
+
+subtest end
+
+# range_value_string_bounds covers a RANGE-partitioned STRING column, which
+# none of the tables above do: string-typed bounds are quoted, unlike the
+# bare integers t1 uses above, so this exercises the interval-notation
+# brackets combined with quoted tuple contents. Filtered by parent_name
+# instead of table_id/index_id, which are allocation-order-dependent on
+# everything else in this file.
+subtest range_value_string_bounds
+
+user root
+
+statement ok
+CREATE TABLE t_range_str (a STRING PRIMARY KEY) PARTITION BY RANGE (a) (
+  PARTITION plo VALUES FROM (MINVALUE) TO ('m'),
+  PARTITION phi VALUES FROM ('m') TO (MAXVALUE)
+)
+
+query TT
+SELECT name, range_value FROM crdb_internal.partitions
+WHERE parent_name IS NULL AND name IN ('plo', 'phi') ORDER BY name
+----
+phi  [('m'), (MAXVALUE))
+plo  [(MINVALUE), ('m'))
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/distsql_partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_partitioning
@@ -141,13 +141,13 @@ test  t1  p3  NULL  x  t1@t1_pkey  (3)         constraints = '[+dc=dc3]'  range_
                                                                           num_replicas = 3,
                                                                           constraints = '[+dc=dc3]',
                                                                           lease_preferences = '[]'
-test  t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+test  t2  p1  NULL  x  t2@t2_pkey  [(1), (2))  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
                                                                           range_max_bytes = 536870912,
                                                                           gc.ttlseconds = 14400,
                                                                           num_replicas = 3,
                                                                           constraints = '[+dc=dc1]',
                                                                           lease_preferences = '[]'
-test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+test  t2  p2  NULL  x  t2@t2_pkey  [(2), (3))  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
                                                                           range_max_bytes = 536870912,
                                                                           gc.ttlseconds = 14400,
                                                                           num_replicas = 3,
@@ -157,13 +157,13 @@ test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_
 query TTTTTTTTT
 SELECT * FROM [SHOW PARTITIONS FROM TABLE t2] ORDER BY partition_name
 ----
-test  t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+test  t2  p1  NULL  x  t2@t2_pkey  [(1), (2))  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
                                                                           range_max_bytes = 536870912,
                                                                           gc.ttlseconds = 14400,
                                                                           num_replicas = 3,
                                                                           constraints = '[+dc=dc1]',
                                                                           lease_preferences = '[]'
-test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+test  t2  p2  NULL  x  t2@t2_pkey  [(2), (3))  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
                                                                           range_max_bytes = 536870912,
                                                                           gc.ttlseconds = 14400,
                                                                           num_replicas = 3,
@@ -173,13 +173,13 @@ test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_
 query TTTTTTTTT
 SELECT * FROM [SHOW PARTITIONS FROM INDEX t2@t2_pkey] ORDER BY partition_name
 ----
-test  t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+test  t2  p1  NULL  x  t2@t2_pkey  [(1), (2))  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
                                                                           range_max_bytes = 536870912,
                                                                           gc.ttlseconds = 14400,
                                                                           num_replicas = 3,
                                                                           constraints = '[+dc=dc1]',
                                                                           lease_preferences = '[]'
-test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+test  t2  p2  NULL  x  t2@t2_pkey  [(2), (3))  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
                                                                           range_max_bytes = 536870912,
                                                                           gc.ttlseconds = 14400,
                                                                           num_replicas = 3,

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -1279,7 +1279,7 @@ ALTER TABLE t_inherit_range PARTITION BY RANGE (x) ( PARTITION p1 VALUES FROM (1
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit_range
 ----
-test  t_inherit_range  p1  NULL  x  t_inherit_range@t_inherit_range_pkey  (1) TO (2)  NULL  range_min_bytes = 134217728,
+test  t_inherit_range  p1  NULL  x  t_inherit_range@t_inherit_range_pkey  [(1), (2))  NULL  range_min_bytes = 134217728,
                                                                                             range_max_bytes = 536870912,
                                                                                             gc.ttlseconds = 14400,
                                                                                             num_replicas = 3,
@@ -1292,7 +1292,7 @@ ALTER PARTITION p1 of TABLE t_inherit_range CONFIGURE ZONE USING num_replicas=5
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit_range
 ----
-test  t_inherit_range  p1  NULL  x  t_inherit_range@t_inherit_range_pkey  (1) TO (2)  num_replicas = 5  range_min_bytes = 134217728,
+test  t_inherit_range  p1  NULL  x  t_inherit_range@t_inherit_range_pkey  [(1), (2))  num_replicas = 5  range_min_bytes = 134217728,
                                                                                                         range_max_bytes = 536870912,
                                                                                                         gc.ttlseconds = 14400,
                                                                                                         num_replicas = 5,


### PR DESCRIPTION
Fixes #173103

`crdb_internal.partitions.range_value` (and therefore `SHOW PARTITIONS`,
which reads it through the `coalesce` in `delegate/show_partitions.go`)
displayed range partition bounds as `(from) TO (to)`. This format doesn't
say whether either bound is inclusive or exclusive, which is ambiguous
since range partitions are actually half-open: the lower bound is
inclusive and the upper bound is exclusive.

This PR renders the same bounds in interval notation instead:
`[from, to)`. For example:

```
-  (0) TO (86)
+  [(0), (86))
```

This only touches the `crdb_internal`/`SHOW PARTITIONS` display path
(`addPartitioningRows` in `crdb_internal.go`). `SHOW CREATE TABLE`'s
`PARTITION ... VALUES FROM (...) TO (...)` clause is produced by a
separate code path (`ShowCreatePartitioning` in
`show_create_clauses.go`) and is unaffected, since that output must
stay valid, parseable DDL syntax.

Updated the three logic test files that assert on
`crdb_internal.partitions.range_value` / `SHOW PARTITIONS` output:
`partitioning`, `distsql_partitioning`, and `crdb_internal_ccl`.

Release note: None