### PR TITLE
opt: don't flatten ROW(...) as a parenthesized list in GROUP BY/ORDER BY/PARTITION BY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,37 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+# Regression test for GROUP BY ROW(...) being incorrectly flattened like a
+# parenthesized list, including GROUP BY ROW() wrongly behaving like the true
+# empty grouping set GROUP BY () (#173264).
+statement ok
+CREATE TABLE t173264 (a INT, b INT);
+INSERT INTO t173264 VALUES (1, 10), (1, 20), (2, 30);
+
+# GROUP BY ROW() groups by a constant scalar, so (unlike GROUP BY (), the
+# true empty grouping set) it produces zero rows when the input is empty.
+query I
+SELECT count(*) FROM t173264 WHERE a > 100 GROUP BY ROW();
+----
+
+query I
+SELECT count(*) FROM t173264 WHERE a > 100 GROUP BY ();
+----
+0
+
+# ROW(a, b) is not flattened, so a and b remain unavailable to the select
+# list individually.
+query error pgcode 42803 column "a" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT a FROM t173264 GROUP BY ROW(a, b)
+
+query error pgcode 42803 column "a" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT a FROM t173264 GROUP BY ROW(a)
+
+# A parenthesized list (not ROW(...)) still flattens as before.
+query I rowsort
+SELECT a FROM t173264 GROUP BY (a, b)
+----
+1
+1
+2

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -349,6 +349,64 @@ SELECT count(w) FROM kv GROUP BY 1
 ----
 error (42803): count(): aggregate functions are not allowed in GROUP BY
 
+# ROW(...) is a row constructor, not shorthand for a parenthesized list, so
+# unlike "GROUP BY (k, v)" it is not flattened: it groups by the composite
+# value as a single scalar grouping column, so k and v individually remain
+# unavailable to the select list.
+build
+SELECT k, v FROM kv GROUP BY ROW(k, v)
+----
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
+
+build
+SELECT count(*) FROM kv GROUP BY ROW(k, v)
+----
+project
+ ├── columns: count:7!null
+ └── group-by (hash)
+      ├── columns: count_rows:7!null column8:8
+      ├── grouping columns: column8:8
+      ├── project
+      │    ├── columns: column8:8
+      │    ├── scan kv
+      │    │    └── columns: k:1!null v:2 w:3 s:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── projections
+      │         └── (k:1, v:2) [as=column8:8]
+      └── aggregations
+           └── count-rows [as=count_rows:7]
+
+# Unlike "GROUP BY ()" (the true empty grouping set, which is a special case
+# that always produces exactly one output row, even for empty input),
+# "GROUP BY ROW()" groups by a constant composite scalar: a single, real
+# grouping column, so it produces zero output rows for empty input.
+build
+SELECT count(*) FROM kv GROUP BY ROW()
+----
+project
+ ├── columns: count:7!null
+ └── group-by (hash)
+      ├── columns: count_rows:7!null column8:8!null
+      ├── grouping columns: column8:8!null
+      ├── project
+      │    ├── columns: column8:8!null
+      │    ├── scan kv
+      │    │    └── columns: k:1!null v:2 w:3 s:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── projections
+      │         └── () [as=column8:8]
+      └── aggregations
+           └── count-rows [as=count_rows:7]
+
+build
+SELECT count(*) FROM kv GROUP BY ()
+----
+scalar-group-by
+ ├── columns: count:7!null
+ ├── project
+ │    └── scan kv
+ │         └── columns: k:1!null v:2 w:3 s:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+ └── aggregations
+      └── count-rows [as=count_rows:7]
+
 build
 SELECT sum(v) FROM kv GROUP BY k LIMIT sum(v)
 ----

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -234,6 +234,22 @@ sort
       └── scan t
            └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
 
+# ROW(...) is a row constructor, not shorthand for a parenthesized list, so
+# unlike "ORDER BY (b, a)" it is not flattened into separate sort keys: it
+# orders by the composite value as a whole.
+build
+SELECT * FROM t ORDER BY ROW(b, a), c
+----
+sort
+ ├── columns: a:1!null b:2 c:3  [hidden: column6:6]
+ ├── ordering: +6,+3
+ └── project
+      ├── columns: column6:6 a:1!null b:2 c:3
+      ├── scan t
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── projections
+           └── (b:2, a:1) [as=column6:6]
+
 build
 SELECT * FROM t ORDER BY b, (a, c)
 ----

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -685,6 +685,25 @@ project
       └── windows
            └── row-number [as=row_number:10]
 
+# ROW(...) is a row constructor, not shorthand for a parenthesized list, so
+# unlike "PARTITION BY (k, v)" above it is not flattened: it partitions by
+# the composite value as a single key.
+build
+SELECT k, row_number() OVER (PARTITION BY ROW(k, v)) FROM kv
+----
+project
+ ├── columns: k:1!null row_number:10
+ └── window partition=(11)
+      ├── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9 row_number:10 row_number_1_partition_1:11
+      ├── project
+      │    ├── columns: row_number_1_partition_1:11 k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      │    ├── scan kv
+      │    │    └── columns: k:1!null v:2 w:3 f:4 d:5 s:6 b:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      │    └── projections
+      │         └── (k:1, v:2) [as=row_number_1_partition_1:11]
+      └── windows
+           └── row-number [as=row_number:10]
+
 build
 SELECT k, row_number() OVER (PARTITION BY kv.*) FROM kv
 ----

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -388,12 +388,19 @@ func makeBackfillError(name tree.Name) error {
 		"column %q is being backfilled", tree.ErrString(&name))
 }
 
-// flattenTuples extracts the members of tuples into a list of columns.
+// flattenTuples extracts the members of syntactic parenthesized-list tuples
+// (e.g. "(a, b)") into a list of columns. A tuple built with the explicit ROW
+// keyword (e.g. "ROW(a, b)") is a row constructor, not shorthand for listing
+// its members separately, and is left as a single, opaque scalar expression
+// (Tuple.Row distinguishes the two; see its doc comment). This matches
+// Postgres: a parenthesized list in a position like GROUP BY, ORDER BY, or
+// PARTITION BY is flattened, but ROW(...) there groups/orders/partitions by
+// the composite value as a whole.
 func flattenTuples(exprs []tree.TypedExpr) []tree.TypedExpr {
 	// We want to avoid allocating new slices unless strictly necessary.
 	var newExprs []tree.TypedExpr
 	for i, e := range exprs {
-		if t, ok := e.(*tree.Tuple); ok {
+		if t, ok := e.(*tree.Tuple); ok && !t.Row {
 			if newExprs == nil {
 				// All right, it was necessary to allocate the slices after all.
 				newExprs = make([]tree.TypedExpr, i, len(exprs))
@@ -412,10 +419,11 @@ func flattenTuples(exprs []tree.TypedExpr) []tree.TypedExpr {
 }
 
 // flattenTuple recursively extracts the members of a tuple into a list of
-// expressions.
+// expressions. A member built with the explicit ROW keyword is kept as a
+// single, unflattened expression; see flattenTuples.
 func flattenTuple(t *tree.Tuple, exprs []tree.TypedExpr) []tree.TypedExpr {
 	for _, e := range t.Exprs {
-		if eT, ok := e.(*tree.Tuple); ok {
+		if eT, ok := e.(*tree.Tuple); ok && !eT.Row {
 			exprs = flattenTuple(eT, exprs)
 		} else {
 			expr := e.(tree.TypedExpr)


### PR DESCRIPTION
Fixes #173264

`flattenTuples`/`flattenTuple` (`pkg/sql/opt/optbuilder/util.go`) treated a `ROW(...)` expression the same as a syntactic parenthesized list like `(a, b)`, splitting its elements into separate grouping/ordering/partition columns. Per SQL92 and Postgres, only a syntactic paren list is shorthand for a list of expressions; `ROW(...)` is a row constructor producing a single composite scalar value, and grouping/ordering/partitioning by it should use that one value as-is.

This function is shared by all five call sites affected by the bug: the main `GROUP BY` list and an aggregate function's internal `ORDER BY` (`groupby.go`), the statement `ORDER BY` (`orderby.go`), and window `PARTITION BY` (`window.go`, x2) — so the fix is made once at the shared utility rather than patched per caller.

Two concrete bugs this caused, both reproduced from the issue:

- `GROUP BY ROW()` was funneled into the same zero-grouping-columns path as the true empty grouping set `GROUP BY ()`, incorrectly picking up scalar-aggregation semantics (always emits exactly one row, even for empty input) instead of grouping by a real, constant composite column (zero rows for empty input). This is a silently-incorrect-results bug.
- `GROUP BY ROW(a, b)` silently accepted `a` and `b` individually in the select list, when only the composite value should be available — CockroachDB was more permissive than Postgres here, which rejects such queries with `42803`.

## Verification

- New optbuilder unit tests (`testdata/aggregate`, `testdata/orderby`, `testdata/window`) covering all three affected clause positions, generated/verified via `-rewrite` and confirmed stable; full `optbuilder_test` suite passes with no other diffs (zero regressions).
- New end-to-end logictest (`testdata/logic_test/aggregate`) reproducing the issue's key cases: `GROUP BY ROW()` now correctly returns zero rows for empty input (vs. `GROUP BY ()`'s one row), `GROUP BY ROW(a, b)`/`ROW(a)` now correctly reject referencing `a` individually (`42803`), and the pre-existing `GROUP BY (a, b)` paren-list flattening behavior is unchanged. Full `TestLogic_aggregate` suite passes.

Release note (bug fix): Fixed a bug where `GROUP BY`, `ORDER BY`, and window `PARTITION BY` clauses incorrectly flattened a `ROW(...)` expression's elements into separate columns, as though it were a parenthesized list. This could silently produce incorrect results, most notably `GROUP BY ROW()` being wrongly treated as the empty grouping set (always returning one row) instead of grouping by a constant value (returning no rows for empty input).