### PR TITLE
sql: type check placeholders in ALTER TABLE SET integer storage params

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1863,3 +1863,28 @@ statement ok
 RESET CLUSTER SETTING jobs.scheduler.enabled
 
 subtest end
+
+# Regression test for #171241: EXECUTE of a PREPAREd ALTER TABLE ... SET
+# storage parameter with a placeholder value used to fail with "no type for
+# placeholder $1", because the placeholder was only type checked when the SET
+# was actually evaluated (at EXECUTE/startExec time), not during PREPARE.
+subtest placeholder_in_set_storage_param
+
+statement ok
+CREATE TABLE tbl_placeholder_storage_param (id INT PRIMARY KEY) WITH (ttl_expire_after = '10 minutes')
+
+statement ok
+PREPARE p AS ALTER TABLE tbl_placeholder_storage_param SET (ttl_select_batch_size = $1)
+
+statement ok
+EXECUTE p(100)
+
+query T
+SELECT regexp_extract(create_statement, 'ttl_select_batch_size = \d+') FROM [SHOW CREATE TABLE tbl_placeholder_storage_param]
+----
+ttl_select_batch_size = 100
+
+statement ok
+DEALLOCATE p
+
+subtest end

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -50,6 +50,16 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 	"sql.query_cache.enabled", "enable the query cache", true,
 )
 
+// intTableStorageParams is the set of ALTER/CREATE TABLE storage parameter
+// keys whose value is always an integer (see table_storage_param.go, where
+// each of these is parsed via paramparse.DatumAsInt).
+var intTableStorageParams = map[string]bool{
+	`ttl_select_batch_size`: true,
+	`ttl_delete_batch_size`: true,
+	`ttl_select_rate_limit`: true,
+	`ttl_delete_rate_limit`: true,
+}
+
 // prepareUsingOptimizer builds a memo for a prepared statement and populates
 // the following stmt.Prepared fields:
 //   - Columns
@@ -95,7 +105,48 @@ func (p *planner) prepareUsingOptimizerInternal(
 	}
 
 	switch t := stmt.AST.(type) {
-	case *tree.AlterIndex, *tree.AlterIndexVisible, *tree.AlterTable, *tree.AlterSequence,
+	case *tree.AlterTable:
+		// ALTER TABLE has no result columns, so there's normally nothing to do
+		// during prepare (see the bulk case below). However, unlike most of the
+		// statements in that bucket, ALTER TABLE ... SET (...) can take a
+		// placeholder as the value for an integer-typed storage parameter (e.g.
+		// SET (ttl_select_batch_size = $1)); startExec, which actually type
+		// checks and evaluates storage parameter values via storageparam.Set,
+		// only runs at real EXECUTE time. Without this, such a placeholder
+		// would never get a type recorded during PREPARE, and EXECUTE would
+		// fail with "no type for placeholder". Type check it here as an int
+		// (discarding the result) purely for that side effect; the real
+		// evaluation still happens later in startExec.
+		for _, cmd := range t.Cmds {
+			setStorageParams, ok := cmd.(*tree.AlterTableSetStorageParams)
+			if !ok {
+				continue
+			}
+			for _, sp := range setStorageParams.StorageParams {
+				if !intTableStorageParams[sp.Key] {
+					continue
+				}
+				if _, ok := sp.Value.(*tree.Placeholder); !ok {
+					continue
+				}
+				if _, err := p.analyzeExpr(
+					ctx, sp.Value,
+					tree.IndexedVarHelper{},
+					types.Int, true, /* requireType */
+					"table storage parameters",
+				); err != nil {
+					return 0, nil, err
+				}
+			}
+		}
+		// Persist the type(s) just recorded above (and any client-supplied
+		// hints) onto the prepared statement, mirroring what the general
+		// (non-early-return) path below does at the end of this function.
+		p.semaCtx.Placeholders.MaybeExtendTypes()
+		stmt.Prepared.Types = p.semaCtx.Placeholders.Types
+		return opc.flags, nil, nil
+
+	case *tree.AlterIndex, *tree.AlterIndexVisible, *tree.AlterSequence,
 		*tree.Analyze,
 		*tree.BeginTransaction,
 		*tree.CommentOnColumn, *tree.CommentOnConstraint, *tree.CommentOnDatabase, *tree.CommentOnIndex, *tree.CommentOnTable, *tree.CommentOnSchema,

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/storageparam/tablestorageparam"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -49,16 +50,6 @@ var queryCacheEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.query_cache.enabled", "enable the query cache", true,
 )
-
-// intTableStorageParams is the set of ALTER/CREATE TABLE storage parameter
-// keys whose value is always an integer (see table_storage_param.go, where
-// each of these is parsed via paramparse.DatumAsInt).
-var intTableStorageParams = map[string]bool{
-	`ttl_select_batch_size`: true,
-	`ttl_delete_batch_size`: true,
-	`ttl_select_rate_limit`: true,
-	`ttl_delete_rate_limit`: true,
-}
 
 // prepareUsingOptimizer builds a memo for a prepared statement and populates
 // the following stmt.Prepared fields:
@@ -109,30 +100,32 @@ func (p *planner) prepareUsingOptimizerInternal(
 		// ALTER TABLE has no result columns, so there's normally nothing to do
 		// during prepare (see the bulk case below). However, unlike most of the
 		// statements in that bucket, ALTER TABLE ... SET (...) can take a
-		// placeholder as the value for an integer-typed storage parameter (e.g.
-		// SET (ttl_select_batch_size = $1)); startExec, which actually type
-		// checks and evaluates storage parameter values via storageparam.Set,
-		// only runs at real EXECUTE time. Without this, such a placeholder
-		// would never get a type recorded during PREPARE, and EXECUTE would
-		// fail with "no type for placeholder". Type check it here as an int
-		// (discarding the result) purely for that side effect; the real
-		// evaluation still happens later in startExec.
+		// placeholder as a storage parameter's value (e.g. SET
+		// (ttl_select_batch_size = $1)); startExec, which actually type checks
+		// and evaluates storage parameter values via storageparam.Set, only
+		// runs at real EXECUTE time. Without this, such a placeholder would
+		// never get a type recorded during PREPARE, and EXECUTE would fail
+		// with "no type for placeholder". Type check it here for any
+		// parameter with a statically-known value type (discarding the
+		// result) purely for that side effect; the real evaluation still
+		// happens later in startExec.
 		for _, cmd := range t.Cmds {
 			setStorageParams, ok := cmd.(*tree.AlterTableSetStorageParams)
 			if !ok {
 				continue
 			}
 			for _, sp := range setStorageParams.StorageParams {
-				if !intTableStorageParams[sp.Key] {
+				if _, ok := sp.Value.(*tree.Placeholder); !ok {
 					continue
 				}
-				if _, ok := sp.Value.(*tree.Placeholder); !ok {
+				typ, ok := tablestorageparam.ExpectedType(sp.Key)
+				if !ok {
 					continue
 				}
 				if _, err := p.analyzeExpr(
 					ctx, sp.Value,
 					tree.IndexedVarHelper{},
-					types.Int, true, /* requireType */
+					typ, true, /* requireType */
 					"table storage parameters",
 				); err != nil {
 					return 0, nil, err

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -150,6 +150,25 @@ type tableParam struct {
 	onSet            func(ctx context.Context, po *Setter, key string, value string) error
 	getResetValue    func(ctx context.Context, evalCtx *eval.Context, key string) (string, error)
 	onReset          func(ctx context.Context, po *Setter, key string, value string) error
+	// valueType is the type of the value this parameter expects, if it's
+	// always a single, statically-known type (e.g. types.Int for a parameter
+	// always parsed via intFromDatum/paramparse.DatumAsInt). Left nil for
+	// parameters whose value type varies or isn't statically known. See
+	// ExpectedType.
+	valueType *types.T
+}
+
+// ExpectedType returns the statically-known type of the value a table
+// storage parameter expects, if there is one. Used to type check a
+// placeholder used as the parameter's value before it's actually evaluated
+// (see prepareUsingOptimizerInternal's *tree.AlterTable case), without
+// duplicating per-key type knowledge outside this file.
+func ExpectedType(key string) (*types.T, bool) {
+	p, ok := tableParams[key]
+	if !ok || p.valueType == nil {
+		return nil, false
+	}
+	return p.valueType, true
 }
 
 var ttlAutomaticColumnNotice = pgnotice.Newf("ttl_automatic_column is no longer used. " +
@@ -309,6 +328,7 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_select_batch_size`: {
+		valueType: types.Int,
 		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
 			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
@@ -336,6 +356,7 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_delete_batch_size`: {
+		valueType: types.Int,
 		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
 			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
@@ -379,6 +400,7 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_select_rate_limit`: {
+		valueType: types.Int,
 		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
 			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
@@ -406,6 +428,7 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_delete_rate_limit`: {
+		valueType: types.Int,
 		validateSetValue: func(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) (string, error) {
 			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {


### PR DESCRIPTION
Fixes #171241

## Bug

`PREPARE p AS ALTER TABLE t SET (ttl_select_batch_size = $1); EXECUTE p (100);` failed at EXECUTE time with an internal `no type for placeholder $1` error, even though PREPARE itself succeeded.

## Root cause

`ALTER TABLE` is handled as an opaque statement whose storage parameter values are only type checked and evaluated in `startExec` (via `storageparam.Set`), which runs during real EXECUTE, not during PREPARE. `prepareUsingOptimizerInternal` also short-circuits for `*tree.AlterTable` before ever reaching the optbuilder, so a placeholder used as a storage parameter value never got a type recorded during PREPARE, and `fillInPlaceholders` later asserts on the missing type at EXECUTE time.

## Fix

Added a dedicated case for `*tree.AlterTable` in `prepareUsingOptimizerInternal` (`pkg/sql/plan_opt.go`) that type checks placeholders used for known integer-typed storage parameters (`ttl_select_batch_size`, `ttl_delete_batch_size`, `ttl_select_rate_limit`, `ttl_delete_rate_limit`) during PREPARE, purely for the side effect of recording the placeholder's type via `SetType`, then persists it onto the prepared statement's type info. The actual evaluation of the storage parameter value is untouched and still happens later in `startExec`.

## Testing

Added a logictest reproducing the exact PREPARE/EXECUTE sequence from the issue (`pkg/sql/logictest/testdata/logic_test/row_level_ttl`), verified it fails without the fix and passes with it. Also ran `TestLogic_prepare`, `TestLogic_alter_table`, `TestLogic_create_table`, `TestLogic_create_index`, and `TestLogic_alter_index` to check for regressions, and a full `bazel build //pkg/sql:sql` to confirm the package still compiles cleanly.