### PR TITLE
sql: preserve filters during distinct preprocessing

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2333,6 +2333,11 @@ func (dsp *DistSQLPlanner) planAggregators(
 			for _, colIdx := range e.ColIdx {
 				distinctColumnsSet.Add(int(colIdx))
 			}
+			if e.FilterColIdx != nil {
+				// Preserve rows with the same arguments but different filter
+				// results so that each aggregate can apply its own filter.
+				distinctColumnsSet.Add(int(*e.FilterColIdx))
+			}
 		}
 		if distinctColumnsSet.Len() > 0 {
 			// We only need to plan distinct processors if we have non-empty

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,36 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+subtest regression_158770
+
+# Multiple filtered aggregates over the same argument must each read the
+# argument column, even when their filters require a pre-projection that
+# reorders the input stream.
+query II
+SELECT count(DISTINCT a.z) FILTER (WHERE b.x > 1),
+       count(DISTINCT a.z) FILTER (WHERE b.x > 2)
+FROM (VALUES (1, 1), (2, 1), (3, 2), (4, 2)) AS b(x, y)
+JOIN (VALUES (1), (2)) AS a(z) ON a.z = b.y;
+----
+2  1
+
+statement ok
+PREPARE regression_158770 (INT) AS
+SELECT count(DISTINCT a.z) FILTER (WHERE b.x > 1),
+       count(DISTINCT a.z) FILTER (WHERE b.x > $1)
+FROM (VALUES (1, 1), (2, 1), (3, 2), (4, 2)) AS b(x, y)
+JOIN (VALUES (1), (2)) AS a(z) ON a.z = b.y;
+
+query II
+EXECUTE regression_158770(1)
+----
+2  2
+
+query II
+EXECUTE regression_158770(2)
+----
+2  1
+
+statement ok
+DEALLOCATE regression_158770


### PR DESCRIPTION
Fixes #158770.

## Root cause

When every aggregate in a stage is `DISTINCT`, physical planning adds an early distinct processor keyed by the union of the aggregate argument columns. Filter columns were not included in that key. Rows with the same aggregate argument but different filter results could therefore be collapsed before each aggregate evaluated its own filter, causing multiple filtered DISTINCT aggregates over the same argument to observe the wrong subset of rows. Placeholders made the issue visible by preventing optimizer deduplication, but they were not the source of the error; two different literal filters failed in the same way.

## How I tracked it down

I compared the reported prepared query with direct literal filters, reordered aggregates, a single filtered DISTINCT aggregate, non-DISTINCT controls, identical filters, different aggregate arguments, and `COUNT` plus `SUM` over the same DISTINCT argument. Row/vectorized and local/forced-distributed execution agreed on the failure, which placed it before either aggregation implementation. The physical plan contained both aggregate specs and both Boolean filter projections, but the shared all-DISTINCT preprocessing stage deduplicated only on the argument column. For a repeated argument, that stage could retain a false-filter row and discard the true-filter row before either aggregate ran.

## Fix

The early distinct key now includes every non-nil aggregate filter column in addition to the existing union of argument columns. This preserves rows that are distinguishable by any later filter while retaining the shared preprocessing optimization and leaving individual aggregate implementations unchanged.

## Test coverage

- Added a direct SQL regression with two literal filters over the same DISTINCT argument, expecting counts `2,1`.
- Added a prepared regression with one literal and one parameterized filter, covering both equal thresholds (`2,2`) and different thresholds (`2,1`).
- Verified the focused regression in five local/fake-distributed row, vectorized, and disk-spilling configurations; ran the complete aggregate logic suite locally and fake-distributed, the full 16-shard SQL test target, and the five-node distributed aggregation suite containing the earlier distinct-preprocessing regression.
