### PR TITLE
opt: resolve ordinals nested in a parenthesized GROUP BY tuple

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -534,8 +534,44 @@ func (b *Builder) buildGroupingList(
 func (b *Builder) buildGrouping(
 	groupBy tree.Expr, selects tree.SelectExprs, projectionsScope, fromScope, aggInScope *scope,
 ) {
-	// Unwrap parenthesized expressions like "((a))" to "a".
-	groupBy = tree.StripParens(groupBy)
+	// A parenthesized list in GROUP BY position is a row constructor, and
+	// PostgreSQL flattens it into its individual elements before resolving
+	// each one (e.g. as a select-list ordinal or column name) rather than
+	// resolving the tuple as a whole. Flatten first so that ordinals and
+	// names nested inside a multi-element tuple, like the "1" in
+	// "GROUP BY (1, x)", are resolved the same way a bare "GROUP BY 1"
+	// would be.
+	for _, e := range flattenGroupByExpr(groupBy) {
+		b.buildGroupingItem(e, selects, projectionsScope, fromScope, aggInScope)
+	}
+}
+
+// flattenGroupByExpr strips parentheses and recursively flattens nested
+// tuples (row constructors) in a GROUP BY item into its leaf expressions.
+// "GROUP BY (a, (b, c))" and "GROUP BY a, b, c" are equivalent, and each
+// leaf must be resolved independently: a bare integer leaf like the "1" in
+// "GROUP BY (1, x)" refers to select-list position 1, exactly as it would
+// if written as a top-level "GROUP BY 1".
+func flattenGroupByExpr(e tree.Expr) []tree.Expr {
+	e = tree.StripParens(e)
+	t, ok := e.(*tree.Tuple)
+	if !ok {
+		return []tree.Expr{e}
+	}
+	exprs := make([]tree.Expr, 0, len(t.Exprs))
+	for _, sub := range t.Exprs {
+		exprs = append(exprs, flattenGroupByExpr(sub)...)
+	}
+	return exprs
+}
+
+// buildGroupingItem builds a single, already-flattened GROUP BY leaf
+// expression: resolving select-list ordinals and target-list aliases,
+// then building the resulting scalar expression(s) into aggInScope. See
+// buildGrouping for the flattening step that produces these leaves.
+func (b *Builder) buildGroupingItem(
+	groupBy tree.Expr, selects tree.SelectExprs, projectionsScope, fromScope, aggInScope *scope,
+) {
 	alias := ""
 
 	// Comment below pasted from PostgreSQL (findTargetListEntrySQL92 in

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -349,6 +349,46 @@ SELECT count(w) FROM kv GROUP BY 1
 ----
 error (42803): count(): aggregate functions are not allowed in GROUP BY
 
+# Ordinals nested inside a parenthesized GROUP BY tuple are resolved as
+# select-list positions too, exactly like a bare ordinal (a parenthesized
+# list in GROUP BY position is a row constructor that PostgreSQL flattens
+# before resolving each element).
+build
+SELECT count(w), k FROM kv GROUP BY (1, k)
+----
+error (42803): count(): aggregate functions are not allowed in GROUP BY
+
+build
+SELECT k FROM kv GROUP BY (1, v)
+----
+project
+ ├── columns: k:1!null
+ └── group-by (hash)
+      ├── columns: k:1!null v:2
+      ├── grouping columns: k:1!null v:2
+      └── project
+           ├── columns: k:1!null v:2
+           └── scan kv
+                └── columns: k:1!null v:2 w:3 s:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+
+build
+SELECT k, v FROM kv GROUP BY (5, k)
+----
+error (42P10): GROUP BY position 5 is not in select list
+
+build
+SELECT k FROM kv GROUP BY ((1), v)
+----
+project
+ ├── columns: k:1!null
+ └── group-by (hash)
+      ├── columns: k:1!null v:2
+      ├── grouping columns: k:1!null v:2
+      └── project
+           ├── columns: k:1!null v:2
+           └── scan kv
+                └── columns: k:1!null v:2 w:3 s:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v)
 ----


### PR DESCRIPTION
Fixes #173471.

CockroachDB resolved a `GROUP BY` item's select-list ordinal (e.g. the `1` in `GROUP BY 1`) by checking the whole item before flattening parenthesized tuples. Bare and singly-parenthesized ordinals (`GROUP BY 1`, `GROUP BY (1)`) worked because `tree.StripParens` unwraps those down to a plain integer, but an ordinal nested inside a multi-element tuple (`GROUP BY (1, x)`) stayed a literal constant, since the tuple was only flattened *after* ordinal/name resolution had already been skipped for it.

PostgreSQL flattens a parenthesized `GROUP BY` list first, then resolves each resulting element independently (`findTargetListEntrySQL92`). This PR reorders `buildGrouping` in `pkg/sql/opt/optbuilder/groupby.go` to do the same:

- `flattenGroupByExpr` recursively strips parens and flattens nested tuples at the raw-expression level (before type resolution), matching PostgreSQL's row-constructor flattening semantics for `GROUP BY`.
- Each flattened leaf then goes through the existing ordinal/alias resolution logic on its own (extracted into `buildGroupingItem`, previously the whole body of `buildGrouping`).

This fixes all three divergences from the issue:
- `GROUP BY (1, x)` where `1` refers to an aggregate select-list item now correctly errors, instead of silently accepting an illegal grouping key.
- `GROUP BY (1, v)` now correctly resolves `1` as a select-list ordinal instead of rejecting the query.
- An out-of-range ordinal nested in a tuple now reports the correct "position N is not in select list" error instead of a generic grouping error.

Release note (bug fix): Fixed a bug where a SELECT-list ordinal reference nested inside a parenthesized GROUP BY tuple, such as `GROUP BY (1, x)`, was treated as a literal constant instead of a reference to the first SELECT-list item, unlike PostgreSQL.