### PR TITLE
kv/kvpb: decode EncodedError once in checkTxnStatusValid

### DIFF
--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -230,10 +230,17 @@ func (e *Error) String() string {
 // TransactionRestart returns the TransactionRestart for this Error.
 func (e *Error) TransactionRestart() TransactionRestart {
 	if e.EncodedError.IsSet() {
-		var iface transactionRestartError
-		if errors.As(errors.DecodeError(context.Background(), e.EncodedError), &iface) {
-			return iface.canRestartTransaction()
-		}
+		return transactionRestartFromDecodedError(errors.DecodeError(context.Background(), e.EncodedError))
+	}
+	return TransactionRestart_NONE
+}
+
+// transactionRestartFromDecodedError returns the TransactionRestart for an
+// already-decoded error, without re-decoding it.
+func transactionRestartFromDecodedError(err error) TransactionRestart {
+	var iface transactionRestartError
+	if errors.As(err, &iface) {
+		return iface.canRestartTransaction()
 	}
 	return TransactionRestart_NONE
 }
@@ -394,8 +401,14 @@ func (e *Error) GetDetail() ErrorDetailInterface {
 	if e == nil || !e.EncodedError.IsSet() {
 		return nil
 	}
+	return detailFromDecodedError(errors.DecodeError(context.Background(), e.EncodedError))
+}
+
+// detailFromDecodedError returns the error detail for an already-decoded
+// error, without re-decoding it.
+func detailFromDecodedError(err error) ErrorDetailInterface {
 	var detail ErrorDetailInterface
-	errors.As(errors.DecodeError(context.Background(), e.EncodedError), &detail)
+	errors.As(err, &detail)
 	return detail
 }
 
@@ -424,14 +437,18 @@ func (e *Error) UpdateTxn(o *roachpb.Transaction) {
 // error detail.
 func (e *Error) checkTxnStatusValid() {
 	txn := e.UnexposedTxn
-	err := e.GetDetail()
 	if txn == nil {
 		return
 	}
+	var decoded error
+	if e.EncodedError.IsSet() {
+		decoded = errors.DecodeError(context.Background(), e.EncodedError)
+	}
+	err := detailFromDecodedError(decoded)
 	if errors.HasType(err, (*TransactionAbortedError)(nil)) {
 		return
 	}
-	if e.TransactionRestart() == TransactionRestart_NONE {
+	if transactionRestartFromDecodedError(decoded) == TransactionRestart_NONE {
 		return
 	}
 	if txn.Status.IsFinalized() {

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -59,6 +59,28 @@ func TestSetTxn(t *testing.T) {
 	}
 }
 
+// TestSetTxnRestartableNotFinalized exercises checkTxnStatusValid's
+// restartable-but-not-yet-finalized path: a detail that can restart the
+// transaction (unlike TestSetTxn's TransactionAbortedError, which returns
+// early) paired with a non-finalized txn (unlike TestErrorTxn's plain
+// error, which never reaches the restart check). This is the one branch
+// that actually reaches both the detail check and the restart check on the
+// same decoded error.
+func TestSetTxnRestartableNotFinalized(t *testing.T) {
+	e := NewError(&TransactionRetryError{Reason: RETRY_SERIALIZABLE})
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), isolation.Serializable, 1, hlc.Timestamp{}, 0, 99, 0, false /* omitInRangefeeds */)
+	// txn defaults to PENDING (not finalized), so this must not fatal.
+	e.SetTxn(&txn)
+
+	detail := e.GetDetail()
+	if _, ok := detail.(*TransactionRetryError); !ok {
+		t.Fatalf("expected *TransactionRetryError, got %T", detail)
+	}
+	if got := e.TransactionRestart(); got != TransactionRestart_IMMEDIATE {
+		t.Fatalf("expected TransactionRestart_IMMEDIATE, got %v", got)
+	}
+}
+
 func TestErrPriority(t *testing.T) {
 	unhandledAbort := &UnhandledRetryableError{
 		PErr: *NewError(&TransactionAbortedError{}),


### PR DESCRIPTION
Fixes #171516

`Error.checkTxnStatusValid` calls `e.GetDetail()` and then
`e.TransactionRestart()`, each of which independently calls
`errors.DecodeError` on the same `e.EncodedError` payload. When the encoded
error is large (e.g. a `LockConflictError` with many lock spans), this pays
the protobuf-unmarshal cost twice for no benefit. Per the issue, this showed
up as 13% of node CPU during a customer incident, split evenly across the
two redundant decodes.

This PR decodes once in `checkTxnStatusValid` and feeds the already-decoded
error to two new unexported helpers, `detailFromDecodedError` and
`transactionRestartFromDecodedError`, which `GetDetail()` and
`TransactionRestart()` now also use internally. Exported signatures and
behavior are unchanged — this is purely removing a redundant decode.

Verified via `bazel test //pkg/kv/kvpb:kvpb_test` (existing `TestSetTxn` /
`TestErrorTxn` exercise `checkTxnStatusValid`'s two early-return branches);
full package suite passes.

Release note (performance improvement): Reduced CPU overhead on the
DistSender response path when a batch response carries a retryable
transaction error with a large encoded payload (e.g. a lock conflict error
with many lock spans), by decoding the error once instead of twice.