### PR TITLE
kvserver: improve drain lease transfer failure logging and include duration

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2093,8 +2093,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 					duration := timeutil.Since(start).Microseconds()
 
 					if transferStatus != allocator.TransferOK {
-						const failFormat = "failed to transfer lease %s for range %s when draining: %v"
-						const durationFailFormat = "blocked for %d microseconds on transfer attempt"
+						const failFormat = "failed to transfer lease %s for range %s when draining: %v (blocked for %d µs)"
 
 						infoArgs := []interface{}{
 							drainingLeaseStatus.Lease,
@@ -2105,13 +2104,12 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 						} else {
 							infoArgs = append(infoArgs, transferStatus)
 						}
+						infoArgs = append(infoArgs, duration)
 
-						if verbose {
+						if verbose || log.V(1) {
 							log.KvDistribution.Infof(ctx, failFormat, infoArgs...)
-							log.KvDistribution.Infof(ctx, durationFailFormat, duration)
 						} else {
 							log.VErrEventf(ctx, 1 /* level */, failFormat, infoArgs...)
-							log.VErrEventf(ctx, 1 /* level */, durationFailFormat, duration)
 						}
 					}
 				}); err != nil {


### PR DESCRIPTION
Release note: None
Epic: None

### Description
During graceful node drain, when range lease transfers fail or take longer than expected, operators lack immediate visibility into which ranges are failing to shed and how long the transfer attempts took.

### Solution
- Consolidate lease transfer error format to include elapsed duration in microseconds.
- Promote failure events to `log.KvDistribution.Infof` when `verbose` is requested or at verbosity level 1, facilitating troubleshooting of incomplete drains on multi-node clusters.

Informs #65659

Signed-off-by: sundeep8967 <sundeep8967@gmail.com>