### PR TITLE
sql: preserve filter semantics in distinct aggregations

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2319,10 +2319,12 @@ func (dsp *DistSQLPlanner) planAggregators(
 	}
 
 	// We can have a local stage of distinct processors if all aggregation
-	// functions are distinct.
+	// functions are distinct and none have a filter. The distinct key contains
+	// only the aggregate argument columns, so rows with the same arguments but
+	// different filter values must not be deduplicated before aggregation.
 	allDistinct := true
 	for _, e := range info.aggregations {
-		if !e.Distinct {
+		if !e.Distinct || e.FilterColIdx != nil {
 			allDistinct = false
 			break
 		}

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4034,3 +4034,122 @@ query R
 SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
 ----
 {2.2}
+
+subtest distinct_filter
+
+# Regression tests for #131087. A row that fails one aggregate's FILTER may
+# still contribute to another aggregate. Deduplicating only on the aggregate
+# arguments before evaluating the filters can discard such a row.
+query III
+WITH data AS (
+  SELECT * FROM unnest(
+    ARRAY[1, 2, 3, 4, 1],
+    ARRAY[true, true, true, true, false]
+  ) AS t(id, value)
+)
+SELECT count(DISTINCT id),
+       count(DISTINCT id) FILTER (WHERE value IS TRUE),
+       count(DISTINCT id) FILTER (WHERE value IS FALSE)
+FROM data;
+----
+4  4  1
+
+# Expressing the filters as nullable arguments must produce the same result.
+query III
+WITH data AS (
+  SELECT * FROM unnest(
+    ARRAY[1, 2, 3, 4, 1],
+    ARRAY[true, true, true, true, false]
+  ) AS t(id, value)
+)
+SELECT count(DISTINCT id),
+       count(DISTINCT CASE WHEN value IS TRUE THEN id END),
+       count(DISTINCT CASE WHEN value IS FALSE THEN id END)
+FROM data;
+----
+4  4  1
+
+# Reversing the input must not change which filter sees the duplicate id.
+query III
+WITH data AS (
+  SELECT * FROM unnest(
+    ARRAY[1, 4, 3, 2, 1],
+    ARRAY[false, true, true, true, true]
+  ) AS t(id, value)
+)
+SELECT count(DISTINCT id),
+       count(DISTINCT id) FILTER (WHERE value IS TRUE),
+       count(DISTINCT id) FILTER (WHERE value IS FALSE)
+FROM data;
+----
+4  4  1
+
+# NULL arguments are not counted, and NULL filter values do not contribute.
+query III
+WITH data(id, value) AS (
+  VALUES (1, true), (1, false), (2, NULL),
+         (NULL, true), (NULL, false), (3, true), (3, false)
+)
+SELECT count(DISTINCT id),
+       count(DISTINCT id) FILTER (WHERE value),
+       count(DISTINCT id) FILTER (WHERE NOT value)
+FROM data;
+----
+3  2  2
+
+# Even identical filters on different aggregates must run before deduplication.
+query IR
+WITH data(id, value) AS (
+  VALUES (1, false), (1, true), (2, true), (2, false), (3, NULL)
+)
+SELECT count(DISTINCT id) FILTER (WHERE value),
+       sum(DISTINCT id) FILTER (WHERE value)
+FROM data;
+----
+2  3
+
+# Each aggregate must keep its own filtered set, including different arguments.
+query IIII
+WITH data(x, y, value) AS (
+  VALUES (1, 10, true), (1, 10, false),
+         (2, 10, true), (2, 10, false), (3, 20, NULL)
+)
+SELECT count(DISTINCT x),
+       count(DISTINCT x) FILTER (WHERE NOT value),
+       count(DISTINCT y) FILTER (WHERE value),
+       count(DISTINCT y) FILTER (WHERE NOT value)
+FROM data;
+----
+3  2  1  1
+
+# Exercise table scans and repeated values across input batches. The fakedist
+# configurations also plan scans across multiple nodes.
+statement ok
+CREATE TABLE distinct_filter_test (id INT, value BOOL);
+INSERT INTO distinct_filter_test
+  SELECT i % 17, i % 34 < 17 FROM generate_series(0, 4999) AS g(i);
+
+query III
+SELECT count(DISTINCT id),
+       count(DISTINCT id) FILTER (WHERE value),
+       count(DISTINCT id) FILTER (WHERE NOT value)
+FROM distinct_filter_test;
+----
+17  17  17
+
+# Aggregates without filters and aggregates over empty input remain correct.
+query IR
+SELECT count(DISTINCT id), sum(DISTINCT id) FROM distinct_filter_test;
+----
+17  136
+
+query IIR
+SELECT count(DISTINCT id),
+       count(DISTINCT id) FILTER (WHERE value),
+       sum(DISTINCT id) FILTER (WHERE NOT value)
+FROM distinct_filter_test WHERE id < 0;
+----
+0  0  NULL
+
+statement ok
+DROP TABLE distinct_filter_test;


### PR DESCRIPTION
Fixes #131087.

Queries combining DISTINCT aggregates and FILTER clauses can return incorrect results when the same aggregate argument occurs in rows with different filter outcomes. This change prevents a pre-aggregation DISTINCT stage from discarding rows that a filtered aggregate still needs.

## Problem and root cause

For the input below, the three counts should be `(4, 4, 1)`. Before this fix, they are `(4, 4, 0)`:

```sql
WITH data AS (
  SELECT * FROM unnest(
    ARRAY[1, 2, 3, 4, 1],
    ARRAY[true, true, true, true, false]
  ) AS t(id, value)
)
SELECT count(DISTINCT id),
       count(DISTINCT id) FILTER (WHERE value IS TRUE),
       count(DISTINCT id) FILTER (WHERE value IS FALSE)
FROM data;
```

`DistSQLPlanner.planAggregators` inserts local DISTINCT processors when every aggregation specification has `Distinct=true`. The DISTINCT key is the union of the aggregates' argument columns (`ColIdx`); their filter columns (`FilterColIdx`) are omitted.

For this query, that key is just `id`. The rows `(1, true)` and `(1, false)` are deduplicated before either filtered aggregate evaluates its predicate. If the first row survives, the FALSE-filtered count loses its only contributing value. Reversing the input can instead lose a value from the TRUE-filtered count. Even aggregates sharing the same FILTER can be affected when duplicate arguments have different filter outcomes.

The aggregate processors already implement the required order: apply each aggregate's FILTER, then deduplicate the arguments that passed that filter. The incorrect result originates in the earlier physical-plan optimization.

## How the problem was localized

The investigation used a metamorphic repair workflow with the issue's expected full result `(4, 4, 1)` as an explicit oracle:

1. Reproduce the complete three-column query and retain its incorrect result as the failing observation.
2. Generate equivalent queries that preserve all three output columns. One transformation replaces `count(DISTINCT id) FILTER (WHERE p)` with `count(DISTINCT CASE WHEN p THEN id END)`. Other references compute the aggregates in separate scalar subqueries. All four generated references returned the expected full result.
3. Compare query plans and instrumented Go coverage for the failing query and the references to guide source inspection. The coverage samples include test-server startup and background work, so they were treated as process-level execution evidence. Inspection of DISTINCT-stage construction and the aggregate's filter-before-distinct processing established the failure mechanism.
4. Independently inspect `EXPLAIN (VEC)` before and after the fix. The failing plan contains `colexec.UnorderedDistinct` before `rowexec.orderedAggregator`; the repaired plan omits the former. An unfiltered DISTINCT control retains its pre-aggregation DISTINCT operator and its correct result.

The initial diagnosis and one-line eligibility change were proposed by DeepSeek. The proposed fix was then independently checked by source inspection and deterministic result comparisons, including additional inputs outside the original repair run.

## Fix

The pre-aggregation DISTINCT optimization now requires every aggregate to be DISTINCT **and to have no FILTER**:

```go
if !e.Distinct || e.FilterColIdx != nil {
    allDistinct = false
    break
}
```

The final aggregate specifications retain their DISTINCT and FILTER settings, so each aggregate sees all of the rows it needs before performing its own deduplication. Unfiltered all-DISTINCT aggregations remain eligible for the optimization. A comment records why filtered aggregates must be excluded.

This is a conservative eligibility restriction. It can increase the rows processed or transmitted for duplicate-heavy filtered aggregations. Extending the pre-aggregation key to include all filter columns could be investigated separately; this PR does not claim a performance improvement.

## Regression coverage and validation

The existing `aggregate` SQL logic test file gains a standalone `distinct_filter` subtest with nine queries covering:

- The complete issue query and its equivalent CASE form.
- Reversed input order and NULL arguments/predicates.
- Identical FILTER predicates on COUNT and SUM.
- Different aggregate argument columns.
- A 5,000-row table scan with duplicates across input batches.
- Unfiltered DISTINCT aggregates and empty input.

Validated against upstream commit `8812064a015d2faf99d3fc7e15880f94042954b0`:

| Native configuration | New subtest before fix | New subtest after fix | Complete `aggregate` file after fix |
| --- | --- | --- | --- |
| `local` | FAIL: `(4,4,0)` vs `(4,4,1)` | PASS | 685 checks, 0 failures |
| `local-vec-off` | FAIL: `(4,4,0)` vs `(4,4,1)` | PASS | 685 checks, 0 failures |
| `fakedist` (3 nodes) | FAIL: `(4,4,0)` vs `(4,4,1)` | PASS | 685 checks, 0 failures |
| `fakedist-vec-off` (3 nodes) | FAIL: `(4,4,0)` vs `(4,4,1)` | PASS | 685 checks, 0 failures |

The baseline runner stops at the first mismatch; the before-fix result above is the original issue query. After the fix, each focused run executes all nine SQL queries plus setup/cleanup. The complete-file runs have no skipped subtests. The 685 checks include statements and queries, rather than 685 separate Go test functions.

The native targets can be run with:

```sh
bazel test \
  //pkg/sql/logictest/tests/local:local_test \
  //pkg/sql/logictest/tests/local-vec-off:local-vec-off_test \
  //pkg/sql/logictest/tests/fakedist:fakedist_test \
  //pkg/sql/logictest/tests/fakedist-vec-off:fakedist-vec-off_test \
  --test_sharding_strategy=disabled \
  --test_filter='^TestLogic_aggregate$/^distinct_filter$' \
  --test_arg=-test.count=1
```

Repeating with `--test_filter='^TestLogic_aggregate$'` runs the surrounding aggregate file. Local execution used `--norun_validations`; `crlfmt -fast -tab 2` on the changed Go file, `gofmt`, and `git diff --check` passed separately. No generated test registration or BUILD file changes are needed because the existing aggregate test entry reads this fixture.

Prior independent experiments on the initial checkout ran 52 SQL observations across vectorize on/off: the baseline matched 20 expected results, and the candidate matched all 52. The configured colexec suite also passed all 82 tests. These are supplementary results; the native tests above validate the actual PR base and patch.

For clarity, in this checkout FILTER aggregates use the row processor even with `vectorize=on`. Running both settings checks their respective plans and surrounding operators; it does not establish independent native-vectorized FILTER aggregation coverage. The full CockroachDB repository suite and performance benchmarks have not been run.

Release note (bug fix): Fixed incorrect results from queries combining DISTINCT aggregates and FILTER clauses when rows with the same aggregate arguments had different filter outcomes. Each aggregate now retains the rows required by its own filter before deduplicating its arguments.
