### PR TITLE
kvserver,obs: do not mask LockWait state with nested TxnPushWait

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -454,17 +454,20 @@ func (m *managerImpl) maybeInterceptReq(ctx context.Context, req Request) (Respo
 		// If necessary, wait in the txnWaitQueue for the pushee transaction to
 		// expire or to move to a finalized state.
 		t := req.Requests[0].GetPushTxn()
-		tenantID, _ := roachpb.ClientTenantFromContext(ctx)
-		var info ash.WorkloadInfo
-		if req.Batch != nil {
-			info = ash.WorkloadInfo{
-				WorkloadID:    req.Batch.WorkloadID,
-				AppNameID:     req.Batch.AppNameID,
-				GatewayNodeID: req.Batch.GatewayNodeID,
-				WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
+		cleanup := func() {}
+		if !ash.HasWorkEvent("LockWait") {
+			tenantID, _ := roachpb.ClientTenantFromContext(ctx)
+			var info ash.WorkloadInfo
+			if req.Batch != nil {
+				info = ash.WorkloadInfo{
+					WorkloadID:    req.Batch.WorkloadID,
+					AppNameID:     req.Batch.AppNameID,
+					GatewayNodeID: req.Batch.GatewayNodeID,
+					WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
+				}
 			}
+			cleanup = ash.SetWorkState(tenantID, info, ash.WorkLock, "TxnPushWait")
 		}
-		cleanup := ash.SetWorkState(tenantID, info, ash.WorkLock, "TxnPushWait")
 		resp, err := m.twq.MaybeWaitForPush(ctx, t, req.WaitPolicy)
 		cleanup()
 		if err != nil {
@@ -476,17 +479,20 @@ func (m *managerImpl) maybeInterceptReq(ctx context.Context, req Request) (Respo
 		// If necessary, wait in the txnWaitQueue for a transaction state update
 		// or for a dependent transaction to change.
 		t := req.Requests[0].GetQueryTxn()
-		tenantID, _ := roachpb.ClientTenantFromContext(ctx)
-		var info ash.WorkloadInfo
-		if req.Batch != nil {
-			info = ash.WorkloadInfo{
-				WorkloadID:    req.Batch.WorkloadID,
-				AppNameID:     req.Batch.AppNameID,
-				GatewayNodeID: req.Batch.GatewayNodeID,
-				WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
+		cleanup := func() {}
+		if !ash.HasWorkEvent("LockWait") {
+			tenantID, _ := roachpb.ClientTenantFromContext(ctx)
+			var info ash.WorkloadInfo
+			if req.Batch != nil {
+				info = ash.WorkloadInfo{
+					WorkloadID:    req.Batch.WorkloadID,
+					AppNameID:     req.Batch.AppNameID,
+					GatewayNodeID: req.Batch.GatewayNodeID,
+					WorkloadType:  workloadid.WorkloadType(req.Batch.WorkloadType),
+				}
 			}
+			cleanup = ash.SetWorkState(tenantID, info, ash.WorkLock, "TxnQueryWait")
 		}
-		cleanup := ash.SetWorkState(tenantID, info, ash.WorkLock, "TxnQueryWait")
 		pErr := m.twq.MaybeWaitForQuery(ctx, t)
 		cleanup()
 		return nil, pErr

--- a/pkg/obs/ash/work_state.go
+++ b/pkg/obs/ash/work_state.go
@@ -172,6 +172,24 @@ func pushWorkState(shard *workStateMapShard, gid int64, state *WorkState) {
 	shard.m[gid] = state
 }
 
+// HasWorkEvent returns true if the current goroutine is already registered with
+// the specified work event.
+func HasWorkEvent(event string) bool {
+	if !enabled.Load() {
+		return false
+	}
+	gid := goid.Get()
+	shard := workStateShard(gid)
+	shard.Lock()
+	defer shard.Unlock()
+	for s := shard.m[gid]; s != nil; s = s.prev {
+		if s.WorkEvent == event {
+			return true
+		}
+	}
+	return false
+}
+
 // noop is a pre-allocated no-op function returned when ASH is disabled.
 var noop = func() {}
 

--- a/pkg/obs/ash/work_state_test.go
+++ b/pkg/obs/ash/work_state_test.go
@@ -199,3 +199,28 @@ func TestRetiredWorkStatesCapOverflow(t *testing.T) {
 	// Clean up: drain the retired list back to the pool.
 	reclaimRetiredWorkStates()
 }
+
+func TestHasWorkEvent(t *testing.T) {
+	enabled.Store(true)
+	defer enabled.Store(false)
+
+	tenantID := roachpb.MustMakeTenantID(1)
+
+	require.False(t, HasWorkEvent("LockWait"), "should return false when no work state active")
+
+	clear1 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 10}, WorkLock, "LockWait")
+	require.True(t, HasWorkEvent("LockWait"), "should return true when LockWait is active")
+	require.False(t, HasWorkEvent("TxnPushWait"), "should return false for inactive event")
+
+	// Push nested event on top
+	clear2 := SetWorkState(tenantID, WorkloadInfo{WorkloadID: 20}, WorkLock, "TxnPushWait")
+	require.True(t, HasWorkEvent("LockWait"), "should return true for ancestor work event in stack")
+	require.True(t, HasWorkEvent("TxnPushWait"), "should return true for top work event")
+
+	clear2()
+	require.True(t, HasWorkEvent("LockWait"), "should return true after popping top event")
+	require.False(t, HasWorkEvent("TxnPushWait"), "should return false after popping TxnPushWait")
+
+	clear1()
+	require.False(t, HasWorkEvent("LockWait"), "should return false after clearing all events")
+}


### PR DESCRIPTION
Release note: None

### Description
When a request blocked on a lock escalates from the initial liveness-push delay to synchronously pushing the lock holder's transaction, the push executes on the waiter's own goroutine.

Previously, `maybeInterceptReq` registered `TxnPushWait` / `TxnQueryWait` on top of the already active `LockWait` in the goroutine's work-state stack. Because the ASH sampler inspects the top of the stack, long-blocked waiters were sampled almost entirely as un-labeled `TxnPushWait` rather than `LockWait`.

This change adds `ash.HasWorkEvent` to inspect the current goroutine's active work stack and avoids registering nested `TxnPushWait` or `TxnQueryWait` if `LockWait` is already active.

Fixes #173845