### PR TITLE
sql: preserve common type for homogeneous builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1843,6 +1843,54 @@ SELECT least(NULL, NULL, NULL, a, -1) FROM foo
 ----
 -1
 
+subtest regression_159153
+
+statement ok
+CREATE TABLE t159153 (c1 INT2, c2 INT4)
+
+statement ok
+INSERT INTO t159153 VALUES
+  (-9551, -1347373370),
+  (9551, 1347373370),
+  (NULL, -1234567890)
+
+# LEAST is commutative, and explicitly promoting the narrow argument must not
+# change the result.
+query III
+SELECT least(c1, least(0, c2)),
+       least(least(0, c2), c1),
+       least(c1::INT4, least(0, c2))
+FROM t159153 WHERE c1 = -9551
+----
+-1347373370 -1347373370 -1347373370
+
+# GREATEST uses the same homogeneous overload and must preserve a selected
+# value that does not fit in the first argument's width.
+query III
+SELECT greatest(c1, greatest(0, c2)),
+       greatest(greatest(0, c2), c1),
+       greatest(c1::INT4, greatest(0, c2))
+FROM t159153 WHERE c1 = 9551
+----
+1347373370 1347373370 1347373370
+
+# NULL arguments are ignored by LEAST, so the wide inner value is still the
+# expected result when the narrow outer argument is NULL.
+query I
+SELECT least(c1, least(0, c2)) FROM t159153 WHERE c1 IS NULL
+----
+-1234567890
+
+# Flat mixed-width calls exercise the control path without nested return-type
+# propagation.
+query II
+SELECT least(c1, c2), greatest(c1, c2)
+FROM t159153 WHERE c1 = -9551
+----
+-1347373370 -9551
+
+subtest end
+
 # Test float and int comparison.
 
 query BBBB

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
@@ -893,9 +894,27 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 				return errors.AssertionFailedf(
 					"only one overload can have HomogeneousType parameters")
 			}
-			typedExprs, _, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, s.exprs...)
+			typedExprs, commonType, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, s.exprs...)
 			if err != nil {
 				return err
+			}
+			// Homogeneous builtins derive their return type from the first non-NULL
+			// argument. Ensure that argument has the common type chosen above. The
+			// types can be equivalent but not identical (for example, INT2 and
+			// INT4), in which case using the narrower argument's type as the return
+			// type can truncate a wider argument selected at execution time.
+			for j, typedExpr := range typedExprs {
+				typ := typedExpr.ResolvedType()
+				if typ.Family() == types.UnknownFamily {
+					continue
+				}
+				if !typ.Identical(commonType) {
+					if !cast.ValidCast(typ, commonType, cast.ContextExplicit) {
+						return unexpectedTypeError(s.exprs[j], commonType, typ)
+					}
+					typedExprs[j] = NewTypedCastExpr(typedExpr, commonType)
+				}
+				break
 			}
 			s.typedExprs = typedExprs
 			s.overloadIdxs = append(s.overloadIdxs[:0], uint8(i))

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -336,6 +336,58 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	}
 }
 
+func TestTypeCheckHomogeneousExprsWithMixedIntWidths(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	intConst := func(s string) Expr {
+		return NewNumVal(constant.MakeFromLiteral(s, token.INT, 0), s, false /* negative */)
+	}
+	homogeneousFn := &Overload{
+		Types:      HomogeneousType{},
+		ReturnType: FirstNonNullReturnType(),
+	}
+	testCases := []struct {
+		name  string
+		types []*types.T
+		exprs func(IndexedVarHelper) []Expr
+	}{
+		{
+			name:  "columns",
+			types: []*types.T{types.Int2, types.Int4},
+			exprs: func(h IndexedVarHelper) []Expr {
+				return []Expr{h.IndexedVar(0), h.IndexedVar(1)}
+			},
+		},
+		{
+			name:  "constant-and-column",
+			types: []*types.T{types.Int4},
+			exprs: func(h IndexedVarHelper) []Expr {
+				return []Expr{intConst("0"), h.IndexedVar(0)}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			semaCtx := MakeSemaContext(nil /* resolver */)
+			ivarHelper := MakeIndexedVarHelperWithTypes(tc.types)
+			semaCtx.IVarContainer = ivarHelper.Container()
+			s := getOverloadTypeChecker(overloadImpls{homogeneousFn}, tc.exprs(ivarHelper)...)
+			defer s.release()
+
+			require.NoError(t, s.typeCheckOverloadedExprs(
+				context.Background(), &semaCtx, types.AnyElement, false, /* inBinOp */
+			))
+			require.Len(t, s.typedExprs, 2)
+			for i := range s.typedExprs {
+				require.Truef(t, s.typedExprs[i].ResolvedType().Identical(types.Int4),
+					"argument %d has type %s", i, s.typedExprs[i].ResolvedType())
+			}
+		})
+	}
+}
+
 func TestGetMostSignificantOverload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
Fixes #159153.

## Root cause

Homogeneous overload resolution selected `INT4` as the common type for mixed-width integer arguments, but equivalent integer types were allowed to keep their original widths. `least` and `greatest` derive their return type from the first non-NULL argument, so a narrow `INT2` first argument made the result slot `INT2` even when evaluation selected an `INT4` value. The wider value was then truncated; in the reported case `-1347373370` became `-18746`.

## How I tracked it down

I reproduced the nested `least` result and compared it with commuting the arguments, explicitly promoting the narrow argument, and an equivalent `CASE` expression. Those controls agreed on the full-width result, while the flat mixed-width `least` call remained correct. The plans differed only in scalar rendering. A focused overload-resolution test then showed the violated invariant directly: common-type selection returned `INT4`, but the first return-determining expression still resolved as `INT2`. That localized the bug to the `HomogeneousType` overload path rather than comparison or vectorized evaluation.

## Fix

After homogeneous arguments have been validated and their common type selected, overload resolution now retypes only the first non-NULL argument to that common type when necessary. This keeps the change scoped to builtins that use `HomogeneousType` and `FirstNonNullReturnType`, while preserving the existing common-type checks and the types of the remaining arguments.

## Test coverage

- Added overload-resolution unit cases for mixed-width columns and for an integer constant followed by an `INT4` column, asserting that the homogeneous arguments and return-determining expression resolve as `INT4`.
- Added SQL regressions for the reported nested `least`, commuted arguments, explicit promotion, a NULL outer argument, the corresponding `greatest` case, and a flat mixed-width control.
- Ran the regression in five local/fake-distributed row, vectorized, and disk-spilling configurations, plus the full tree and builtin packages and complete local/fake-distributed builtin-function logic suites.
