### PR TITLE
opt: preserve declared column name of an aliased table-returning UDF

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_setof
+++ b/pkg/sql/logictest/testdata/logic_test/udf_setof
@@ -308,6 +308,86 @@ $$
 
 subtest end
 
+# Regression test for #173710: a bare table alias on a table-returning UDF
+# call with a single declared output column should rename only the relation,
+# not the declared column name (unlike an anonymous single-column SRF, e.g.
+# generate_series(), where Postgres compatibility does rename the column to
+# match the alias).
+subtest regression_173710
+
+query I colnames,rowsort
+SELECT * FROM f_table2()
+----
+x
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+
+query I colnames,rowsort
+SELECT * FROM f_table2() AS f
+----
+x
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+
+query I
+SELECT f.x FROM f_table2() AS f WHERE f.x = 3
+----
+3
+
+statement ok
+CREATE FUNCTION f_table2_wrapper() RETURNS TABLE(x INT) AS $$
+  SELECT f.x FROM f_table2() AS f;
+$$ LANGUAGE SQL;
+
+query I rowsort
+SELECT * FROM f_table2_wrapper()
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+
+# An explicit column-alias list still overrides the declared column name, as
+# it does for any other data source.
+query I colnames,rowsort
+SELECT * FROM f_table2() AS f(y)
+----
+y
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+
+subtest end
+
 # Do not panic when the column definition list for a generator function does
 # not define types for all columns.
 subtest regression_145414

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -71,6 +71,18 @@ func (s *srf) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, error) 
 var _ tree.Expr = &srf{}
 var _ tree.TypedExpr = &srf{}
 
+// hasOutRoutineParam returns true if the overload has at least one OUT or
+// INOUT parameter, i.e. it was declared with RETURNS TABLE(...) or explicit
+// OUT parameters and so has explicitly named output column(s).
+func hasOutRoutineParam(overload *tree.Overload) bool {
+	for i := range overload.RoutineParams {
+		if overload.RoutineParams[i].IsOutParam() {
+			return true
+		}
+	}
+	return false
+}
+
 // buildZip builds a set of memo groups which represent a functional zip over
 // the given expressions.
 //
@@ -94,6 +106,7 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	// Build each of the provided expressions.
 	zip := make(memo.ZipExpr, 0, len(exprs))
 	var outCols opt.ColSet
+	var hasDeclaredOutputUDF bool
 	for _, expr := range exprs {
 		// Output column names should exactly match the original expression, so we
 		// have to determine the output column name before we perform type
@@ -120,6 +133,16 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 
 		isRecordReturningUDF := def != nil && funcExpr.ResolvedOverload().Type == tree.UDFRoutine &&
 			texpr.ResolvedType().Family() == types.TupleFamily && b.insideDataSource
+		// A UDF declared with RETURNS TABLE(...) or OUT parameters has
+		// explicitly named output column(s), even when there's only one (in
+		// which case its return type decays to that column's own type,
+		// rather than a labeled tuple type, so isRecordReturningUDF above
+		// doesn't catch it). Track this so the single-SRF-column aliasing
+		// special case below doesn't override the declared name.
+		isUDF := def != nil && funcExpr.ResolvedOverload().Type == tree.UDFRoutine && b.insideDataSource
+		if isRecordReturningUDF || (isUDF && hasOutRoutineParam(funcExpr.ResolvedOverload())) {
+			hasDeclaredOutputUDF = true
+		}
 		var scalar opt.ScalarExpr
 		_, isScopedColumn := texpr.(*scopeColumn)
 
@@ -196,7 +219,13 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	// Construct the zip as a ProjectSet with empty input.
 	input := b.factory.ConstructNoColsRow()
 	outScope.expr = b.factory.ConstructProjectSet(input, zip)
-	if len(outScope.cols) == 1 {
+	// Do not apply the single-SRF-column aliasing special case (see
+	// renameSource) to a record-returning UDF's column: unlike an anonymous
+	// SRF column (e.g. generate_series's), it already has a real, explicitly
+	// declared name (from RETURNS TABLE(...) or an OUT parameter), and
+	// Postgres only lets a bare table alias rename the relation in that case,
+	// not the column.
+	if len(outScope.cols) == 1 && !hasDeclaredOutputUDF {
 		outScope.singleSRFColumn = true
 	}
 	return outScope


### PR DESCRIPTION
Fixes #173710

## Bug

```sql
CREATE FUNCTION f1() RETURNS TABLE (out_col INT) LANGUAGE SQL AS $$
  SELECT v AS out_col FROM t LIMIT 2;
$$;

SELECT * FROM f1();      -- correct: column is `out_col`
SELECT * FROM f1() AS f; -- BUG: column is renamed to `f` instead of staying `out_col`
```

As a downstream consequence, `f.out_col` fails to resolve after aliasing, which broke a real customer UDF calling pattern (wrapping one table-returning UDF's call, aliased, inside another).

## Root cause

`buildZip` (`pkg/sql/opt/optbuilder/srfs.go`) has a Postgres-compatibility special case: when a set-generating/scalar function produces exactly one *anonymous* output column (e.g. `generate_series(1,3)`), a bare table alias is allowed to rename that column too, not just the relation (`outScope.singleSRFColumn`). This is correct for genuinely anonymous SRF columns, but it was also applied to a table-returning UDF's column, which already has a real, user-declared name.

The existing `isRecordReturningUDF` check (used to detect "this is a UDF with a named return") only catches the *multi*-column case, because `RETURNS TABLE(x INT)` with a single column decays to that column's own scalar type rather than a labeled tuple type (see the comment in `pkg/sql/parser/sql.y` for `RETURNS TABLE`) — so the check's `Family() == types.TupleFamily` condition misses it.

## Fix

Detect a declared-output UDF more generally, via the resolved overload's `RoutineParams` (which still carries the declared `OUT`/`RETURNS TABLE` parameter even in the single-column case, per the grammar), and skip the single-SRF-column aliasing special case for it. An explicit column-alias list (`AS f(y)`) still overrides the name, exactly as it does for any other data source.

## Testing

Added regression tests to `pkg/sql/logictest/testdata/logic_test/udf_setof` covering: bare alias preserves the declared column name, qualified references (`f.x`) resolve after aliasing, a wrapper UDF using this pattern (mirroring the reported customer scenario) works, and an explicit column-alias list still overrides the name. Ran the full `optbuilder_test` datadriven suite and the related logictest suites (`udf_setof`, `udf`, `srfs`, `udf_privileges`, `json`, `udf_plpgsql`, `plpgsql_srf`, `information_schema`) — all pass with no regressions.