### PR TITLE
sql: track cursors across savepoint rollback

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1769,6 +1769,12 @@ type connExecutor struct {
 		// and are destroyed when the transaction finishes.
 		sqlCursors cursorMap
 
+		// preserveCursorsOnTxnRestart is set when rolling back to an initial SQL
+		// savepoint. Cursors created after the savepoint have already been closed,
+		// so resetExtraTxnState must preserve the remaining cursors during the
+		// resulting transaction restart.
+		preserveCursorsOnTxnRestart bool
+
 		// shouldExecuteOnTxnFinish indicates that ex.onTxnFinish will be called
 		// when txn is finished (either committed or aborted). It is true when
 		// txn is started but can remain false when txn is executed within
@@ -2282,6 +2288,8 @@ func (ns *prepStmtNamespace) rewind(
 // The payload error is included for statistics recording.
 // (e.g. onTxnFinish() and onTxnRestart()).
 func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, payloadErr error) {
+	preserveCursors := ev.eventType == txnRestart && ex.extraTxnState.preserveCursorsOnTxnRestart
+	ex.extraTxnState.preserveCursorsOnTxnRestart = false
 	ex.extraTxnState.numDDL = 0
 	ex.extraTxnState.firstStmtExecuted = false
 	ex.extraTxnState.upgradedToSerializable = false
@@ -2330,8 +2338,10 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, pay
 	default:
 		closeReason = cursorCloseForTxnRollback
 	}
-	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, closeReason); err != nil {
-		log.Dev.Warningf(ctx, "error closing cursors: %v", err)
+	if !preserveCursors {
+		if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, closeReason); err != nil {
+			log.Dev.Warningf(ctx, "error closing cursors: %v", err)
+		}
 	}
 
 	switch ev.eventType {

--- a/pkg/sql/conn_executor_savepoints.go
+++ b/pkg/sql/conn_executor_savepoints.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -18,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // commitOnReleaseSavepointName is the name of the savepoint with special
@@ -97,10 +99,11 @@ func (ex *connExecutor) execSavepointInOpenState(
 	}
 
 	sp := savepoint{
-		name:            s.Name,
-		commitOnRelease: commitOnRelease,
-		kvToken:         token,
-		numDDL:          ex.extraTxnState.numDDL,
+		name:               s.Name,
+		commitOnRelease:    commitOnRelease,
+		kvToken:            token,
+		numDDL:             ex.extraTxnState.numDDL,
+		cursorCreationTime: timeutil.Now(),
 	}
 	savepoints.push(sp)
 	ex.sessionDataStack.PushTopClone()
@@ -231,8 +234,14 @@ func (ex *connExecutor) execRollbackToSavepointInOpenState(
 			return ex.makeErrEvent(err, s)
 		}
 	}
+	if err := ex.extraTxnState.sqlCursors.closeCursorsCreatedAfter(
+		entry.cursorCreationTime,
+	); err != nil {
+		return ex.makeErrEvent(err, s)
+	}
 
 	if entry.kvToken.Initial() {
+		ex.extraTxnState.preserveCursorsOnTxnRestart = true
 		return eventTxnRestart{}, nil
 	}
 
@@ -318,8 +327,14 @@ func (ex *connExecutor) execRollbackToSavepointInAbortedState(
 			return ex.makeErrEvent(err, s)
 		}
 	}
+	if err := ex.extraTxnState.sqlCursors.closeCursorsCreatedAfter(
+		entry.cursorCreationTime,
+	); err != nil {
+		return ex.makeErrEvent(err, s)
+	}
 
 	if entry.kvToken.Initial() {
+		ex.extraTxnState.preserveCursorsOnTxnRestart = true
 		return eventTxnRestart{}, nil
 	}
 	return eventSavepointRollback{}, nil
@@ -382,6 +397,10 @@ type savepoint struct {
 	// more DDL statements were executed since the savepoint's creation.
 	// TODO(knz): support partial DDL cancellation in pending txns.
 	numDDL int
+
+	// cursorCreationTime identifies cursors opened after the savepoint. Those
+	// cursors are closed when the savepoint is rolled back.
+	cursorCreationTime time.Time
 }
 
 type savepointStack []savepoint

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -827,6 +827,103 @@ DROP TABLE t
 
 subtest end
 
+# Regression test for cursors not participating in SQL savepoint rollback
+# (#173449).
+subtest regression_173449
+
+statement ok
+CREATE TABLE savepoint_cursor (x INT PRIMARY KEY);
+INSERT INTO savepoint_cursor VALUES (0);
+
+# A non-initial savepoint should close a cursor declared after it, so that the
+# cursor cannot expose writes that were rolled back. A cursor declared before
+# the savepoint should remain open at its current position.
+statement ok
+BEGIN;
+DECLARE before_savepoint CURSOR FOR SELECT * FROM generate_series(1, 4);
+
+query I nosort
+FETCH 2 FROM before_savepoint;
+----
+1
+2
+
+query I nosort
+SELECT count(*) FROM savepoint_cursor;
+----
+1
+
+statement ok
+SAVEPOINT s;
+INSERT INTO savepoint_cursor VALUES (1);
+DECLARE after_savepoint CURSOR FOR SELECT x FROM savepoint_cursor ORDER BY x;
+
+statement ok
+ROLLBACK TO SAVEPOINT s;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+before_savepoint
+
+query I
+SELECT x FROM savepoint_cursor ORDER BY x;
+----
+0
+
+query I nosort
+FETCH ALL FROM before_savepoint;
+----
+3
+4
+
+statement error pgcode 34000 pq: cursor "after_savepoint" does not exist
+FETCH ALL FROM after_savepoint;
+
+statement ok
+ROLLBACK;
+
+# Rolling back to an initial savepoint restarts the KV transaction internally,
+# but should not close a cursor that was declared before the savepoint.
+statement ok
+BEGIN;
+DECLARE before_initial_savepoint CURSOR FOR SELECT * FROM generate_series(1, 4);
+
+query I nosort
+FETCH 2 FROM before_initial_savepoint;
+----
+1
+2
+
+statement ok
+SAVEPOINT initial_s;
+DECLARE after_initial_savepoint CURSOR FOR SELECT * FROM generate_series(1, 2);
+
+statement ok
+ROLLBACK TO SAVEPOINT initial_s;
+
+query T rowsort
+SELECT name FROM pg_cursors;
+----
+before_initial_savepoint
+
+query I nosort
+FETCH 2 FROM before_initial_savepoint;
+----
+3
+4
+
+statement error pgcode 34000 pq: cursor "after_initial_savepoint" does not exist
+FETCH ALL FROM after_initial_savepoint;
+
+statement ok
+ROLLBACK;
+
+statement ok
+DROP TABLE savepoint_cursor;
+
+subtest end
+
 subtest regression
 
 # Regression test for using a SQL cursor that buffers a notice.

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -574,6 +574,16 @@ func (c *cursorMap) closeCursor(s tree.Name) error {
 	return err
 }
 
+func (c *cursorMap) closeCursorsCreatedAfter(created time.Time) error {
+	var retErr error
+	for name, cursor := range c.cursors {
+		if cursor.created.After(created) {
+			retErr = errors.CombineErrors(retErr, c.closeCursor(name))
+		}
+	}
+	return retErr
+}
+
 func (c *cursorMap) getCursor(s tree.Name) *sqlCursor {
 	return c.cursors[s]
 }


### PR DESCRIPTION
Fixes #173449.

SQL savepoints currently do not track cursor lifecycle state. This change records a cursor creation boundary on each SQL savepoint, closes cursors created after that boundary when it is rolled back, and preserves earlier cursors during the transaction restart used for an initial savepoint.

Tests:
- Added a cursor logic-test regression covering initial and non-initial savepoints, cursors opened before and after each savepoint, preservation of cursor position, and prevention of reads from rolled-back writes.
- Ran the regression in all 13 default logic-test configurations.
- Ran the complete local and local-read-committed cursor suites.
- Ran the full 16-shard //pkg/sql:sql_test target.

Release note (bug fix): ROLLBACK TO SAVEPOINT now closes cursors opened after the savepoint and preserves cursors opened before it.