### PR TITLE
sql: preserve integer digits in decimal division

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -12809,7 +12809,7 @@ func (p projDivDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12837,7 +12837,7 @@ func (p projDivDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12861,7 +12861,7 @@ func (p projDivDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12885,7 +12885,7 @@ func (p projDivDecimalInt16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -12938,7 +12938,7 @@ func (p projDivDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12966,7 +12966,7 @@ func (p projDivDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -12990,7 +12990,7 @@ func (p projDivDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13014,7 +13014,7 @@ func (p projDivDecimalInt32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13067,7 +13067,7 @@ func (p projDivDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13095,7 +13095,7 @@ func (p projDivDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13119,7 +13119,7 @@ func (p projDivDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13143,7 +13143,7 @@ func (p projDivDecimalInt64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &tmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13194,7 +13194,7 @@ func (p projDivDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMet
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &arg1, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13226,7 +13226,7 @@ func (p projDivDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMet
 								colexecerror.ExpectedError(tree.ErrDivByZero)
 							}
 
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &arg1, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13254,7 +13254,7 @@ func (p projDivDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMet
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &arg1, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13282,7 +13282,7 @@ func (p projDivDecimalDecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMet
 							colexecerror.ExpectedError(tree.ErrDivByZero)
 						}
 
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &arg1, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &arg1, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13340,7 +13340,7 @@ func (p projDivInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13367,7 +13367,7 @@ func (p projDivInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13390,7 +13390,7 @@ func (p projDivInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13413,7 +13413,7 @@ func (p projDivInt16Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13465,7 +13465,7 @@ func (p projDivInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13492,7 +13492,7 @@ func (p projDivInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13515,7 +13515,7 @@ func (p projDivInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13538,7 +13538,7 @@ func (p projDivInt16Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13590,7 +13590,7 @@ func (p projDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13617,7 +13617,7 @@ func (p projDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13640,7 +13640,7 @@ func (p projDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13663,7 +13663,7 @@ func (p projDivInt16Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13716,7 +13716,7 @@ func (p projDivInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13750,7 +13750,7 @@ func (p projDivInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -13780,7 +13780,7 @@ func (p projDivInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13810,7 +13810,7 @@ func (p projDivInt16DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -13868,7 +13868,7 @@ func (p projDivInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13895,7 +13895,7 @@ func (p projDivInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -13918,7 +13918,7 @@ func (p projDivInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13941,7 +13941,7 @@ func (p projDivInt32Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -13993,7 +13993,7 @@ func (p projDivInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14020,7 +14020,7 @@ func (p projDivInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14043,7 +14043,7 @@ func (p projDivInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14066,7 +14066,7 @@ func (p projDivInt32Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14118,7 +14118,7 @@ func (p projDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14145,7 +14145,7 @@ func (p projDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14168,7 +14168,7 @@ func (p projDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14191,7 +14191,7 @@ func (p projDivInt32Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14244,7 +14244,7 @@ func (p projDivInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -14278,7 +14278,7 @@ func (p projDivInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -14308,7 +14308,7 @@ func (p projDivInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14338,7 +14338,7 @@ func (p projDivInt32DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14396,7 +14396,7 @@ func (p projDivInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14423,7 +14423,7 @@ func (p projDivInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14446,7 +14446,7 @@ func (p projDivInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14469,7 +14469,7 @@ func (p projDivInt64Int16Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14521,7 +14521,7 @@ func (p projDivInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14548,7 +14548,7 @@ func (p projDivInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14571,7 +14571,7 @@ func (p projDivInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14594,7 +14594,7 @@ func (p projDivInt64Int32Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14646,7 +14646,7 @@ func (p projDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14673,7 +14673,7 @@ func (p projDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+							if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -14696,7 +14696,7 @@ func (p projDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14719,7 +14719,7 @@ func (p projDivInt64Int64Op) Next() (coldata.Batch, *execinfrapb.ProducerMetadat
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Quo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
+						if _, err := tree.DecimalQuo(&projCol[i], &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -14772,7 +14772,7 @@ func (p projDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -14806,7 +14806,7 @@ func (p projDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+							_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -14836,7 +14836,7 @@ func (p projDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -14866,7 +14866,7 @@ func (p projDivInt64DecimalOp) Next() (coldata.Batch, *execinfrapb.ProducerMetad
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Quo(&projCol[i], &tmpDec, &arg2)
+						_, err := tree.DecimalQuo(&projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -322,6 +322,7 @@ func (decimalCustomizer) getBinOpAssignFunc() assignFunc {
 			"Target":           targetElem,
 			"Left":             leftElem,
 			"Right":            rightElem,
+			"IsDiv":            binOp == treebin.Div,
 			"IsPow":            binOp == treebin.Pow,
 		}
 		buf := strings.Builder{}
@@ -332,7 +333,9 @@ func (decimalCustomizer) getBinOpAssignFunc() assignFunc {
 					colexecerror.ExpectedError(tree.ErrDivByZero)
 				}
 				{{end}}
-				{{if .IsPow -}}
+				{{if .IsDiv -}}
+				_, err := tree.DecimalQuo(&{{.Target}}, &{{.Left}}, &{{.Right}})
+				{{else if .IsPow -}}
 				err := eval.{{.Op}}(tree.{{.Ctx}}, &{{.Target}}, &{{.Left}}, &{{.Right}})
 				{{else -}}
 				_, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, &{{.Right}})
@@ -489,7 +492,6 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 
 		case treebin.Div:
 			// Note that this is the '/' operator, which has a decimal result.
-			args["Ctx"] = binaryOpDecCtx[binOp]
 			t = template.Must(template.New("").Parse(`
 			{
 				if {{.Right}} == 0 {
@@ -498,7 +500,7 @@ func (c intCustomizer) getBinOpAssignFunc() assignFunc {
 				var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 				leftTmpDec.SetInt64(int64({{.Left}}))
 				rightTmpDec.SetInt64(int64({{.Right}}))
-				if _, err := tree.{{.Ctx}}.Quo(&{{.Target}}, &leftTmpDec, &rightTmpDec); err != nil {
+				if _, err := tree.DecimalQuo(&{{.Target}}, &leftTmpDec, &rightTmpDec); err != nil {
 					colexecerror.ExpectedError(err)
 				}
 			}
@@ -564,6 +566,7 @@ func (c decimalIntCustomizer) getBinOpAssignFunc() assignFunc {
 			"Target":           targetElem,
 			"Left":             leftElem,
 			"Right":            rightElem,
+			"IsDiv":            binOp == treebin.Div,
 			"IsPow":            binOp == treebin.Pow,
 		}
 		buf := strings.Builder{}
@@ -576,7 +579,9 @@ func (c decimalIntCustomizer) getBinOpAssignFunc() assignFunc {
 				{{end}}
 				var tmpDec apd.Decimal //gcassert:noescape
 				tmpDec.SetInt64(int64({{.Right}}))
-				{{if .IsPow -}}
+				{{if .IsDiv -}}
+				if _, err := tree.DecimalQuo(&{{.Target}}, &{{.Left}}, &tmpDec); err != nil {
+				{{else if .IsPow -}}
 				if err := eval.{{.Op}}(tree.{{.Ctx}}, &{{.Target}}, &{{.Left}}, &tmpDec); err != nil {
 				{{else -}}
 				if _, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &{{.Left}}, &tmpDec); err != nil {
@@ -603,6 +608,7 @@ func (c intDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 			"Target":           targetElem,
 			"Left":             leftElem,
 			"Right":            rightElem,
+			"IsDiv":            binOp == treebin.Div,
 			"IsPow":            binOp == treebin.Pow,
 		}
 		buf := strings.Builder{}
@@ -615,7 +621,9 @@ func (c intDecimalCustomizer) getBinOpAssignFunc() assignFunc {
 				{{end}}
 				var tmpDec apd.Decimal //gcassert:noescape
 				tmpDec.SetInt64(int64({{.Left}}))
-				{{if .IsPow -}}
+				{{if .IsDiv -}}
+				_, err := tree.DecimalQuo(&{{.Target}}, &tmpDec, &{{.Right}})
+				{{else if .IsPow -}}
 				err := eval.{{.Op}}(tree.{{.Ctx}}, &{{.Target}}, &tmpDec, &{{.Right}})
 				{{else -}}
 				_, err := tree.{{.Ctx}}.{{.Op}}(&{{.Target}}, &tmpDec, &{{.Right}})

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,33 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+subtest regression_168373
+
+# A manually expanded population-variance expression over a constant input
+# must agree with VAR_POP. Previously, the intermediate division rounded away
+# integer digits and left a false negative residual.
+statement ok
+CREATE TABLE t168373_0 (c0 TIMESTAMP);
+CREATE TABLE t168373_1 (c0 BIGINT UNIQUE);
+CREATE TABLE t168373_2 (c0 INT NOT NULL);
+
+statement ok
+INSERT INTO t168373_0 VALUES
+  ('1969-12-08 19:18:57'), ('1970-01-09 09:36:22'),
+  ('1970-01-20 09:32:22'), ('1970-01-11 00:06:06');
+INSERT INTO t168373_1 VALUES (424210762), (NULL), (-766426769);
+INSERT INTO t168373_2 SELECT * FROM generate_series(1, 11);
+
+query RR rowsort
+SELECT
+  (SUM((-1737664727) * (-1737664727)) - SUM(-1737664727) * SUM(-1737664727) / COUNT(-1737664727)) / COUNT(-1737664727),
+  VAR_POP(-1737664727)
+FROM t168373_1, t168373_0, t168373_2
+GROUP BY t168373_1.c0;
+----
+0  0
+0  0
+0  0
+
+subtest end

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -432,7 +432,7 @@ func (e *evaluator) EvalDivDecimalIntOp(
 	}
 	dd := &tree.DDecimal{}
 	dd.SetInt64(int64(r))
-	_, err := tree.DecimalCtx.Quo(&dd.Decimal, l, &dd.Decimal)
+	_, err := tree.DecimalQuo(&dd.Decimal, l, &dd.Decimal)
 	return dd, err
 }
 
@@ -447,7 +447,7 @@ func (e *evaluator) EvalDivDecimalOp(
 		return tree.DZeroDecimal, nil
 	}
 	dd := &tree.DDecimal{}
-	_, err := tree.DecimalCtx.Quo(&dd.Decimal, l, r)
+	_, err := tree.DecimalQuo(&dd.Decimal, l, r)
 	return dd, err
 }
 
@@ -474,7 +474,7 @@ func (e *evaluator) EvalDivIntDecimalOp(
 	}
 	dd := &tree.DDecimal{}
 	dd.SetInt64(int64(l))
-	_, err := tree.DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, r)
+	_, err := tree.DecimalQuo(&dd.Decimal, &dd.Decimal, r)
 	return dd, err
 }
 
@@ -489,7 +489,7 @@ func (e *evaluator) EvalDivIntOp(
 	div.SetInt64(int64(rInt))
 	dd := &tree.DDecimal{}
 	dd.SetInt64(int64(tree.MustBeDInt(left)))
-	_, err := tree.DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, &div)
+	_, err := tree.DecimalQuo(&dd.Decimal, &dd.Decimal, &div)
 	return dd, err
 }
 

--- a/pkg/sql/sem/eval/testdata/eval/float_decimal_div
+++ b/pkg/sql/sem/eval/testdata/eval/float_decimal_div
@@ -39,3 +39,17 @@ eval
 1.1:::decimal / 2:::int
 ----
 0.55000000000000000000
+
+# Decimal division must not round digits to the left of the decimal point.
+# This is the division which caused the non-zero variance result in #168373.
+eval
+5845710769898530048144:::decimal / 44:::int
+----
+132857062952239319276
+
+# Preserve the established 20-significant-digit result when the integer part
+# fits within the default precision.
+eval
+10:::decimal / 3:::decimal
+----
+3.3333333333333333333

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -389,7 +389,7 @@ func (expr *NumVal) ResolveAsType(
 						"could not evaluate denominator %v as Datum type DDecimal from string %q",
 						expr, den)
 				}
-				if cond, err := DecimalCtx.Quo(&dd.Decimal, &dd.Decimal, &denDec.Decimal); err != nil {
+				if cond, err := DecimalQuo(&dd.Decimal, &dd.Decimal, &denDec.Decimal); err != nil {
 					if cond.DivisionByZero() {
 						return nil, ErrDivByZero
 					}

--- a/pkg/sql/sem/tree/decimal.go
+++ b/pkg/sql/sem/tree/decimal.go
@@ -47,6 +47,39 @@ var (
 	errScaleOutOfRange = pgerror.New(pgcode.NumericValueOutOfRange, "scale out of range")
 )
 
+// DecimalQuo divides x by y using DecimalCtx's precision unless that would
+// round digits to the left of the decimal point. In that case, it increases
+// the precision just enough to preserve the quotient's integer portion.
+//
+// PostgreSQL likewise chooses NUMERIC division precision dynamically based on
+// the size of the quotient. Keep CockroachDB's established 20-significant-digit
+// minimum, while avoiding a fixed upper bound on integer digits.
+func DecimalQuo(d, x, y *apd.Decimal) (apd.Condition, error) {
+	// Quo permits the destination to alias either operand. Preserve aliased
+	// operands in case the first, default-precision result needs to be retried.
+	var xCopy, yCopy apd.Decimal
+	if d == x {
+		xCopy.Set(x)
+		x = &xCopy
+	}
+	if d == y {
+		yCopy.Set(y)
+		y = &yCopy
+	}
+
+	ctx := DecimalCtx
+	for {
+		condition, err := ctx.Quo(d, x, y)
+		if err != nil || !condition.Inexact() || d.Form != apd.Finite || d.Exponent <= 0 {
+			return condition, err
+		}
+		// A positive exponent on an inexact result means that the current
+		// significant-digit limit rounded the quotient somewhere in its integer
+		// portion. Each exponent position requires one more digit of precision.
+		ctx = DecimalCtx.WithPrecision(ctx.Precision + uint32(d.Exponent))
+	}
+}
+
 // LimitDecimalWidth limits d's precision (total number of digits) and scale
 // (number of digits after the decimal point). Note that this any limiting will
 // modify the decimal in-place.


### PR DESCRIPTION
Fixes #168373.

## Root cause

SQL decimal division always used the fixed 20-significant-digit `DecimalCtx`. In the reported expression, `5845710769898530048144 / 44` requires 21 integer digits, so the exact quotient `132857062952239319276` was rounded to `1.3285706295223931928E+20`. Subtracting that rounded quotient from the exact sum left `-4`, and the final division produced `-1/11` even though every input in the group was constant and the variance-equivalent expression must be zero.

## How I tracked it down

I reproduced the result for both constants and all three reported groups, then compared the expression with `VAR_POP`, a translation to zero, and an algebraically equivalent form that performs the division last; all three metamorphic oracles returned zero. Changing only the row count showed the precision boundary: counts 4 and 11 returned zero, while 44 and 101 returned `-1/n`. Optimizer and distributed plans had the same aggregation levels, and row and vectorized execution failed identically. Inspecting the final scalar render then exposed the rounded quotient and exact `-4` residual, locating the problem in the shared decimal division policy rather than aggregation.

## Fix

Added `tree.DecimalQuo`, which first divides with the existing 20-digit context and retries only when an inexact finite result has a positive exponent, adding just enough precision to retain the quotient's integer portion. The helper preserves aliased operands across a retry. Row evaluation, numeric constant resolution, and generated vectorized decimal/integer division now use the same helper. Ordinary fractional results retain the established 20-significant-digit behavior, so this does not raise the global decimal context or change unrelated decimal operations.

## Test coverage

- Added evaluator coverage for the exact large quotient that triggered the bug and for `10/3` retaining the existing 20-digit result.
- Added the reported aggregate expression for both large constants and all three groups, with `VAR_POP` as the zero oracle.
- Verified the regression across five local/fake-distributed row, vectorized, and disk-spilling configurations; ran the full evaluator, tree, and vectorized projection tests and the complete aggregate and decimal logic suites; and confirmed the generated vectorized output is reproducible.
