### PR TITLE
sql: stabilize decimal SQRDIFF with large offsets

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,37 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+subtest regression_173065
+
+statement ok
+SET distsql = always;
+SET vectorize = off;
+CREATE TABLE t173065 (
+  i INT PRIMARY KEY,
+  d DECIMAL NOT NULL
+);
+INSERT INTO t173065 VALUES (1, 99999999999999999999.9999999999);
+
+query R
+SELECT sqrdiff(d) FROM t173065;
+----
+0
+
+statement ok
+INSERT INTO t173065
+SELECT i, 99999999999999999999.9999999999::DECIMAL
+FROM generate_series(2, 10) AS g(i);
+
+query R
+SELECT sqrdiff(d) FROM t173065;
+----
+0
+
+statement ok
+INSERT INTO t173065 VALUES (11, 99999999999999997999.9999999999);
+
+query R
+SELECT round(sqrdiff(d), 12) FROM t173065;
+----
+3636363.636363636364

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -4109,10 +4109,12 @@ type decimalSqrDiffAggregate struct {
 	count   apd.Decimal
 	mean    apd.Decimal
 	sqrDiff apd.Decimal
+	offset  apd.Decimal
 
 	// Variables used as scratch space within iterations.
 	delta apd.Decimal
 	tmp   apd.Decimal
+	value apd.Decimal
 }
 
 func newDecimalSqrDiff(evalCtx *eval.Context) decimalSqrDiff {
@@ -4147,22 +4149,32 @@ func (a *decimalSqrDiffAggregate) Add(
 	}
 	d := &datum.(*tree.DDecimal).Decimal
 
+	// Center the inputs around the first value. Variance is invariant under
+	// translation, and centering prevents a large common offset from consuming
+	// the precision needed for differences between the values.
+	if a.count.IsZero() {
+		a.offset.Set(d)
+	}
+	a.ed.Sub(&a.value, d, &a.offset)
+
 	// Uses the Knuth/Welford method for accurately computing squared difference online in a
 	// single pass. Refer to squared difference calculations
 	// in http://www.johndcook.com/blog/standard_deviation/ and
 	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
 	a.ed.Add(&a.count, &a.count, decimalOne)
-	a.ed.Sub(&a.delta, d, &a.mean)
+	a.ed.Sub(&a.delta, &a.value, &a.mean)
 	a.ed.Quo(&a.tmp, &a.delta, &a.count)
 	a.ed.Add(&a.mean, &a.mean, &a.tmp)
-	a.ed.Sub(&a.tmp, d, &a.mean)
+	a.ed.Sub(&a.tmp, &a.value, &a.mean)
 	a.ed.Add(&a.sqrDiff, &a.sqrDiff, a.ed.Mul(&a.delta, &a.delta, &a.tmp))
 
 	size := int64(a.count.Size() +
 		a.mean.Size() +
 		a.sqrDiff.Size() +
+		a.offset.Size() +
 		a.delta.Size() +
-		a.tmp.Size())
+		a.tmp.Size() +
+		a.value.Size())
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
 		return err
 	}
@@ -4192,6 +4204,8 @@ func (a *decimalSqrDiffAggregate) Reset(ctx context.Context) {
 	a.count.SetInt64(0)
 	a.mean.SetInt64(0)
 	a.sqrDiff.SetInt64(0)
+	a.offset.SetInt64(0)
+	a.value.SetInt64(0)
 	a.reset(ctx)
 }
 
@@ -4303,12 +4317,14 @@ type decimalSumSqrDiffsAggregate struct {
 	count   apd.Decimal
 	mean    apd.Decimal
 	sqrDiff apd.Decimal
+	offset  apd.Decimal
 
 	// Variables used as scratch space within iterations.
-	tmpCount apd.Decimal
-	tmpMean  apd.Decimal
-	delta    apd.Decimal
-	tmp      apd.Decimal
+	tmpCount    apd.Decimal
+	tmpMean     apd.Decimal
+	centeredSum apd.Decimal
+	delta       apd.Decimal
+	tmp         apd.Decimal
 }
 
 func newDecimalSumSqrDiffs(evalCtx *eval.Context) decimalSqrDiff {
@@ -4341,7 +4357,21 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	sum := &sumD.(*tree.DDecimal).Decimal
 	a.tmpCount.SetInt64(int64(*countD.(*tree.DInt)))
 
-	a.ed.Quo(&a.tmpMean, sum, &a.tmpCount)
+	// Use the first partial mean as a common offset, then center every partial
+	// sum before dividing. The exact multiply and subtract preserve differences
+	// that would be lost by subtracting two independently rounded large means.
+	if a.count.IsZero() {
+		if _, err := tree.IntermediateCtx.Quo(&a.offset, sum, &a.tmpCount); err != nil {
+			return err
+		}
+	}
+	if _, err := tree.ExactCtx.Mul(&a.centeredSum, &a.offset, &a.tmpCount); err != nil {
+		return err
+	}
+	if _, err := tree.ExactCtx.Sub(&a.centeredSum, sum, &a.centeredSum); err != nil {
+		return err
+	}
+	a.ed.Quo(&a.tmpMean, &a.centeredSum, &a.tmpCount)
 	a.ed.Sub(&a.delta, &a.tmpMean, &a.mean)
 
 	// Compute the sum of Knuth/Welford sum of squared differences from the
@@ -4377,8 +4407,10 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	size := int64(a.count.Size() +
 		a.mean.Size() +
 		a.sqrDiff.Size() +
+		a.offset.Size() +
 		a.tmpCount.Size() +
 		a.tmpMean.Size() +
+		a.centeredSum.Size() +
 		a.delta.Size() +
 		a.tmp.Size())
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
@@ -4405,6 +4437,8 @@ func (a *decimalSumSqrDiffsAggregate) Reset(ctx context.Context) {
 	a.count.SetInt64(0)
 	a.mean.SetInt64(0)
 	a.sqrDiff.SetInt64(0)
+	a.offset.SetInt64(0)
+	a.centeredSum.SetInt64(0)
 	a.reset(ctx)
 }
 

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -270,6 +270,69 @@ func TestSqrDiffDecimalResultDeepCopy(t *testing.T) {
 	testAggregateResultDeepCopy(t, newDecimalSqrDiffAggregate, makeDecimalTestDatum(10))
 }
 
+func TestDecimalSqrDiffLargeOffset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
+	acc := evalCtx.TestingMon.MakeBoundAccount()
+	defer acc.Close(ctx)
+	evalCtx.SingleDatumAggMemAccount = &acc
+
+	parseDecimal := func(t *testing.T, s string) tree.Datum {
+		t.Helper()
+		d, err := tree.ParseDDecimal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return d
+	}
+	run := func(
+		t *testing.T,
+		constructor func([]*types.T, *eval.Context, tree.Datums) eval.AggregateFunc,
+		inputs [][]tree.Datum,
+		expected string,
+	) {
+		t.Helper()
+		agg := constructor(nil, evalCtx, nil)
+		defer agg.Close(ctx)
+		for _, input := range inputs {
+			if err := agg.Add(ctx, input[0], input[1:]...); err != nil {
+				t.Fatal(err)
+			}
+		}
+		result, err := agg.Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual := result.String(); actual != expected {
+			t.Fatalf("expected %s, got %s", expected, actual)
+		}
+	}
+
+	const value = "99999999999999999999.9999999999"
+	t.Run("local singleton", func(t *testing.T) {
+		run(t, newDecimalSqrDiffAggregate, [][]tree.Datum{{parseDecimal(t, value)}}, "0")
+	})
+	t.Run("local nonzero", func(t *testing.T) {
+		inputs := make([][]tree.Datum, 0, 11)
+		for i := 0; i < 10; i++ {
+			inputs = append(inputs, []tree.Datum{parseDecimal(t, value)})
+		}
+		inputs = append(inputs, []tree.Datum{
+			parseDecimal(t, "99999999999999997999.9999999999"),
+		})
+		run(t, newDecimalSqrDiffAggregate, inputs, "3636363.6363636363636")
+	})
+	t.Run("final", func(t *testing.T) {
+		inputs := [][]tree.Datum{
+			{parseDecimal(t, "0"), parseDecimal(t, value), tree.NewDInt(1)},
+			{parseDecimal(t, "0"), parseDecimal(t, "99999999999999999999.9999999998"), tree.NewDInt(1)},
+		}
+		run(t, newDecimalFinalSqrdiffAggregate, inputs, "5E-21")
+	})
+}
+
 func TestVarPopIntResultDeepCopy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntVarPopAggregate, makeIntTestDatum(10))


### PR DESCRIPTION
Fixes #173065.

## Summary

`SQRDIFF` on high-precision `DECIMAL` inputs with a large common offset could
return a negative value. The magnitude depended on how many local aggregation
states the physical plan created, so equivalent distributed scan and join plans
could produce different answers.

This change keeps the existing Welford aggregation and distributed intermediate
state, but performs the calculation in coordinates centered around a stable
offset. It also adds focused coverage for local accumulation, final partial-state
merging, and SQL execution with forced DistSQL.

## Root cause

The decimal aggregate uses `tree.IntermediateCtx`, whose precision is 25
significant digits. For the reported value
`99999999999999999999.9999999999`, the first local Welford update previously
proceeded as follows:

1. `value - 0` was rounded to 25 significant digits while computing `delta`.
2. The running mean was set to that rounded value.
3. Subtracting the rounded mean from the original input left a residual of
   `-1E-10`.
4. Multiplying that residual by a delta of approximately `1E20` stored
   `-1E10` in the sum of squared differences.

The bad state was therefore created by the first local input, before partial
aggregation state was serialized. Each local aggregation state contributed one
such error, which explains why the distributed scan and lateral join plans in
the issue returned different negative multiples of `1E10`.

The final decimal SQRDIFF aggregate had a related precision problem. It derived
each partial mean as `sum / count` in `IntermediateCtx` and then subtracted the
independently rounded means. Two large partial means separated only in digits
beyond that context could become indistinguishable. For example, merging two
singleton states whose values differ by `1E-10` returned zero instead of the
correct `5E-21`.

Clamping a negative result to zero would hide the corrupted state and would
also be incorrect for inputs with a small, positive variance. Ten copies of the
reported value plus one value smaller by 2000 should produce
`3636363.6363636363636`, whereas the old implementation returned a negative
result.

## Fix

The local decimal accumulator now saves the first non-NULL input as an offset
and feeds `value - offset` into the existing Welford recurrence. Variance and
SQRDIFF are invariant under translation, so this preserves the result while
making the required precision depend on the spread of the inputs instead of
their absolute magnitude.

The final accumulator similarly chooses the first partial mean as a common
offset. For each partial state it computes

```
centeredSum = sum - offset * count
```

using `tree.ExactCtx`, and only then divides by the count in
`IntermediateCtx`. This retains low-order differences that would be lost by
subtracting separately rounded large means. The existing parallel Welford merge
then operates on those centered means.

The distributed `(sqrdiff, sum, count)` intermediate representation, aggregate
signatures, planner mappings, result rounding, float implementation, and integer
delegation are unchanged. The additional decimal fields are included in memory
accounting and reset with the rest of the accumulator state.

## Testing

Added `TestDecimalSqrDiffLargeOffset`, covering:

- a large singleton, whose SQRDIFF must be zero;
- the positive-variance case with a large common offset;
- final aggregation of two singleton partial states separated by `1E-10`.

Added the `regression_173065` SQL logic test with forced DistSQL, covering both
identical large values and the positive-variance case.

Validation included:

- the complete `//pkg/sql/sem/builtins:builtins_test` target;
- the regression across 12 local, fakedist, tenant, and mixed-version logic-test
  configurations;
- the complete aggregate logic test under local and fakedist configurations;
- the complete five-node `distsql_agg` logic suite;
- repeated three-node executions of the reported distributed scan and lateral
  merge-join plans.

After the change, the reported all-equal inputs return zero in every tested plan,
while the positive-variance case retains its nonzero result.

Release note (bug fix): Fixed SQRDIFF, VARIANCE, and standard-deviation
aggregates returning negative or plan-dependent results for high-precision
DECIMAL values with a large common offset.
