### PR TITLE
sql/jsonpath: preserve boolean results for empty comparisons

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists_index_acceleration
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists_index_acceleration
@@ -302,25 +302,25 @@ SELECT a, jsonb_path_exists(b, '$.lllaaann.dddooo == 123123') FROM json_tab ORDE
 14  true
 15  true
 
-# Result from this query is different from PG, tracked by #154588.
+# Missing lax members produce an empty comparison sequence (regression #154588).
 query IT
 SELECT a, jsonb_path_query(b, '$.lllaaann.dddooo == 123123') as jpq FROM json_tab@primary WHERE jsonb_path_exists(b, '$.lllaaann.dddooo == 123123') ORDER BY a, jpq;
 ----
-1   null
-2   null
-3   null
-4   null
-5   null
-6   null
-7   null
-8   null
-9   null
-10  null
-11  null
-12  null
-13  null
-14  null
-15  null
+1   false
+2   false
+3   false
+4   false
+5   false
+6   false
+7   false
+8   false
+9   false
+10  false
+11  false
+12  false
+13  false
+14  false
+15  false
 
 query IB
 SELECT a, jsonb_path_exists(b, '$.a.b like_regex "hi.*"') FROM json_tab ORDER BY a;
@@ -341,20 +341,20 @@ SELECT a, jsonb_path_exists(b, '$.a.b like_regex "hi.*"') FROM json_tab ORDER BY
 14  true
 15  true
 
-# Result from this query is different from PG, tracked by #154589.
+# Missing lax members have no regex matches (regression #154589).
 query IT
 SELECT a, jsonb_path_query(b, '$.a.b like_regex "hi.*"') as jpq FROM json_tab@primary WHERE jsonb_path_exists(b, '$.a.b like_regex "hi.*"') ORDER BY a, jpq;
 ----
-1   null
-2   null
+1   false
+2   false
 3   false
 4   null
-5   null
+5   false
 6   null
 7   null
 8   false
 9   false
-10  null
+10  false
 11  null
 12  null
 13  null
@@ -368,25 +368,25 @@ SELECT a, jsonb_path_query(b, '$.a.b like_regex "hi.*"') as jpq FROM json_tab@fo
 statement error index "foo_inv" is inverted and cannot be used for this query
 SELECT a, jsonb_path_query(b, '$.lllaaann.dddooo == 123123') as jpq FROM json_tab@foo_inv WHERE jsonb_path_exists(b, '$.lllaaann.dddooo == 123123') ORDER BY a, jpq;
 
-# Result from this query is different from PG, tracked by #154588.
+# Missing lax members produce an empty comparison sequence (regression #154588).
 query IT
 SELECT a, jsonb_path_query(b, '$.lllaaann.dddooo == 123123') as jpq FROM json_tab@primary WHERE jsonb_path_exists(b, '$.lllaaann.dddooo == 123123') ORDER BY a, jpq;
 ----
-1   null
-2   null
-3   null
-4   null
-5   null
-6   null
-7   null
-8   null
-9   null
-10  null
-11  null
-12  null
-13  null
-14  null
-15  null
+1   false
+2   false
+3   false
+4   false
+5   false
+6   false
+7   false
+8   false
+9   false
+10  false
+11  false
+12  false
+13  false
+14  false
+15  false
 
 # Without json_path_exists in the filter, hinted inverted index will not work.
 statement error index "foo_inv" is inverted and cannot be used for this query

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -2111,3 +2111,46 @@ SELECT jsonb_path_query('{"LIKE_REGEx": 1}'::JSONB, '$.LIKE_REGEx'::JSONPATH);
 query T
 SELECT jsonb_path_query('{"LIKE_REGEx": 1}'::JSONB, '$.LIKE_REGEX'::JSONPATH);
 ----
+
+subtest regression_145399
+
+# Empty comparison operands produce false, whose type is boolean. Genuine
+# unknown comparisons must still produce JSON null and report type null.
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '($[*].a > 3).type()');
+----
+"boolean"
+
+query ITTT
+WITH inputs(id, doc) AS (VALUES
+  (1, '[1,2,3]'), (2, '[{},{}]'), (3, '[]'),
+  (4, '[{"a":2}]'), (5, '[{"a":5}]'), (6, '[{"a":"x"}]'),
+  (7, '[{"a":null}]'), (8, '[{"a":"x"},{"a":5}]')
+)
+SELECT id,
+  jsonb_path_query(doc::JSONB, '$[*].a > 3'),
+  jsonb_path_query(doc::JSONB, '($[*].a > 3).type()'),
+  jsonb_path_query(doc::JSONB, '($[*].a > 3) is unknown')
+FROM inputs ORDER BY id;
+----
+1  false  "boolean"  false
+2  false  "boolean"  false
+3  false  "boolean"  false
+4  false  "boolean"  false
+5  true   "boolean"  false
+6  null   "null"     true
+7  false  "boolean"  false
+8  true   "boolean"  false
+
+query T
+SELECT jsonb_path_query('[1,2,3]', '(3 < $[*].a).type()');
+----
+"boolean"
+
+query TTT
+SELECT
+  jsonb_path_query('{}', 'strict ($.missing > 3).type()', '{}', true),
+  jsonb_path_query('{}', '(1 / 0 > 3).type()', '{}', true),
+  jsonb_path_query('null', '$.type()');
+----
+"null"  "null"  "null"

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -147,15 +147,10 @@ func jsonpathQuery(
 // eval evaluates a JSONPath expression against a JSON value and returns a
 // slice of results.
 //
-// Return value semantics are critical for proper JSONPath behavior:
-//   - nil slice: Path evaluation failed or path does not exist (e.g., $.nonexistent)
-//     In comparisons: returns unknown/null in strict mode, false in lax mode
-//   - Empty slice ([]json.JSON{}): Path exists but contains no items (e.g., empty array [])
-//     In comparisons: returns false in lax mode (no items to compare).
-//   - Non-empty slice: Path found one or more matching items.
-//
-// This distinction is essential for JSONPath comparison operations to match
-// PostgreSQL behavior.
+// Empty result sequences may be represented by nil or empty slices. In silent
+// mode, evaluation failures can also yield nil without an error. Callers that
+// need to distinguish empty results from failures must disable silent evaluation
+// and inspect the returned error.
 //
 // Many of jsonpath operations require automatic unwrapping of arrays in lax
 // mode. If the input value is an array the operation is performed not on the

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -265,22 +265,28 @@ func (ctx *jsonpathCtx) evalPredicate(
 	exec func(op jsonpath.Operation, l, r json.JSON) (jsonpathBool, error),
 	evalRight, unwrapRight bool,
 ) (jsonpathBool, error) {
+	// Predicates turn operand errors into unknown, even in silent mode. Keep
+	// those errors distinguishable from a valid empty sequence until we handle
+	// them here. Copy the context so enclosing expressions retain their mode.
+	operandCtx := *ctx
+	operandCtx.silent = false
+
 	// The left argument results are always auto-unwrapped.
-	left, err := ctx.evalAndUnwrapResult(op.Left, jsonValue, true /* unwrap */)
+	left, err := operandCtx.evalAndUnwrapResult(op.Left, jsonValue, true /* unwrap */)
 	if !isIgnorableError(err) {
 		return jsonpathBoolUnknown, err
 	}
-	if err != nil || left == nil {
+	if err != nil {
 		return jsonpathBoolUnknown, nil //nolint:returnerrcheck
 	}
 	var right []json.JSON
 	if evalRight {
 		// The right argument results are conditionally evaluated and unwrapped.
-		right, err = ctx.evalAndUnwrapResult(op.Right, jsonValue, unwrapRight)
+		right, err = operandCtx.evalAndUnwrapResult(op.Right, jsonValue, unwrapRight)
 		if !isIgnorableError(err) {
 			return jsonpathBoolUnknown, err
 		}
-		if err != nil || right == nil {
+		if err != nil {
 			return jsonpathBoolUnknown, nil //nolint:returnerrcheck
 		}
 	} else {


### PR DESCRIPTION
## Problem

The query reported in #145399 returns the JSON string `"null"` instead of `"boolean"`:

```sql
SELECT jsonb_path_query('[1, 2, 3]', '($[*].a > 3).type()');
```

In the default lax mode, `$[*].a` selects no items from this input. The comparison has existential semantics: it is true if some selected item satisfies `> 3`. With no items and no operand-evaluation error, it must be false. Its type is therefore `"boolean"`.

The defect occurs before `.type()`: the comparison incorrectly produces `unknown`, which is converted to JSON `null`. The type method correctly reports the type of that wrong input. JSON `null` here is not SQL NULL.

## Metamorphic relations used to establish the correct result

The investigation compared the original query W with two semantics-preserving transformations, C_materialized and C_guard, on the same database state. It observed the predicate value, its `.type()`, and `is unknown` together, rather than checking the displayed type alone.

Both relations below are scoped to lax evaluation, an error-free path operand producing a sequence of scalar terminal values, and the fixed, error-free scalar right operand `3`. Incompatible scalar comparisons are retained as genuine-unknown controls. These are not unconditional rewrite rules for strict paths, suppressed evaluation errors, arbitrary nested arrays, or context-dependent paths.

The input matrix was:

```sql
CREATE TABLE inputs (id INT PRIMARY KEY, doc JSONB);
INSERT INTO inputs VALUES
  (1, '[1,2,3]'),
  (2, '[{},{}]'),
  (3, '[]'),
  (4, '[{"a":2}]'),
  (5, '[{"a":5}]'),
  (6, '[{"a":"x"}]'),
  (7, '[{"a":null}]'),
  (8, '[{"a":"x"},{"a":5}]');

-- W: original predicate, observed in three ways.
SELECT id,
  jsonb_path_query(doc, '$[*].a > 3') AS predicate,
  jsonb_path_query(doc, '($[*].a > 3).type()') AS kind,
  jsonb_path_query(doc, '($[*].a > 3) is unknown') AS unknown
FROM inputs ORDER BY id;
```

### MR1: materialize and unwrap the same selected sequence

Let S be the scalar sequence selected by `$[*].a`. Materializing S as a JSON array and then automatically unwrapping that root array in a lax comparison preserves the items and their JSON types. Thus `S > 3` must agree with `unwrap(materialize(S)) > 3`:

```sql
WITH seq AS MATERIALIZED (
  SELECT id, jsonb_path_query_array(doc, '$[*].a') AS items
  FROM inputs
)
SELECT id,
  jsonb_path_query(items, '$ > 3') AS predicate,
  jsonb_path_query(items, '($ > 3).type()') AS kind,
  jsonb_path_query(items, '($ > 3) is unknown') AS unknown
FROM seq ORDER BY id;
```

The direct root `$` is important to the diagnosis. An initial probe using `$[*]` after materialization still reached the faulty nil-empty representation and was rejected as a correct-result oracle. Comparing the root array instead uses existing automatic unwrapping, producing a non-nil empty slice for `[]`. It preserves the intended sequence while exposing the representation-dependent result.

### MR2: guard an existential comparison with existence of its operand

Under the conditions above, `P(S) = (S > 3)` must equal `exists(S) && P(S)`: when S is empty, both are false; when S is nonempty, the guard is true and preserves P, including a genuine unknown result.

```sql
SELECT id,
  jsonb_path_query(doc, 'exists($[*].a) && ($[*].a > 3)') AS predicate,
  jsonb_path_query(doc, '(exists($[*].a) && ($[*].a > 3)).type()') AS kind,
  jsonb_path_query(doc, '(exists($[*].a) && ($[*].a > 3)) is unknown') AS unknown
FROM inputs ORDER BY id;
```

This guard is not an oracle for arbitrary error-producing operands: its short circuit can hide an error. Such cases were tested separately as preservation controls, not counted as equivalent votes.

### Observed results

Three complete baseline runs agreed. Both transformed queries agreed on all eight inputs; W disagreed only on the three empty-sequence inputs. Three candidate runs restored agreement. The tuples below are `(predicate, type, is unknown)`; `null` denotes JSON null.

| Inputs | Baseline W | Baseline C_materialized and C_guard | Candidate W and both C queries |
|---|---|---|---|
| IDs 1–3: empty selected sequence | `(null, "null", true)` | `(false, "boolean", false)` | `(false, "boolean", false)` |
| ID 4: numeric non-match | `(false, "boolean", false)` | same | same |
| ID 5: numeric match | `(true, "boolean", false)` | same | same |
| ID 6: incompatible string | `(null, "null", true)` | same | same |
| ID 7: actual JSON null item | `(false, "boolean", false)` | same | same |
| ID 8: incompatible item plus a matching number | `(true, "boolean", false)` | same | same |

The expectation is justified by the existential semantics and the two different equivalent evaluation paths, not merely by choosing the majority output. The issue's PostgreSQL result also agrees with the corrected exact reproducer.

## How the root cause was localized

For W and C_guard, `EXPLAIN (OPT, VERBOSE)` retained the same relational structure; the relevant difference was the JSONPath scalar argument. `EXPLAIN ANALYZE` showed the same local `scan -> project set -> sort` pipeline, with eight decoded input rows and eight emitted rows at each operator. The separate SELECT results above establish the value discrepancy; EXPLAIN ANALYZE itself is not a value oracle.

Row-engine and forced-DistSQL-setting runs reproduced the same result matrix. The captured W/C analyzed plans ran on n1, so this evidence does not claim a cross-node execution trace. It localizes the discrepancy to scalar JSONPath evaluation rather than row loss or a different relational operator pipeline. The following branch-level explanation comes from source inspection, not from instrumented branch tracing.

In `pkg/util/jsonpath/eval/operation.go`, `evalPredicate` previously treated `left == nil` or `right == nil` as `unknown`, even when the returned error was nil. However, a successful lax path with no matches can legitimately return a nil slice. The original query therefore followed this path:

```text
lax missing member -> valid empty sequence (nil, no error)
                   -> evalPredicate's nil guard returns unknown
                   -> convertFromBool emits JSON null
                   -> type() correctly reports "null"
```

The materialized-root arm represents the same empty sequence as a non-nil empty slice and reaches the existing false result. The existence-guard arm yields false for the empty selection. This explains both the observed metamorphic violation and its precise source-level divergence.

There is a second constraint: with `silent=true`, a real evaluation error can also be suppressed into `(nil, nil)`. Simply removing the nil checks would therefore conflate genuine errors with successful empty results and incorrectly change some unknown predicates to false.

## Repair and rationale

`evalPredicate` now copies the evaluation context and disables silent suppression only while evaluating its operands:

```go
operandCtx := *ctx
operandCtx.silent = false
```

Both operands use this copy. The existing error classification is retained: non-ignorable errors still propagate, and ignorable operand errors produce `unknown`. When evaluation succeeds, a nil slice is accepted as a valid empty sequence and reaches the existing no-matching-pair result, false. Non-nil empty sequences follow the same semantics.

This is preferable to special-casing `.type()` because it repairs the predicate value itself and preserves the type of genuinely unknown predicates. It is preferable to merely removing the nil guards because it preserves real-error behavior. Copying the context keeps the enclosing expression's silent mode and existing evaluation state intact; it does not change global silent-mode policy. The `eval` return-value comment is updated to document the actual ambiguity instead of treating nilness as a reliable failure indicator.

The repair also respects the relevant implementation history:

- [30ce5204](https://github.com/cockroachdb/cockroach/commit/30ce5204fe730acaecac17d64cf5ea9240e75601) unified comparison and regex predicate evaluation, explaining why the invariant belongs in the shared evaluator.
- [PR #144188](https://github.com/cockroachdb/cockroach/pull/144188) separated structural strictness from silent error suppression. The fix preserves that distinction instead of forcing lax mode.
- [d374f596](https://github.com/cockroachdb/cockroach/commit/d374f596fdf7baa38be5ce4a84a740aad10d3ada) addressed non-nil empty-array results, but a valid nil-empty result can still hit the earlier unknown guard. This repair removes that remaining dependence on slice representation while retaining error information.

## Regression coverage and completed local validation

The checked-in `regression_145399` section adds the exact reported query, the eight-input value/type/unknown matrix, a right-side-empty comparison, and strict-missing-member, silent arithmetic-error, and actual JSON-null type controls. The new regression was red on the baseline and green on the candidate with unchanged test bytes. Existing expectations in `jsonb_path_exists_index_acceleration` are corrected for the same shared predicate behavior. No `.type()` implementation is modified.

The complete MR transformations above were investigation SQL; the committed native regression asserts their established outcomes and preservation controls rather than adding the full MR harness to the repository.

Completed local validation for commit `48ebc1147e82e6174ca522022fcf1dfe53a296b6`, based on `8812064a015d2faf99d3fc7e15880f94042954b0`, includes:

- Three baseline/candidate matrices, the W/C plan comparison, and row-engine/forced-DistSQL-setting controls.
- Fifteen held-out empty predicates: all six comparisons with empty operands on either side, plus prefix, regex, and two-empty-operand cases; query-first/query-array/match API checks.
- Strict/lax crossed with silent true/false arithmetic-error controls, base scalar types, genuine-unknown method chaining, and unchanged enclosing non-predicate silent suppression.
- Shared-invariant validation with a 26-input degeneration matrix: existence-guard and independent SQL-fold mismatch counts both fell from six to zero. Strict/lax silent-mode mismatch counts remained zero; nested context and valid strict-empty controls also passed.
- All seven JSONPath/jsonb_path_* logic files in `local`, `local-vec-off`, `fakedist`, `fakedist-vec-off`, and `fakedist-disk`, including actual RUN/PASS records for this regression in every configuration.
- The complete builtins, `pkg/sql/sem/eval`, JSONPath parser, and SQL package test targets; SQL ran in 16 shards.

These are completed local results, not a claim that upstream PR CI has passed.

## Scope and related issue

This fixes #145399 at its predicate root cause and covers the related empty-operand behavior handled by the same evaluator. It deliberately preserves genuine unknown comparisons, strict structural errors, ignorable-error conversion to unknown, non-ignorable error propagation, and outer silent behavior. It does not redesign `.type()`, JSON null semantics, or all JSONPath compatibility behavior; the MR assumptions above are not broadened into general optimizer rewrites.

#154589 has the same underlying nil-empty predicate defect, exposed through regex. The two production-file changes and existing acceleration-fixture corrections are identical to that issue's prepared fork repair. This PR carries the shared fix with the dedicated #145399 regression; it is not a second independent implementation, and it does not include #154589's separate new regression section. There is no separate upstream PR for that fork repair at submission time. The shared production patch should be landed once, not as two unrelated fixes.

Resolves: #145399
See also: #154589
Epic: none

Release note (bug fix): Fixed JSONPath comparisons over missing lax members returning JSON null rather than false, which could cause a following type() method to return "null" rather than "boolean".
