### PR TITLE
sql: stabilize decimal VARIANCE with large offsets

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,35 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+subtest regression_173063
+
+statement ok
+SET distsql = always;
+SET vectorize = on;
+CREATE TABLE t173063 (
+  i INT PRIMARY KEY,
+  d DECIMAL
+);
+INSERT INTO t173063
+SELECT i,
+       CASE WHEN i <= 2 THEN NULL ELSE 99999999999999999999.9999999999::DECIMAL END
+FROM generate_series(1, 12) AS g(i);
+
+query R
+SELECT variance(d) FROM t173063;
+----
+0
+
+query R
+SELECT variance(d - 99999999999999999999.9999999999::DECIMAL) FROM t173063;
+----
+0
+
+statement ok
+INSERT INTO t173063 VALUES (13, 99999999999999997999.9999999999);
+
+query R
+SELECT round(variance(d), 12) FROM t173063;
+----
+363636.363636363636

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -4109,10 +4109,12 @@ type decimalSqrDiffAggregate struct {
 	count   apd.Decimal
 	mean    apd.Decimal
 	sqrDiff apd.Decimal
+	offset  apd.Decimal
 
 	// Variables used as scratch space within iterations.
 	delta apd.Decimal
 	tmp   apd.Decimal
+	value apd.Decimal
 }
 
 func newDecimalSqrDiff(evalCtx *eval.Context) decimalSqrDiff {
@@ -4147,22 +4149,32 @@ func (a *decimalSqrDiffAggregate) Add(
 	}
 	d := &datum.(*tree.DDecimal).Decimal
 
+	// Center the inputs around the first value. Variance is invariant under
+	// translation, and centering prevents a large common offset from consuming
+	// the precision needed for differences between the values.
+	if a.count.IsZero() {
+		a.offset.Set(d)
+	}
+	a.ed.Sub(&a.value, d, &a.offset)
+
 	// Uses the Knuth/Welford method for accurately computing squared difference online in a
 	// single pass. Refer to squared difference calculations
 	// in http://www.johndcook.com/blog/standard_deviation/ and
 	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
 	a.ed.Add(&a.count, &a.count, decimalOne)
-	a.ed.Sub(&a.delta, d, &a.mean)
+	a.ed.Sub(&a.delta, &a.value, &a.mean)
 	a.ed.Quo(&a.tmp, &a.delta, &a.count)
 	a.ed.Add(&a.mean, &a.mean, &a.tmp)
-	a.ed.Sub(&a.tmp, d, &a.mean)
+	a.ed.Sub(&a.tmp, &a.value, &a.mean)
 	a.ed.Add(&a.sqrDiff, &a.sqrDiff, a.ed.Mul(&a.delta, &a.delta, &a.tmp))
 
 	size := int64(a.count.Size() +
 		a.mean.Size() +
 		a.sqrDiff.Size() +
+		a.offset.Size() +
 		a.delta.Size() +
-		a.tmp.Size())
+		a.tmp.Size() +
+		a.value.Size())
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
 		return err
 	}
@@ -4192,6 +4204,8 @@ func (a *decimalSqrDiffAggregate) Reset(ctx context.Context) {
 	a.count.SetInt64(0)
 	a.mean.SetInt64(0)
 	a.sqrDiff.SetInt64(0)
+	a.offset.SetInt64(0)
+	a.value.SetInt64(0)
 	a.reset(ctx)
 }
 
@@ -4303,12 +4317,14 @@ type decimalSumSqrDiffsAggregate struct {
 	count   apd.Decimal
 	mean    apd.Decimal
 	sqrDiff apd.Decimal
+	offset  apd.Decimal
 
 	// Variables used as scratch space within iterations.
-	tmpCount apd.Decimal
-	tmpMean  apd.Decimal
-	delta    apd.Decimal
-	tmp      apd.Decimal
+	tmpCount    apd.Decimal
+	tmpMean     apd.Decimal
+	centeredSum apd.Decimal
+	delta       apd.Decimal
+	tmp         apd.Decimal
 }
 
 func newDecimalSumSqrDiffs(evalCtx *eval.Context) decimalSqrDiff {
@@ -4341,7 +4357,21 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	sum := &sumD.(*tree.DDecimal).Decimal
 	a.tmpCount.SetInt64(int64(*countD.(*tree.DInt)))
 
-	a.ed.Quo(&a.tmpMean, sum, &a.tmpCount)
+	// Use the first partial mean as a common offset, then center every partial
+	// sum before dividing. The exact multiply and subtract preserve differences
+	// that would be lost by subtracting two independently rounded large means.
+	if a.count.IsZero() {
+		if _, err := tree.IntermediateCtx.Quo(&a.offset, sum, &a.tmpCount); err != nil {
+			return err
+		}
+	}
+	if _, err := tree.ExactCtx.Mul(&a.centeredSum, &a.offset, &a.tmpCount); err != nil {
+		return err
+	}
+	if _, err := tree.ExactCtx.Sub(&a.centeredSum, sum, &a.centeredSum); err != nil {
+		return err
+	}
+	a.ed.Quo(&a.tmpMean, &a.centeredSum, &a.tmpCount)
 	a.ed.Sub(&a.delta, &a.tmpMean, &a.mean)
 
 	// Compute the sum of Knuth/Welford sum of squared differences from the
@@ -4377,8 +4407,10 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	size := int64(a.count.Size() +
 		a.mean.Size() +
 		a.sqrDiff.Size() +
+		a.offset.Size() +
 		a.tmpCount.Size() +
 		a.tmpMean.Size() +
+		a.centeredSum.Size() +
 		a.delta.Size() +
 		a.tmp.Size())
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
@@ -4405,6 +4437,8 @@ func (a *decimalSumSqrDiffsAggregate) Reset(ctx context.Context) {
 	a.count.SetInt64(0)
 	a.mean.SetInt64(0)
 	a.sqrDiff.SetInt64(0)
+	a.offset.SetInt64(0)
+	a.centeredSum.SetInt64(0)
 	a.reset(ctx)
 }
 

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -255,6 +255,72 @@ func TestVarianceDecimalResultDeepCopy(t *testing.T) {
 	testAggregateResultDeepCopy(t, newDecimalVarianceAggregate, makeDecimalTestDatum(10))
 }
 
+func TestDecimalVarianceLargeOffset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
+	acc := evalCtx.TestingMon.MakeBoundAccount()
+	defer acc.Close(ctx)
+	evalCtx.SingleDatumAggMemAccount = &acc
+
+	parseDecimal := func(t *testing.T, s string) tree.Datum {
+		t.Helper()
+		d, err := tree.ParseDDecimal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return d
+	}
+	run := func(
+		t *testing.T,
+		constructor func([]*types.T, *eval.Context, tree.Datums) eval.AggregateFunc,
+		inputs [][]tree.Datum,
+		expected string,
+	) {
+		t.Helper()
+		agg := constructor(nil, evalCtx, nil)
+		defer agg.Close(ctx)
+		for _, input := range inputs {
+			if err := agg.Add(ctx, input[0], input[1:]...); err != nil {
+				t.Fatal(err)
+			}
+		}
+		result, err := agg.Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual := result.String(); actual != expected {
+			t.Fatalf("expected %s, got %s", expected, actual)
+		}
+	}
+
+	const value = "99999999999999999999.9999999999"
+	t.Run("local equal values", func(t *testing.T) {
+		run(t, newDecimalVarianceAggregate, [][]tree.Datum{
+			{parseDecimal(t, value)},
+			{parseDecimal(t, value)},
+		}, "0")
+	})
+	t.Run("local nonzero", func(t *testing.T) {
+		inputs := make([][]tree.Datum, 0, 11)
+		for i := 0; i < 10; i++ {
+			inputs = append(inputs, []tree.Datum{parseDecimal(t, value)})
+		}
+		inputs = append(inputs, []tree.Datum{
+			parseDecimal(t, "99999999999999997999.9999999999"),
+		})
+		run(t, newDecimalVarianceAggregate, inputs, "363636.36363636363636")
+	})
+	t.Run("final", func(t *testing.T) {
+		inputs := [][]tree.Datum{
+			{parseDecimal(t, "0"), parseDecimal(t, value), tree.NewDInt(1)},
+			{parseDecimal(t, "0"), parseDecimal(t, "99999999999999999999.9999999998"), tree.NewDInt(1)},
+		}
+		run(t, newDecimalFinalVarianceAggregate, inputs, "5E-21")
+	})
+}
+
 func TestSqrDiffIntResultDeepCopy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testAggregateResultDeepCopy(t, newIntSqrDiffAggregate, makeIntTestDatum(10))


### PR DESCRIPTION
Fixes #173063.

## Root cause

The DECIMAL variance accumulator applied Welford's algorithm directly to absolute input values with the 25-significant-digit intermediate context. When a value had more leading digits than that context retained, the first mean was rounded. A later equal value then produced a nonzero residual against the rounded mean, and the residual product could make the squared-difference state negative. Distributed aggregation repeated the same loss while combining partial means, which amplified the error.

## How I tracked it down

I reproduced the report in both local and multi-node distributed execution, then compared it with translation-equivalent and scaling-equivalent inputs whose variance is unchanged. The aggregate and scan paths remained the same while the translated cases returned zero, and row and vectorized execution agreed on the failure. Reducing the input to a singleton exposed the first invalid state before finalization: the internal squared-difference value was already `-1E+10`. Varying the number of significant digits put the boundary at the intermediate context's precision. I also kept a nearby nonzero-variance case as a control; that ruled out clamping negative results at finalization because the implementation still needs to distinguish a real small variance from numerical error.

## Fix

The local accumulator now stores the first exact input as an offset and runs Welford's updates on centered values. The final accumulator uses the first partial mean as a common offset and reconstructs each centered partial sum with exact decimal arithmetic before combining states. This keeps the existing `(squared difference, sum, count)` partial-state interface unchanged while preventing high-order digits that cancel out from consuming the working precision.

## Test coverage

- Added aggregate unit cases for equal large-offset values returning zero, a nearby nonzero dataset returning `363636.36363636363636`, and two partial states whose final variance is `5E-21`.
- Added the reported high-offset SQL regression with NULL input, an equal-value zero result, a translated zero oracle, a nearby nonzero control, and forced distributed/vectorized execution.
- Ran the focused regression across all aggregate logic-test configurations, the complete local and fake-distributed aggregate suites, the full builtin aggregate package, and the five-node distributed aggregation suite.
