### PR TITLE
sql: reject nested array constructors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -119,16 +119,7 @@ SELECT ARRAY(VALUES (1),(2),(1))
 ----
 {1,2,1}
 
-# This query works in local config but fails in distributed config since the
-# support for nested arrays is incomplete.
-onlyif config #32252 local
-query T
-SELECT ARRAY(VALUES (ARRAY[1]))
-----
-{"{1}"}
-
-onlyif config #32252 fakedist
-query error unimplemented: nested arrays are not fully supported.*\nHINT.*\n.*32552
+query error pgcode 0A000 arrays of int\[\] not allowed.*\nHINT.*\n.*32552
 SELECT ARRAY(VALUES (ARRAY[1]))
 
 query T
@@ -485,16 +476,7 @@ DROP TABLE boundedtable
 statement error .*unimplemented.*\nHINT.*\n.*32552
 CREATE TABLE badtable (b INT[][])
 
-# This query works in local config but fails in distributed config since the
-# support for nested arrays is incomplete.
-onlyif config #32252 local
-query T
-SELECT ARRAY[ARRAY[1,2,3]]
-----
-{"{1,2,3}"}
-
-onlyif config #32552 fakedist
-query error unimplemented: nested arrays are not fully supported.*\nHINT.*\n.*32552
+query error pgcode 0A000 arrays of int\[\] not allowed.*\nHINT.*\n.*32552
 SELECT ARRAY[ARRAY[1,2,3]]
 
 # The postgres-compat aliases should be disallowed.
@@ -2560,3 +2542,52 @@ SELECT width_bucket(true, '{}');
 
 query error pgcode 42804 could not determine polymorphic type because input has type unknown
 SELECT array_to_string('{}', 'foo');
+
+subtest regression_146717
+
+# Multidimensional constructors must reject unsupported array elements before
+# they can be formatted as an array of strings instead of a nested array.
+query error pgcode 0A000 arrays of string\[\] not allowed.*\nHINT.*\n.*32552
+SELECT ARRAY[ARRAY['a']]::TEXT;
+
+query error pgcode 0A000 arrays of string\[\] not allowed
+SELECT ARRAY[['a']]::TEXT;
+
+query error pgcode 0A000 arrays of string\[\] not allowed
+SELECT ARRAY(SELECT ARRAY['a'])::TEXT;
+
+query error pgcode 0A000 arrays of string\[\] not allowed
+SELECT ARRAY(VALUES (ARRAY['a']))::TEXT;
+
+query error pgcode 0A000 arrays of int\[\] not allowed
+SELECT ARRAY[ARRAY[1, 2]];
+
+query error pgcode 0A000 arrays of int\[\] not allowed
+SELECT ARRAY[ARRAY[]::INT[]];
+
+query error pgcode 0A000 arrays of string\[\] not allowed
+SELECT ARRAY[NULL::TEXT[]];
+
+query error pgcode 0A000 arrays of int\[\] not allowed
+SELECT ARRAY(SELECT ARRAY[1] WHERE false);
+
+# Braces in scalar strings and array-valued tuple fields are not dimensions.
+query T
+SELECT ARRAY['{a}']::TEXT;
+----
+{"{a}"}
+
+query T
+SELECT ARRAY[ROW(ARRAY['a'])]::TEXT;
+----
+{"({a})"}
+
+query T
+SELECT ARRAY[]::TEXT[]::TEXT;
+----
+{}
+
+query T
+SELECT ARRAY[NULL::TEXT]::TEXT;
+----
+{NULL}

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2713,13 +2713,13 @@ values
 # EliminateJoinNoColsLeft
 # --------------------------------------------------
 norm expect=EliminateJoinNoColsLeft
-SELECT unnest(ARRAY[[1,2,3],[4,5]])
+SELECT unnest(ARRAY[1,2])
 ----
 values
  ├── columns: unnest:1!null
  ├── cardinality: [2 - 2]
- ├── (ARRAY[1,2,3],)
- └── (ARRAY[4,5],)
+ ├── (1,)
+ └── (2,)
 
 # --------------------------------------------------
 # EliminateJoinNoColsRight

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -936,19 +936,19 @@ project
 
 # No-op case because the single column in Values is not of type tuple.
 norm expect-not=FoldTupleAccessIntoValues
-SELECT col[1], col[2] FROM unnest(ARRAY[[1,2],[3,4]]) AS col
+SELECT col[1], col[2] FROM (VALUES (ARRAY[1,2]), (ARRAY[3,4])) AS v(col)
 ----
 project
  ├── columns: col:2 col:3
  ├── cardinality: [2 - 2]
  ├── values
- │    ├── columns: unnest:1!null
+ │    ├── columns: column1:1!null
  │    ├── cardinality: [2 - 2]
  │    ├── (ARRAY[1,2],)
  │    └── (ARRAY[3,4],)
  └── projections
-      ├── unnest:1[1] [as=col:2, outer=(1)]
-      └── unnest:1[2] [as=col:3, outer=(1)]
+      ├── column1:1[1] [as=col:2, outer=(1)]
+      └── column1:1[2] [as=col:3, outer=(1)]
 
 # No-op case because one of the tuple rows in Values can only be determined at
 # run-time. Put dynamic tuple expression at end of list to ensure that all rows

--- a/pkg/sql/opt/norm/testdata/rules/project_set
+++ b/pkg/sql/opt/norm/testdata/rules/project_set
@@ -166,15 +166,15 @@ values
  ├── key: ()
  └── fd: ()-->(1)
 
-# unnest case with array of arrays.
+# unnest case with array of tuples containing arrays.
 norm expect=ConvertZipArraysToValues
-SELECT unnest(ARRAY[[1,2,3],[4,5]])
+SELECT unnest(ARRAY[ROW(ARRAY[1,2,3]), ROW(ARRAY[4,5])])
 ----
 values
  ├── columns: unnest:1!null
  ├── cardinality: [2 - 2]
- ├── (ARRAY[1,2,3],)
- └── (ARRAY[4,5],)
+ ├── ((ARRAY[1,2,3],),)
+ └── ((ARRAY[4,5],),)
 
 # json_array_elements case with array of arrays.
 norm expect=ConvertZipArraysToValues
@@ -211,10 +211,10 @@ project
       └── filters (true)
 
 # No-op case - ConvertZipArraysToValues fires the first time but not the
-# second because the outer zip is over a variable of an array instead of the
-# array itself.
+# second because the outer zip is over an array-valued tuple field instead of
+# a static array.
 norm expect=ConvertZipArraysToValues
-SELECT unnest(x) FROM unnest(ARRAY[[1,2,3],[4,5],[6]]) AS x
+SELECT unnest((x).@1) FROM unnest(ARRAY[ROW(ARRAY[1,2,3]), ROW(ARRAY[4,5]), ROW(ARRAY[6])]) AS t(x)
 ----
 project
  ├── columns: unnest:2
@@ -225,11 +225,11 @@ project
       ├── values
       │    ├── columns: unnest:1!null
       │    ├── cardinality: [3 - 3]
-      │    ├── (ARRAY[1,2,3],)
-      │    ├── (ARRAY[4,5],)
-      │    └── (ARRAY[6],)
+      │    ├── ((ARRAY[1,2,3],),)
+      │    ├── ((ARRAY[4,5],),)
+      │    └── ((ARRAY[6],),)
       └── zip
-           └── unnest(unnest:1) [outer=(1), immutable]
+           └── unnest((unnest:1).@1) [outer=(1), immutable]
 
 # No-op case - an unnest with multiple inputs is not matched.
 norm expect-not=ConvertZipArraysToValues

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -989,15 +989,7 @@ project
 build
 SELECT ARRAY(VALUES (ARRAY[1]))
 ----
-project
- ├── columns: array:2
- ├── values
- │    └── ()
- └── projections
-      └── array-flatten [as=array:2]
-           └── values
-                ├── columns: column1:1
-                └── (ARRAY[1],)
+error (0A000): unimplemented: arrays of int[] not allowed
 
 build
 SELECT ARRAY(SELECT (1, 2))
@@ -1279,21 +1271,7 @@ project
 build
 SELECT ARRAY(SELECT y FROM u ORDER BY x) FROM v
 ----
-project
- ├── columns: array:10
- ├── scan v
- │    └── columns: v.y:1 v.rowid:2!null v.crdb_internal_mvcc_timestamp:3 v.tableoid:4
- └── projections
-      └── array-flatten col=9 [as=array:10]
-           └── sort
-                ├── columns: y:9  [hidden: x:5]
-                ├── ordering: +5
-                └── project
-                     ├── columns: y:9 x:5
-                     ├── scan u
-                     │    └── columns: x:5 u.rowid:6!null u.crdb_internal_mvcc_timestamp:7 u.tableoid:8
-                     └── projections
-                          └── v.y:1 [as=y:9]
+error (0A000): unimplemented: arrays of int[] not allowed
 
 build-scalar
 ISERROR(1/0)

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -294,9 +294,9 @@ func TestEvalError(t *testing.T) {
 		{`'1- 2:3:4 9'::interval`,
 			`could not parse "1- 2:3:4 9" as type interval: invalid input syntax for type interval 1- 2:3:4 9`},
 		{`e'\\xdedf0d36174'::BYTES`, `could not parse "\\xdedf0d36174" as type bytes: encoding/hex: odd length hex string`},
-		{`ARRAY[NULL, ARRAY[1, 2]]`, `multidimensional arrays must have array expressions with matching dimensions`},
-		{`ARRAY[ARRAY[1, 2], NULL]`, `multidimensional arrays must have array expressions with matching dimensions`},
-		{`ARRAY[ARRAY[1, 2], ARRAY[1]]`, `multidimensional arrays must have array expressions with matching dimensions`},
+		{`ARRAY[NULL, ARRAY[1, 2]]`, `unimplemented: arrays of int[] not allowed`},
+		{`ARRAY[ARRAY[1, 2], NULL]`, `unimplemented: arrays of int[] not allowed`},
+		{`ARRAY[ARRAY[1, 2], ARRAY[1]]`, `unimplemented: arrays of int[] not allowed`},
 		// TODO(pmattis): Check for overflow.
 		// {`~0 + 1`, `0`},
 		{`9223372036854775807::int + 1::int`, `integer out of range`},

--- a/pkg/sql/sem/eval/testdata/eval/array
+++ b/pkg/sql/sem/eval/testdata/eval/array
@@ -23,7 +23,7 @@ ARRAY['a','b','c']
 eval
 ARRAY[ARRAY[1, 2], ARRAY[2, 3]]
 ----
-ARRAY[ARRAY[1,2],ARRAY[2,3]]
+unimplemented: arrays of int[] not allowed
 
 eval
 ARRAY[1, NULL]
@@ -60,17 +60,17 @@ NULL
 eval
 array_length(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 1)
 ----
-2
+unimplemented: arrays of int[] not allowed
 
 eval
 array_length(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 2)
 ----
-3
+unimplemented: arrays of int[] not allowed
 
 eval
 array_length(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 3)
 ----
-NULL
+unimplemented: arrays of int[] not allowed
 
 eval
 array_lower(ARRAY[1, 2, 3], 1)
@@ -95,17 +95,17 @@ NULL
 eval
 array_lower(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 1)
 ----
-1
+unimplemented: arrays of int[] not allowed
 
 eval
 array_lower(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 2)
 ----
-1
+unimplemented: arrays of int[] not allowed
 
 eval
 array_lower(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 3)
 ----
-NULL
+unimplemented: arrays of int[] not allowed
 
 eval
 array_upper(ARRAY[1, 2, 3], 1)
@@ -130,17 +130,17 @@ NULL
 eval
 array_upper(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 1)
 ----
-2
+unimplemented: arrays of int[] not allowed
 
 eval
 array_upper(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 2)
 ----
-3
+unimplemented: arrays of int[] not allowed
 
 eval
 array_upper(ARRAY[ARRAY[1, 2, 3], ARRAY[1, 2, 3]], 3)
 ----
-NULL
+unimplemented: arrays of int[] not allowed
 
 # overlap, contains, contained by (&&, @>, <@)
 

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -3039,6 +3039,8 @@ func IsStringType(t *T) bool {
 // the issue number should be included in the error report to inform the user.
 func IsValidArrayElementType(t *T) (valid bool, issueNum int) {
 	switch t.Family() {
+	case ArrayFamily:
+		return false, 32552
 	case TSQueryFamily:
 		return false, 90886
 	case TSVectorFamily:

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -20,6 +20,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestArrayElementTypeSupport(t *testing.T) {
+	for _, tc := range []struct {
+		typ   *T
+		issue int
+	}{
+		{String, 0},
+		{Int, 0},
+		{Unknown, 0},
+		{MakeTuple([]*T{StringArray}), 0},
+		{StringArray, 32552},
+		{IntArray, 32552},
+		{MakeArray(StringArray), 32552},
+		{TSQuery, 90886},
+		{TSVector, 90886},
+		{PGVector, 121432},
+	} {
+		t.Run(tc.typ.String(), func(t *testing.T) {
+			valid, issue := IsValidArrayElementType(tc.typ)
+			require.Equal(t, tc.issue == 0, valid)
+			require.Equal(t, tc.issue, issue)
+			if tc.issue == 0 {
+				require.NoError(t, CheckArrayElementType(tc.typ))
+			} else {
+				require.Error(t, CheckArrayElementType(tc.typ))
+			}
+		})
+	}
+}
+
 func TestTypes(t *testing.T) {
 	enCollate := "en"
 


### PR DESCRIPTION
## Summary

Reject array-valued elements in `ARRAY[...]` and `ARRAY(subquery)` through the existing shared array-element support check. This addresses #146717 by reporting the existing unsupported multidimensional-array feature instead of producing an incorrectly formatted nested result.

This is a constructor/type-validation fix, **not an implementation of multidimensional arrays or a universal rejection of every nested-array-producing operation**. In particular, the existing `array_agg(array)` exception is deliberately unchanged. Guidance on that remaining scope is requested below.

## Problem and root cause

The reported expression is:

```sql
SELECT ARRAY[ARRAY['a']]::TEXT;
```

It succeeds on the baseline but produces `{"{a}"}`. This quotes the inner array's text as an outer element rather than representing the intended multidimensional value `{{a}}`. The issue explicitly accepts an unsupported-feature error because multidimensional arrays are not fully supported.

Both ARRAY-constructor paths in the optimizer builder already call `types.CheckArrayElementType`. That function delegates to `IsValidArrayElementType`, which rejects unsupported TSQUERY, TSVECTOR and PGVECTOR elements but has no `ArrayFamily` case. Its default branch therefore accepts an array as an array element. An unsupported nested value can be built and constant-folded before formatting exposes the problem; other execution/encoding paths can reject it later instead.

The missing check is at the feature-support boundary, not simply in the text formatter. Changing the formatter alone would not supply the missing nested-array execution, encoding, or storage support.

## How the discrepancy was localized

The investigation compared alternative representations of the same intended multidimensional value:

```sql
-- Constructor forms that succeeded on the baseline with incorrect text.
SELECT ARRAY[ARRAY['a']]::TEXT;
SELECT ARRAY[['a']]::TEXT;
SELECT ARRAY(SELECT ARRAY['a'])::TEXT;
SELECT ARRAY(VALUES (ARRAY['a']))::TEXT;

-- Existing rejection controls.
SELECT '{{a}}'::TEXT[]::TEXT;
SELECT ARRAY[ARRAY['a']]::TEXT[][]::TEXT;
```

Three isolated baseline matrices consistently observed constructor success with `{"{a}"}`, while the dimensional literal and explicit dimensional annotation rejected the unsupported feature with SQLSTATE `0A000` and a reference to #32552. Row-mode and forced-DistSQL controls did not make the original text result correct.

This is an **error-based metamorphic relation: consistency of the support/rejection boundary across equivalent intended constructions**, rather than equality between two successful CockroachDB result sets. The error controls do not have executable plans. For the successful baseline constructor, `EXPLAIN (OPT, VERBOSE)` already contained the incorrectly formatted constant in a VALUES plan. `EXPLAIN ANALYZE` confirmed execution of a one-row VALUES operator; the separate SELECT returned the incorrect text. The comparison therefore localizes the discrepancy to planning/type-support validation; it is not a claim of two successful runtime branch traces.

On the candidate, the constructors also reject during planning. The literal and type-annotation controls retain their existing errors. Consistency here means the unsupported-feature class/SQLSTATE and feature reference, **not identical complete error wording across syntactic forms**.

## Repair method and scope

The only production change is the missing case in `pkg/sql/types/types.go`:

```go
case ArrayFamily:
    return false, 32552
```

`CheckArrayElementType` converts this into the existing unimplemented-feature error. Reusing the shared predicate covers its existing constructor, scalar-evaluation and type-validation callers without adding ad hoc checks to each syntax form. The constructor rejection is based on element type, including typed NULL/empty inputs, rather than depending on whether an unsupported value happens to be produced at runtime.

The patch does not change `types.MakeArray`, type serialization, `upgradeType`, `UserDefined`, arithmetic, or text formatting. Normal flat arrays, scalar strings containing braces, and arrays of tuples whose fields contain arrays remain supported. Existing TSQUERY/TSVECTOR/PGVECTOR restrictions remain unchanged.

The other eight changed files are tests or fixtures:

- Add direct element-support regression coverage and the original SQL plus bracket, SELECT, VALUES, empty and NULL constructor cases.
- Replace two old array fixtures that expected local nested-array success but distributed failure with planning-error expectations.
- Update evaluator/builder fixtures whose previously accepted nested constructors are now rejected earlier.
- Rewrite affected optimizer-rule fixtures using supported flat arrays or tuple-containing arrays, retaining their existing rule expectations rather than deleting the coverage.

## Relation to the previously closed PR

[#168470](https://github.com/cockroachdb/cockroach/pull/168470) targeted #167545, not #146717. It proposed relaxing nested-array unmarshaling for user-defined types; #146717 was cited during review as a risk of admitting incompletely supported arrays-of-arrays. That PR was [closed in favor of rejecting domain-of-array creation](https://github.com/cockroachdb/cockroach/pull/168470#issuecomment-4270749447). The replacement [#168715](https://github.com/cockroachdb/cockroach/pull/168715) was merged.

This patch follows the early-rejection direction for a different entry point. The baseline already contains the domain-of-array/tuple creation restrictions, and they remain unchanged. The nested-array unmarshaling assertion is not relaxed, and no UDT exception is introduced. This history supports the distinction in approach; it is not a claim of prior approval of this particular patch.

## Completed local verification

The candidate is `49af5ea57c9943cdba56cff708f4fad3241d2bda`, based independently on `8812064a015d2faf99d3fc7e15880f94042954b0`.

- The new direct type-support test and native SQL regression fail on unmodified production code and pass on the candidate. The new regression cases were held unchanged across those runs; updates to pre-existing fixtures are separate.
- Three candidate matrices and eight additional constructor cases pass, including array-valued columns, a scanned subquery, correlation, other element types, empty/NULL elements, and a third dimension. Existing rejection controls and supported controls remain unchanged.
- The complete selected `array`, `aggregate`, and `srfs` logic files pass in local, local-vec-off, fakedist, fakedist-vec-off and fakedist-disk. The new regression has RUN/PASS records in all five configurations. `pg_catalog` passes its selected local-only configuration.
- Final types, parser, tree, eval, normalize, colinfo, optbuilder, norm and SQL-package targets pass. The SQL package's actual 16-shard run is retained; this does not mean every package or every logic configuration in the repository was tested.

These describe completed local validation of the existing candidate, not upstream CI status. No new test execution is implied by opening this PR.

## Known limitations and compatibility implications

1. **`array_agg(array)` remains an exception.** Its existing explicitly registered array-input overload can still produce nested output such as `{"{b,c}"}`. Overload generation first checks a scalar element type, then synthesizes the array-input overload without reapplying this predicate to that array type. It is explicitly blocked from distributed evaluation because nested-array value encoding is unsupported. This PR does not remove that overload or correct its text representation; an existing regression and the candidate's additional checks preserve that behavior.
2. **This is intentionally a behavior change.** Some nested constructors that previously succeeded locally now fail, including uses without a final `::TEXT`. Applications relying on that incomplete local-only behavior will receive an unsupported-feature error. Ordinary supported one-dimensional arrays are not intended to change.
3. **No multidimensional-array implementation is added.** Correct formatting, distributed encoding, storage, ordering and general round-trip behavior for such values remain outside this patch. Keeping internal `MakeArray` nesting available does not make nested values generally supported SQL values.
4. **This is not a repair for pre-existing invalid descriptors or every possible nested-array entry point.** Domain creation restrictions come from the existing baseline, and this change neither reopens them nor claims to repair legacy metadata. Mixed-version execution and a comprehensive audit of every array-producing built-in are not covered by the checks listed above.

The deliberate preservation of `array_agg(array)` means this should be reviewed as a bounded constructor fix, not as a claim that all concerns about nested arrays have been eliminated.

## Questions for review and possible follow-up

Would you like me to continue addressing the remaining nested-array entry points, especially `array_agg(array)`, in this PR or in a separate follow-up? Is preserving that existing overload the preferred compatibility boundary for this constructor fix, or should it also become an unsupported-feature error?

If further rejection work is desired, the next step would be to audit array-input overload registration and other array-producing paths, distinguish nesting operations from flattening operations such as `array_cat_agg`, and assess the compatibility impact before changing the accepted signatures or results. That follow-up is **not implemented or validated here**. Full multidimensional support would instead need a broader design across type representation, formatting, execution and encoding; it should not be implied by a formatter-only change or an unmarshaling exception.

Should remaining work be tracked under #146717, under the broader #32552, or in a separate issue? The existing commit has an issue-closing trailer, so the intended tracking boundary should be agreed before merge.

See also: #146717, #32552
Epic: none

Release note (bug fix): Nested ARRAY[...] and ARRAY(subquery) constructors now consistently return an unsupported-feature error instead of producing incorrectly formatted multidimensional arrays.
