### PR TITLE
sql: restore cursor state during automatic retries

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1833,6 +1833,7 @@ type connExecutor struct {
 			savepoints       savepointStack
 			sessionDataStack *sessiondata.Stack
 			advisoryRewind   advisorylock.RewindSnapshot
+			sqlCursors       sqlCursorSnapshot
 		}
 		// transactionStatementFingerprintIDs tracks all statement IDs that make up the current
 		// transaction. It's length is bound by the TxnStatsNumStmtFingerprintIDsToRecord
@@ -2332,6 +2333,11 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, pay
 	}
 	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, closeReason); err != nil {
 		log.Dev.Warningf(ctx, "error closing cursors: %v", err)
+	}
+	if ev.eventType != txnRestart {
+		if err := ex.extraTxnState.rewindPosSnapshot.sqlCursors.close(); err != nil {
+			log.Dev.Warningf(ctx, "error closing cursor retry snapshot: %v", err)
+		}
 	}
 
 	switch ev.eventType {
@@ -2910,6 +2916,11 @@ func (ex *connExecutor) execCmd() (retErr error) {
 		if err := ex.rewindPrepStmtNamespace(ctx); err != nil {
 			return err
 		}
+		if err := ex.extraTxnState.sqlCursors.rewind(
+			&ex.extraTxnState.rewindPosSnapshot.sqlCursors,
+		); err != nil {
+			return err
+		}
 		ex.extraTxnState.savepoints = ex.extraTxnState.rewindPosSnapshot.savepoints
 		// Note we use the Replace function instead of reassigning, as there are
 		// copies of the ex.sessionDataStack in the iterators and extendedEvalContext.
@@ -3085,6 +3096,10 @@ func (ex *connExecutor) updateTxnRewindPosMaybe(
 // All statements with lower position in stmtBuf (if any) are removed, as we
 // won't ever need them again.
 func (ex *connExecutor) setTxnRewindPos(ctx context.Context, pos CmdPos) error {
+	cursorSnapshot, err := ex.extraTxnState.sqlCursors.snapshot()
+	if err != nil {
+		return err
+	}
 	if pos < ex.extraTxnState.txnRewindPos {
 		panic(errors.AssertionFailedf("can only move the  txnRewindPos forward. "+
 			"Was: %d; new value: %d", ex.extraTxnState.txnRewindPos, pos))
@@ -3098,13 +3113,26 @@ func (ex *connExecutor) setTxnRewindPos(ctx context.Context, pos CmdPos) error {
 	} else {
 		ex.extraTxnState.rewindPosSnapshot.advisoryRewind = advisorylock.RewindSnapshot{}
 	}
-	return ex.commitPrepStmtNamespace(ctx)
+	if err := ex.commitPrepStmtNamespace(ctx); err != nil {
+		_ = cursorSnapshot.close()
+		return err
+	}
+	closeErr := ex.extraTxnState.rewindPosSnapshot.sqlCursors.close()
+	ex.extraTxnState.rewindPosSnapshot.sqlCursors = cursorSnapshot
+	return closeErr
 }
 
 // stmtDoesntNeedRetry returns true if the given statement does not need to be
 // retried when performing automatic retries. This means that the results of the
 // statement do not change with retries.
 func (ex *connExecutor) stmtDoesntNeedRetry(ast tree.Statement) bool {
+	// Keep the rewind point before a lazy cursor's DECLARE; replaying the
+	// declaration is the only exact way to rebuild its query snapshot.
+	for _, cursor := range ex.extraTxnState.sqlCursors.cursors {
+		if !cursor.persisted {
+			return false
+		}
+	}
 	return isSavepoint(ast) || isSetTransaction(ast)
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2755,7 +2755,7 @@ func getPausablePortalInfo(p *planner) *portalPauseInfo {
 // directly.
 func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 	ctx context.Context, p *planner, res RestrictedCommandResult,
-) error {
+) (retErr error) {
 	if ex.executorType == executorTypeInternal {
 		// Because we step the read timestamp below, this is not safe to call within
 		// internal executor.
@@ -2768,6 +2768,13 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 		p.autoRetryStmtReason = ppInfo.dispatchReadCommittedStmtToExecutionEngine.autoRetryStmtReason
 		p.autoRetryStmtCounter = ppInfo.dispatchReadCommittedStmtToExecutionEngine.autoRetryStmtCounter
 	}
+	cursorSnapshot, err := ex.extraTxnState.sqlCursors.snapshot()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		retErr = errors.CombineErrors(retErr, cursorSnapshot.close())
+	}()
 
 	readCommittedSavePointToken, err := ex.state.mu.txn.CreateSavepoint(ctx)
 	if err != nil {
@@ -2834,6 +2841,12 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 			))
 			break
 		}
+		if !cursorSnapshot.canRewind() {
+			res.SetError(errors.Wrap(
+				maybeRetryableErr, "cannot automatically retry a cursor operation that could not be rewound",
+			))
+			break
+		}
 
 		// In order to retry the statement, we need to clear any results and
 		// errors that were buffered, rollback to the savepoint, then prepare the
@@ -2856,6 +2869,9 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 			return err
 		}
 		if err := ex.state.mu.txn.PrepareForPartialRetry(ctx); err != nil {
+			return err
+		}
+		if err := ex.extraTxnState.sqlCursors.rewind(&cursorSnapshot); err != nil {
 			return err
 		}
 		p.autoRetryStmtCounter++

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1596,6 +1596,25 @@ func TestInjectRetryErrors(t *testing.T) {
 
 	_, err := db.Exec("SET inject_retry_errors_enabled = 'true'")
 	require.NoError(t, err)
+	queryInts := func(t *testing.T, conn *gosql.Conn, query string) []int {
+		t.Helper()
+		rows, err := conn.QueryContext(ctx, query)
+		require.NoError(t, err)
+		defer rows.Close()
+		var values []int
+		for {
+			for rows.Next() {
+				var value int
+				require.NoError(t, rows.Scan(&value))
+				values = append(values, value)
+			}
+			if !rows.NextResultSet() {
+				break
+			}
+		}
+		require.NoError(t, rows.Err())
+		return values
+	}
 
 	t.Run("with_savepoints", func(t *testing.T) {
 		// The crdb.ExecuteTx wrapper uses SAVEPOINTs to retry the transaction,
@@ -1673,6 +1692,118 @@ func TestInjectRetryErrors(t *testing.T) {
 		require.NoError(t, tx.Commit())
 		require.Equal(t, 3, txRes)
 		require.Equal(t, int64(3), readCommittedStmtRetries.Load())
+	})
+
+	t.Run("cursor_txn_rewind", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		defer func() {
+			_, err := conn.ExecContext(ctx, `SET inject_retry_errors_enabled = true`)
+			require.NoError(t, err)
+		}()
+
+		_, err = conn.ExecContext(ctx, `SET inject_retry_errors_enabled = false`)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, `SET allow_unsafe_internals = true;
+BEGIN;
+DECLARE held_control CURSOR WITH HOLD FOR SELECT * FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8));
+DECLARE held_retry CURSOR WITH HOLD FOR SELECT * FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8));
+COMMIT;
+`)
+		require.NoError(t, err)
+
+		control := queryInts(t, conn, `
+BEGIN;
+FETCH 2 FROM held_control;
+SELECT crdb_internal.force_retry(0);
+COMMIT;
+`)
+		require.Equal(t, []int{1, 2, 0}, control)
+		retried := queryInts(t, conn, `
+BEGIN;
+FETCH 2 FROM held_retry;
+SELECT crdb_internal.force_retry(3);
+COMMIT;
+`)
+		require.Equal(t, control, retried)
+		retried = queryInts(t, conn, `
+BEGIN;
+FETCH 2 FROM held_retry;
+SELECT crdb_internal.force_retry(3);
+COMMIT;
+`)
+		require.Equal(t, []int{3, 4, 0}, retried)
+
+		saved := queryInts(t, conn, `
+BEGIN;
+DECLARE saved CURSOR FOR SELECT * FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8));
+SAVEPOINT s;
+FETCH 2 FROM saved;
+SELECT crdb_internal.force_retry(3);
+COMMIT;
+`)
+		require.Equal(t, []int{1, 2, 0}, saved)
+	})
+
+	t.Run("cursor_close_txn_rewind", func(t *testing.T) {
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		defer func() {
+			_, err := conn.ExecContext(ctx, `SET inject_retry_errors_enabled = true`)
+			require.NoError(t, err)
+		}()
+
+		_, err = conn.ExecContext(ctx, `SET inject_retry_errors_enabled = false`)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, `SET allow_unsafe_internals = true;
+BEGIN;
+DECLARE held_close CURSOR WITH HOLD FOR SELECT 1;
+COMMIT;
+`)
+		require.NoError(t, err)
+		closed := queryInts(t, conn, `
+BEGIN;
+CLOSE held_close;
+SELECT crdb_internal.force_retry(3);
+COMMIT;
+`)
+		require.Equal(t, []int{0}, closed)
+	})
+
+	t.Run("read_committed_cursor", func(t *testing.T) {
+		readCommittedStmtRetries.Store(0)
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		defer conn.Close()
+		defer func() {
+			_, err := conn.ExecContext(ctx, `SET inject_retry_errors_enabled = true`)
+			require.NoError(t, err)
+		}()
+
+		_, err = conn.ExecContext(ctx, `SET inject_retry_errors_enabled = false`)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, `BEGIN ISOLATION LEVEL READ COMMITTED;
+DECLARE control CURSOR FOR SELECT * FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8));
+DECLARE retried CURSOR FOR SELECT * FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8));
+`)
+		require.NoError(t, err)
+		control := queryInts(t, conn, `FETCH 2 FROM control`)
+		require.Equal(t, []int{1, 2}, control)
+
+		_, err = conn.ExecContext(ctx, `SET inject_retry_errors_enabled = true`)
+		require.NoError(t, err)
+		retried := queryInts(t, conn, `FETCH 2 FROM retried`)
+		require.Equal(t, control, retried)
+		require.Equal(t, int64(3), readCommittedStmtRetries.Load())
+
+		_, err = conn.ExecContext(ctx, `
+SET inject_retry_errors_enabled = false;
+CLOSE ALL;
+COMMIT;
+`)
+		require.NoError(t, err)
 	})
 
 	t.Run("read_committed_txn_retries_exceeded", func(t *testing.T) {

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -129,7 +129,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				// This case shouldn't happen because cursor names are scoped to a session,
 				// and sessions can't have more than one statement running at once. But
 				// let's be diligent and clean up if it somehow does happen anyway.
-				_ = cursor.Close()
+				_ = cursor.Rows.Close()
 				return nil, err
 			}
 			return newZeroNode(nil /* columns */), nil
@@ -175,8 +175,8 @@ type fetchNode struct {
 	fetchMoveNodeBase
 }
 
-func (f *fetchNode) startExec(_ runParams) error {
-	return f.startInternal()
+func (f *fetchNode) startExec(params runParams) error {
+	return f.startInternal(params.p)
 }
 
 func (f *fetchNode) Next(params runParams) (bool, error) {
@@ -197,7 +197,7 @@ type moveNode struct {
 }
 
 func (m *moveNode) startExec(params runParams) error {
-	if err := m.startInternal(); err != nil {
+	if err := m.startInternal(params.p); err != nil {
 		return err
 	}
 	// Execute the move to completion, keeping track of the affected row count.
@@ -261,7 +261,15 @@ func (b *fetchMoveNodeBase) init(p *planner, s *tree.CursorStmt) error {
 	return nil
 }
 
-func (b *fetchMoveNodeBase) startInternal() error {
+func (b *fetchMoveNodeBase) startInternal(p *planner) error {
+	// A checkpointed lazy iterator cannot seek backwards. Materialize it before
+	// advancing so an automatic retry can restore its exact position.
+	if !b.cursor.persisted && b.cursor.refCount > 1 {
+		if err := persistCursor(p, b.cursor); err != nil {
+			b.cursor.retryUnsafe = true
+			return err
+		}
+	}
 	if !b.cursor.persisted {
 		// We need to make sure that we're reading at the same read sequence number
 		// that we had when we created the cursor, to preserve the "sensitivity"
@@ -380,7 +388,7 @@ func (p *planner) PLpgSQLFetchCursor(
 	if err = cursor.init(p, cursorStmt); err != nil {
 		return nil, err
 	}
-	if err = cursor.startInternal(); err != nil {
+	if err = cursor.startInternal(p); err != nil {
 		return nil, err
 	}
 	defer cursor.close(ctx)
@@ -395,6 +403,9 @@ func (p *planner) PLpgSQLFetchCursor(
 
 type sqlCursor struct {
 	isql.Rows
+	// refCount includes the live cursor map and retry snapshots. The underlying
+	// rows are closed only after neither can restore the cursor.
+	refCount int
 	// txn is the transaction object that the internal executor for this cursor
 	// is running with.
 	txn *kv.Txn
@@ -405,6 +416,9 @@ type sqlCursor struct {
 	created    time.Time
 	curRow     int64
 	withHold   bool
+	// retryUnsafe is set if making a lazy cursor rewindable failed after
+	// consuming it. Such an error must be returned instead of retried.
+	retryUnsafe bool
 	// persisted indicates that the cursor's query was executed to completion and
 	// the result stored in a row container. If true, there is no need to set the
 	// transaction sequence number, since the query is no longer active.
@@ -416,6 +430,21 @@ type sqlCursor struct {
 	// WITH HOLD. It is used to ensure that aborting a transaction only closes
 	// cursors that were opened by that transaction.
 	committed bool
+}
+
+func (s *sqlCursor) retain() {
+	s.refCount++
+}
+
+func (s *sqlCursor) release() error {
+	if s.refCount <= 0 {
+		return errors.AssertionFailedf("released SQL cursor without a reference")
+	}
+	s.refCount--
+	if s.refCount == 0 {
+		return s.Rows.Close()
+	}
+	return nil
 }
 
 // Next implements the Rows interface.
@@ -491,6 +520,101 @@ type cursorMap struct {
 	nameCounter int
 }
 
+type sqlCursorSnapshotEntry struct {
+	cursor    *sqlCursor
+	curRow    int64
+	persisted bool
+	position  persistedCursorPosition
+}
+
+// sqlCursorSnapshot retains the cursor resources needed to undo cursor
+// mutations when an automatically retried statement or transaction is replayed.
+type sqlCursorSnapshot struct {
+	cursors     map[tree.Name]sqlCursorSnapshotEntry
+	nameCounter int
+}
+
+func (c *cursorMap) snapshot() (sqlCursorSnapshot, error) {
+	s := sqlCursorSnapshot{
+		cursors:     make(map[tree.Name]sqlCursorSnapshotEntry, len(c.cursors)),
+		nameCounter: c.nameCounter,
+	}
+	for name, cursor := range c.cursors {
+		var position persistedCursorPosition
+		if cursor.persisted {
+			rows, ok := cursor.Rows.(rewindableCursorRows)
+			if !ok {
+				_ = s.close()
+				return sqlCursorSnapshot{}, errors.AssertionFailedf(
+					"cannot checkpoint persisted SQL cursor %q", name,
+				)
+			}
+			position = rows.cursorPosition()
+		}
+		cursor.retain()
+		s.cursors[name] = sqlCursorSnapshotEntry{
+			cursor:    cursor,
+			curRow:    cursor.curRow,
+			persisted: cursor.persisted,
+			position:  position,
+		}
+	}
+	return s, nil
+}
+
+func (s *sqlCursorSnapshot) close() error {
+	var retErr error
+	for _, entry := range s.cursors {
+		retErr = errors.CombineErrors(retErr, entry.cursor.release())
+	}
+	s.cursors = nil
+	return retErr
+}
+
+func (s *sqlCursorSnapshot) canRewind() bool {
+	for _, entry := range s.cursors {
+		if entry.cursor.retryUnsafe ||
+			(!entry.persisted && !entry.cursor.persisted && entry.cursor.curRow != entry.curRow) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *cursorMap) rewind(s *sqlCursorSnapshot) error {
+	if !s.canRewind() {
+		return errors.AssertionFailedf("cannot rewind a consumed lazy SQL cursor")
+	}
+	for _, entry := range s.cursors {
+		if !entry.persisted && !entry.cursor.persisted {
+			continue
+		}
+		entry.cursor.curRow = entry.curRow
+		position := entry.position
+		if !entry.persisted {
+			position = persistedCursorPosition{}
+		}
+		if err := entry.cursor.Rows.(rewindableCursorRows).rewindCursor(position); err != nil {
+			return err
+		}
+	}
+
+	newCursors := make(map[tree.Name]*sqlCursor, len(s.cursors))
+	for name, entry := range s.cursors {
+		entry.cursor.retain()
+		newCursors[name] = entry.cursor
+	}
+	oldCursors := c.cursors
+	c.cursors = newCursors
+	c.nameCounter = s.nameCounter
+
+	var retErr error
+	for _, cursor := range oldCursors {
+		retErr = errors.CombineErrors(retErr, cursor.release())
+	}
+	return retErr
+}
+
 type cursorCloseReason uint8
 
 const (
@@ -516,7 +640,7 @@ func (c *cursorMap) closeAll(p *planner, reason cursorCloseReason) error {
 	// Close the cursor iterators/containers. Make sure to continue closing even
 	// if one of them fails.
 	var retErr error
-	for _, curs := range c.cursors {
+	for n, curs := range c.cursors {
 		if reason != cursorCloseForExplicitClose && curs.committed {
 			// A holdable cursor from a previously committed transaction should remain
 			// open, except for a session close.
@@ -539,7 +663,10 @@ func (c *cursorMap) closeAll(p *planner, reason cursorCloseReason) error {
 				err,
 			)
 		}
-		retErr = errors.CombineErrors(retErr, curs.Close())
+		retErr = errors.CombineErrors(retErr, curs.release())
+		// Remove the map's ownership immediately so recursive error cleanup does
+		// not release the same reference a second time.
+		delete(c.cursors, n)
 	}
 	if reason == cursorCloseForTxnCommit && retErr != nil {
 		return errors.CombineErrors(retErr, c.closeAll(p, cursorCloseForTxnRollback))
@@ -569,7 +696,7 @@ func (c *cursorMap) closeCursor(s tree.Name) error {
 	if !ok {
 		return pgerror.Newf(pgcode.InvalidCursorName, "cursor %q does not exist", s)
 	}
-	err := cursor.Close()
+	err := cursor.release()
 	delete(c.cursors, s)
 	return err
 }
@@ -585,6 +712,7 @@ func (c *cursorMap) addCursor(s tree.Name, cursor *sqlCursor) error {
 	if _, ok := c.cursors[s]; ok {
 		return pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", s)
 	}
+	cursor.retain()
 	c.cursors[s] = cursor
 	return nil
 }
@@ -653,6 +781,14 @@ func (p *planner) checkNoConflictingCursors(stmt tree.Statement) error {
 // persistCursor runs the given cursor to completion and stores the result in a
 // row container that can outlive the cursor's transaction.
 func persistCursor(p *planner, cursor *sqlCursor) (retErr error) {
+	curRow := cursor.curRow
+	origTxnSeqNum := cursor.txn.GetReadSeqNum()
+	if err := cursor.txn.SetReadSeqNum(cursor.readSeqNum); err != nil {
+		return err
+	}
+	defer func() {
+		retErr = errors.CombineErrors(retErr, cursor.txn.SetReadSeqNum(origTxnSeqNum))
+	}()
 	// Use context.Background() because the cursor can outlive the context in
 	// which it was created.
 	helper := persistedCursorHelper{
@@ -660,9 +796,12 @@ func persistCursor(p *planner, cursor *sqlCursor) (retErr error) {
 		resultCols:   cursor.Types(),
 		rowsAffected: cursor.RowsAffected(),
 	}
-	mon := p.sessionMonitor
-	if mon == nil {
-		return errors.AssertionFailedf("cannot persist cursor without an active session")
+	mon := p.TxnMon()
+	if cursor.withHold {
+		mon = p.sessionMonitor
+		if mon == nil {
+			return errors.AssertionFailedf("cannot persist cursor without an active session")
+		}
 	}
 	helper.container.InitWithParentMon(
 		helper.ctx,
@@ -694,6 +833,7 @@ func persistCursor(p *planner, cursor *sqlCursor) (retErr error) {
 		return err
 	}
 	cursor.Rows = &helper
+	cursor.curRow = curRow
 	cursor.persisted = true
 	return nil
 }
@@ -710,6 +850,17 @@ type persistedCursorHelper struct {
 	resultCols   colinfo.ResultColumns
 	lastRow      tree.Datums
 	rowsAffected int
+	position     int64
+}
+
+type persistedCursorPosition struct {
+	position     int64
+	rowsAffected int
+}
+
+type rewindableCursorRows interface {
+	cursorPosition() persistedCursorPosition
+	rewindCursor(persistedCursorPosition) error
 }
 
 var _ isql.Rows = &persistedCursorHelper{}
@@ -725,7 +876,35 @@ func (h *persistedCursorHelper) Next(_ context.Context) (bool, error) {
 	h.lastRow = make(tree.Datums, len(row))
 	copy(h.lastRow, row)
 	h.rowsAffected++
+	h.position++
 	return true, nil
+}
+
+func (h *persistedCursorHelper) cursorPosition() persistedCursorPosition {
+	return persistedCursorPosition{position: h.position, rowsAffected: h.rowsAffected}
+}
+
+func (h *persistedCursorHelper) rewindCursor(position persistedCursorPosition) error {
+	if h.iter != nil {
+		h.iter.Close()
+	}
+	h.iter = newRowContainerIterator(h.ctx, h.container)
+	h.lastRow = nil
+	h.rowsAffected = 0
+	h.position = 0
+	for h.position < position.position {
+		more, err := h.Next(h.ctx)
+		if err != nil {
+			return err
+		}
+		if !more {
+			return errors.AssertionFailedf(
+				"cannot restore SQL cursor to row %d", position.position,
+			)
+		}
+	}
+	h.rowsAffected = position.rowsAffected
+	return nil
 }
 
 // Cur implements the isql.Rows interface.


### PR DESCRIPTION
Fixes #173505.

## Problem

SQL cursors are mutable session state, but their membership and iterator position were not part of either automatic-retry checkpoint:

- a serializable transaction rewind restored the statement buffer, prepared-statement namespace, savepoints, session data, and advisory locks, but not `sqlCursors`;
- a READ COMMITTED statement retry rolled back the KV savepoint and discarded buffered results, but left cursor state at the position reached by the failed attempt.

As a result, replaying `FETCH` or `MOVE` consumed rows twice, while replaying `CLOSE` failed because the first attempt had already removed and destroyed the cursor.

## Solution

Snapshot cursor-map membership and the logical/persisted iterator position together with the existing rewindable state. Cursor resources are retained while a snapshot owns them, so a replayed `CLOSE` can be undone safely. Whole-transaction rewinds restore the transaction snapshot, and READ COMMITTED retries restore a statement-local snapshot after rolling back the KV savepoint.

Lazy cursors remain lazy at `DECLARE`. Immediately before a protected `FETCH` or `MOVE`, the cursor iterator is made seekable so its exact position can be restored. If that conversion fails before the cursor becomes rewindable, CockroachDB now returns the retry error instead of transparently replaying from corrupted cursor state.

## Testing

Added regression coverage for:

- a held cursor `FETCH` with no retry versus three transaction retries;
- a second retry from a non-zero cursor position;
- replaying `CLOSE` on a held cursor;
- rebuilding an ordinary cursor declared before a savepoint;
- a READ COMMITTED `FETCH` with no retry versus exactly three statement retries.

The full sharded `//pkg/sql:sql_test` target and the cursor-related local and local-read-committed logic tests pass.

Release note (bug fix): Automatic transaction and READ COMMITTED statement retries no longer advance or close SQL cursors more than once.
