### PR TITLE
sql: preserve explicit ROW constructors during tuple flattening

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,44 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+subtest regression_173264
+
+statement ok
+CREATE TABLE t173264 (a INT, b INT);
+INSERT INTO t173264 VALUES (1, 10), (1, 20), (2, 30);
+
+# ROW() is a constant composite key, so it produces no group for empty input.
+query I
+SELECT count(*) FROM t173264 WHERE false GROUP BY ROW();
+----
+
+# The empty grouping set has scalar aggregation semantics and always produces
+# one group.
+query I
+SELECT count(*) FROM t173264 WHERE false GROUP BY ();
+----
+0
+
+# An explicit ROW is one composite key, so its fields are not grouped
+# individually, even when it is nested inside a parenthesized grouping list.
+query error pgcode 42803 column "a" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT a FROM t173264 GROUP BY ROW(a, b)
+
+query error pgcode 42803 column "b" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT b FROM t173264 GROUP BY (a, ROW(b))
+
+# Syntactic parenthesized lists continue to flatten recursively.
+query II rowsort
+SELECT a, b FROM t173264 GROUP BY (a, (b))
+----
+1  10
+1  20
+2  30
+
+# Grouping and projecting the complete composite key remains valid.
+query TI rowsort
+SELECT ROW(a), count(*) FROM t173264 GROUP BY ROW(a)
+----
+(1)  2
+(2)  1

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -388,12 +388,13 @@ func makeBackfillError(name tree.Name) error {
 		"column %q is being backfilled", tree.ErrString(&name))
 }
 
-// flattenTuples extracts the members of tuples into a list of columns.
+// flattenTuples extracts the members of syntactic parenthesized lists into a
+// list of columns. Explicit ROW constructors remain scalar expressions.
 func flattenTuples(exprs []tree.TypedExpr) []tree.TypedExpr {
 	// We want to avoid allocating new slices unless strictly necessary.
 	var newExprs []tree.TypedExpr
 	for i, e := range exprs {
-		if t, ok := e.(*tree.Tuple); ok {
+		if t, ok := e.(*tree.Tuple); ok && !t.Row {
 			if newExprs == nil {
 				// All right, it was necessary to allocate the slices after all.
 				newExprs = make([]tree.TypedExpr, i, len(exprs))
@@ -411,11 +412,11 @@ func flattenTuples(exprs []tree.TypedExpr) []tree.TypedExpr {
 	return exprs
 }
 
-// flattenTuple recursively extracts the members of a tuple into a list of
-// expressions.
+// flattenTuple recursively extracts the members of a parenthesized list into
+// a list of expressions, preserving explicit ROW constructors.
 func flattenTuple(t *tree.Tuple, exprs []tree.TypedExpr) []tree.TypedExpr {
 	for _, e := range t.Exprs {
-		if eT, ok := e.(*tree.Tuple); ok {
+		if eT, ok := e.(*tree.Tuple); ok && !eT.Row {
 			exprs = flattenTuple(eT, exprs)
 		} else {
 			expr := e.(tree.TypedExpr)

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -821,9 +821,9 @@ type Tuple struct {
 	Exprs  Exprs
 	Labels []string
 
-	// Row indicates whether `ROW` was used in the input syntax. This is
-	// used solely to generate column names automatically, see
-	// col_name.go.
+	// Row indicates whether `ROW` was used in the input syntax. It distinguishes
+	// explicit row constructors from syntactic parenthesized lists during clause
+	// expansion and is used to generate column names automatically.
 	Row bool
 
 	typ *types.T


### PR DESCRIPTION
## Summary

Fixes #173264.

Explicit ROW constructors are scalar composite expressions, but clause tuple flattening treated them like syntactic parenthesized expression lists. This caused two incorrect GROUP BY behaviors:

- GROUP BY ROW() on empty input became an empty grouping set, selected scalar aggregation, and returned one row containing count 0 instead of returning no groups.
- GROUP BY ROW(a, b) exposed a and b as individual grouping columns, so ungrouped references to either field were incorrectly accepted.

Syntactic lists such as GROUP BY (a, b) still need to flatten recursively, so the fix must retain the parser distinction between those lists and explicit ROW constructors.

## Root cause

The parser already records this distinction in tree.Tuple.Row: explicit ROW(...) syntax sets Row to true, while a parenthesized list leaves it false.

After type resolution, optbuilder calls flattenTuples while expanding GROUP BY and related clause expression lists. Both flattenTuples and its recursive helper previously expanded every tree.Tuple without consulting Row. Consequently:

- ROW() contributed zero grouping expressions and buildGrouping constructed a scalar-group-by operator with cardinality [1-1].
- ROW(a, b) contributed two independent grouping expressions, incorrectly registering both child columns as grouped.

The semantic distinction was therefore lost during optbuilder clause expansion, before physical planning or aggregate execution.

## Fix

Tuple flattening now checks Tuple.Row at both the top-level and recursive boundaries:

- Parenthesized expression lists continue to flatten recursively.
- Explicit ROW constructors remain a single scalar expression, including when nested inside a parenthesized list.
- The Tuple.Row field documentation now records its clause-expansion responsibility.

Because the helper is shared by GROUP BY, statement ORDER BY, aggregate-internal ORDER BY, and window PARTITION BY / ORDER BY processing, this preserves the same explicit-ROW boundary consistently across all callers.

## Tests

Added a regression subtest covering:

- Empty-input GROUP BY ROW() versus the true empty grouping set GROUP BY ().
- GROUP BY ROW(a, b) rejecting an ungrouped child reference with SQLSTATE 42803.
- A nested explicit ROW inside a parenthesized grouping list.
- Continued recursive flattening of syntactic parenthesized lists.
- Valid grouping and projection of the complete composite key.

Validation included the regression in all 12 applicable logic-test configurations, the complete local aggregate logic file, and the full optbuilder data-driven test suite.

Release note (bug fix): GROUP BY now treats explicit ROW(...) constructors as single composite grouping expressions.