### PR TITLE
sql: preserve decimal negative zero in serialized expressions

### DIFF
--- a/pkg/sql/execinfra/execexpr/expr_test.go
+++ b/pkg/sql/execinfra/execexpr/expr_test.go
@@ -103,3 +103,63 @@ func TestDeserializeExpressionConstantEval(t *testing.T) {
 		t.Errorf("invalid expr '%v', expected '%v'", expr, expected)
 	}
 }
+
+func TestDeserializeDecimalSignedZero(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
+	semaCtx := tree.MakeSemaContext(nil /* resolver */)
+
+	for _, input := range []string{
+		"-0", "-0.00", "-0E+3", "-0E-2000", "-0E+2000",
+		"0", "0.00", "-1.25", "1.25", "Infinity", "-Infinity", "NaN",
+	} {
+		t.Run(input, func(t *testing.T) {
+			// Arithmetic can produce negative zero even though SQL literal parsing
+			// canonicalizes it. Construct that intermediate representation directly.
+			d := &tree.DDecimal{}
+			if _, _, err := d.Decimal.SetString(input); err != nil {
+				t.Fatal(err)
+			}
+			before := d.Decimal.String()
+			for name, flags := range map[string]tree.FmtFlags{
+				"parsable": tree.FmtParsable, "serializable": tree.FmtSerializable,
+				"equivalence": tree.FmtCheckEquivalence,
+			} {
+				t.Run(name, func(t *testing.T) {
+					serialized := tree.AsStringWithFlags(d, flags)
+					actual, err := DeserializeExpr(ctx, execinfrapb.Expression{Expr: serialized}, nil, &semaCtx, &evalCtx)
+					if err != nil {
+						t.Fatal(err)
+					}
+					got, ok := actual.(*tree.DDecimal)
+					if !ok || d.Decimal.CmpTotal(&got.Decimal) != 0 {
+						t.Fatalf("%s serialized as %s, deserialized as %s", before, serialized, actual)
+					}
+					if d.Decimal.String() != before {
+						t.Fatal("formatting mutated the original datum")
+					}
+				})
+			}
+			for _, nested := range []tree.Datum{
+				tree.NewDArrayFromDatums(types.Decimal, tree.Datums{d, tree.DNull}),
+				tree.NewDTuple(types.MakeTuple([]*types.T{types.Decimal, types.Int}), d, tree.NewDInt(1)),
+			} {
+				serialized := tree.Serialize(nested)
+				actual, err := DeserializeExpr(ctx, execinfrapb.Expression{Expr: serialized}, nil, &semaCtx, &evalCtx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if actual.String() != nested.String() {
+					t.Fatalf("nested %s serialized as %s, deserialized as %s", nested, serialized, actual)
+				}
+			}
+			for _, flags := range []tree.FmtFlags{tree.FmtSimple, tree.FmtPgwireText, tree.FmtExport} {
+				if actual := tree.AsStringWithFlags(d, flags); actual != before {
+					t.Fatalf("ordinary formatting changed %s to %s", before, actual)
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_builtin
@@ -15,3 +15,48 @@ SELECT c FROM t
 WHERE
 	localtimestamp(7::INT8):::TIMESTAMPTZ
 	IN ('1975-04-24 08:08:35.000071+00:00':::TIMESTAMPTZ, '1980-10-15 12:17:59.000616+00:00':::TIMESTAMPTZ);
+
+subtest regression_148279
+
+# Preserve arithmetic-produced DECIMAL negative zero when shipping expressions.
+statement ok
+CREATE TABLE decimal_zero (k INT PRIMARY KEY, s STRING, num DECIMAL, den INT);
+INSERT INTO decimal_zero VALUES (1, '/a', -61.100, 79);
+
+retry
+statement ok
+ALTER TABLE decimal_zero EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1);
+
+statement ok
+SET distsql = always;
+
+query I
+SELECT count(*) FROM decimal_zero JOIN (SELECT 1) ON NOT(-61.100 // 79 || s <= s);
+----
+0
+
+# Making the implicit text conversion explicit must not affect the result.
+query I
+SELECT count(*) FROM decimal_zero JOIN (SELECT 1) ON NOT((-61.100 // 79)::STRING || s <= s);
+----
+0
+
+# Computing identical operands on the remote node must agree with constant folding.
+query I
+SELECT count(*) FROM decimal_zero JOIN (SELECT 1) ON NOT(num // den || s <= s);
+----
+0
+
+query T
+SELECT (-1::DECIMAL * 0.00::DECIMAL) || s FROM decimal_zero;
+----
+-0.00/a
+
+# This does not change SQL literal parsing or positive zero's representation.
+query TT
+SELECT '-0.00'::DECIMAL::STRING, 0::DECIMAL || s FROM decimal_zero;
+----
+0.00  0/a
+
+statement ok
+RESET distsql;

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1096,6 +1096,17 @@ func (d *DDecimal) Format(ctx *FmtCtx) {
 	// will take precedence over the negation sign.
 	disambiguate := ctx.flags.HasFlags(fmtDisambiguateDatumTypes)
 	parsable := ctx.flags.HasFlags(FmtParsableNumerics)
+	if parsable && d.Negative && d.IsZero() {
+		// SQL decimal literals discard the sign of zero, but arithmetic can
+		// produce negative zero. Reconstruct it without losing its scale when
+		// deserializing an expression. Do not mutate the original datum.
+		zero := d.Decimal
+		zero.Negative = false
+		ctx.WriteByte('(')
+		ctx.WriteString(zero.String())
+		ctx.WriteString(":::DECIMAL * (-1):::DECIMAL)")
+		return
+	}
 	quote := parsable && d.Decimal.Form != apd.Finite
 	needParens := !quote && (disambiguate || parsable) && d.Negative
 	if needParens {


### PR DESCRIPTION
## Summary

Preserve arithmetic-produced DECIMAL negative zero when serializing expressions for remote execution. This fixes the plan-dependent result reported in #148279 while retaining CockroachDB's existing local arithmetic and DECIMAL-to-STRING behavior.

This is a scoped consistency fix, **not a complete resolution of the PostgreSQL-compatibility and zero-normalization questions in the issue discussion**. The unresolved behavior and the shared formatter's external effects are described below for review.

## Problem and root cause

The reported query is:

```sql
CREATE TABLE t0(c0 TEXT);
INSERT INTO t0 VALUES ('/a');
SELECT * FROM t0 JOIN (SELECT 1)
  ON NOT(-61.100 // 79 || c0 <= c0);
```

On the baseline, local execution returns no rows, but a plan executing the filter remotely returns one row. The cause is a mismatch between the representation produced by arithmetic and the representation accepted by ordinary SQL decimal literal resolution:

1. DECIMAL integer division can produce an APD finite zero with `Negative = true`. Numerically it compares equal to positive zero, but the existing DECIMAL-to-STRING conversion exposes the sign as `'-0'`.
2. Local expression execution can retain that `DDecimal` in `Expression.LocalExpr`. Remote expression construction instead formats it through `FmtCheckEquivalence` into `Expression.Expr`, previously as `(-0):::DECIMAL`.
3. On the receiver, `execexpr.helper.deserializeExpr` parses, type-checks, and pre-evaluates the expression. As clarified in the issue, parsing into `NumVal` retains the negative flag; ordinary decimal construction/type resolution canonicalizes zero. `setDecimalString` removes the negative sign from zero, and `NumVal.ResolveAsType` also avoids applying a negative sign to a zero decimal. The remote datum therefore becomes positive zero.
4. The filter consequently compares `'-0/a'` locally but `'0/a'` remotely. For the input `'/a'`, that changes the predicate's truth value and whether the row is returned.

The invalid transition is the **expression datum serialization/deserialization round trip** under the current execution semantics. It is not a different division algorithm or a vectorized comparison defect. The literal normalization itself is deliberate; changing it globally would be a separate semantic decision.

Relevant paths are `pkg/sql/physicalplan/expression.go`, `pkg/sql/execinfra/execexpr/expr.go`, and `pkg/sql/sem/tree/{datum,constant}.go`. This agrees with the issue's [final root-cause clarification](https://github.com/cockroachdb/cockroach/issues/148279#issuecomment-3011137288). Historical commit [f4658b45](https://github.com/cockroachdb/cockroach/commit/f4658b45b60e3afe61e39c99d4fb315b1012e9b4) also deliberately distinguishes preservation of FLOAT negative zero from DECIMAL literal normalization.

## How the cause was isolated

The investigation used type- and representation-preserving metamorphic comparisons, followed by query-plan, actual execution, and source-path comparison. The baseline was `8812064a015d2faf99d3fc7e15880f94042954b0`; the candidate is `27ec5128087eebed707527e1fe313759ef600fd5`.

Three independent three-node baseline runs compared the following paths, then repeated the same observations on the candidate:

| Query/path | Baseline row count | Candidate row count |
|---|---:|---:|
| Original expression, local execution | 0 | 0 |
| Original expression, remote execution | 1 | 0 |
| Explicit `(-61.100 // 79)::STRING` before concatenation, remote execution | 0 | 0 |
| Remote division using stored `num DECIMAL = -61.100` and `den INT = 79` | 0 | 0 |

The explicit cast is a useful control because the already-computed STRING `'-0'` survives the expression boundary. The column-based control performs the identical typed arithmetic after that boundary and produces the signed zero on the remote node. Row-oriented and vectorized execution both exhibited the original mismatch.

`EXPLAIN (OPT, VERBOSE)` showed the folded decimal expression versus the explicitly converted STRING expression. `EXPLAIN ANALYZE` verified that the compared filters actually executed on node n2 and checked their actual row counts; this was not inferred merely from `SET distsql` or from a distributed plan label. Source inspection then located the different `LocalExpr` and serialized-expression paths. Finally, a native regression through the real `DeserializeExpr` reproduced the sign loss independently of the SQL predicate.

Numeric rewrites such as adding zero or substituting a positive-zero literal were **not** accepted as equivalent oracles: DECIMAL-to-STRING observes a representation difference that numeric equality alone does not preserve.

These comparisons establish consistency with the existing local semantics, not that exposing DECIMAL negative zero is the desired long-term SQL contract. If all DECIMAL zeros were instead canonicalized before conversion to STRING, the original query would consistently return one row, not zero.

## Fix

The production change is eleven lines in `DDecimal.Format`, restricted to finite negative zero under `FmtParsableNumerics`.

Instead of serializing a zero literal whose sign will be discarded, emit a fully parenthesized typed multiplication, for example:

```sql
(0.00:::DECIMAL * (-1):::DECIMAL)
```

A sign-cleared copy supplies the positive-zero spelling while retaining the exponent/scale. Constant evaluation after deserialization reconstructs the negative-zero datum using existing arithmetic. The original datum is not mutated. The outer parentheses and operand type annotations preserve expression grouping and DECIMAL typing.

No arithmetic implementation, ordinary SQL literal parsing, FLOAT handling, or ordinary scalar formatting is changed. No new SQL syntax or wire-protocol field is introduced; mixed-version execution has not been independently tested here.

## Regression coverage and completed local validation

- `TestDeserializeDecimalSignedZero` fails on the baseline and passes on the candidate through actual expression deserialization. It uses `CmpTotal` for scalar representation fidelity, covers negative zero with scale and tested exponents -2000/+2000, positive zero, nonzero and nonfinite controls, nested ARRAY/TUPLE expressions, and non-mutation of the input. It also checks that ordinary scalar formatting remains unchanged.
- The five-node `distsql_builtin/regression_148279` test relocates the data to node 2 and checks the original expression, explicit STRING conversion, and remote computation over identical typed operands. The unchanged regression fails on baseline production and passes on the candidate.
- The selected `decimal`, `distsql_expr`, and `zero` files passed their five selected local/fakedist configurations; `distsql_builtin` passed the selected 5node and 5node-disk configurations.
- Complete tree, parser, eval, normalize, execexpr, physicalplan, and `//pkg/sql:sql_test` targets passed. The last is the SQL package's 16-shard test target, not the entire repository or every package under `pkg/sql/...`.
- Three candidate three-node replays corrected the original result while preserving the equivalent controls. A separate held-out matrix covered six signed-zero execution scenarios over five non-NULL strings plus a NULL control, with positive-zero, nonzero, Infinity, FLOAT-negative-zero, and literal-parsing controls.

These are completed local checks for the unchanged candidate, not a claim that upstream CI has already passed.

## What this fixes, and what remains unresolved

**Fixed:** loss of the negative sign of finite DECIMAL zero in the tested expression round trips, and the resulting plan-dependent STRING-conversion/filter results. The replacement representation preserves the existing scale as well; scale loss was not the baseline defect. The new serialization also works for the tested nested expression containers.

**Not fixed or decided:**

- The [PostgreSQL-facing zero behavior noted in the discussion](https://github.com/cockroachdb/cockroach/issues/148279#issuecomment-3011085177). This patch does not make every final arithmetic DECIMAL zero display as positive zero, nor redefine DECIMAL-to-STRING conversion.
- The proposed normalization at execution/output/storage boundaries. Text PGwire still uses the ordinary decimal string representation, while binary numeric encoding selects a positive sign for zero. VALUE/composite storage still preserves negative zero. These are existing behaviors, not newly introduced boundary regressions.
- The alternative [creator-wide DDecimal audit](https://github.com/cockroachdb/cockroach/issues/148279#issuecomment-3020047625). Arithmetic and built-ins can still create signed zero; the two proposed normalization strategies have not been treated as an agreed design.
- Exhaustive coverage of PGwire text/binary protocols, DistSQLReceiver boundaries, stored-value round trips, spill, or legacy stored negative zeros. Passing expression-formatting tests does not substitute for those checks.

**Additional shared-formatter effect requiring review:** this change is not exclusively internal. `DArray.Format` switches exported array elements to parsable formatting, so DECIMAL arrays containing negative zero can acquire the multiplication spelling in EXPORT CSV and CSV changefeed output. Scalar EXPORT spelling stays unchanged. The ARRAY import path uses a full SQL expression parser/type-checker/evaluator, so the new spelling is not an identified import-syntax failure; however, actual EXPORT/IMPORT and changefeed compatibility tests for this case are not included. In particular, scalar text import still normalizes zero whereas the new array expression can reconstruct its sign.

I am seeking review of this bounded consistency fix and guidance on whether the broader semantics should be addressed here or separately. The existing commit includes an issue-closing trailer; please decide how remaining work should be tracked before merging rather than interpreting that trailer as a claim that all discussion points are resolved.

See also: #148279
Epic: none

Release note (bug fix): Fixed incorrect distributed query results when an arithmetic-produced DECIMAL negative zero was converted to a string. Serialized expressions now preserve its sign and scale, matching local execution.
