### PR TITLE
sql: reject qualified column names that match whole-row references

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1079,10 +1079,14 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 				}
 				// Attempt to resolve as columnname.*, which allows items
 				// such as SELECT row_to_json(tbl_name) FROM tbl_name to work.
-				return func() (bool, tree.Expr) {
-					defer wrapColTupleStarPanic(resolveErr)
-					return s.VisitPre(columnNameAsTupleStar(string(t.ColumnName)))
-				}()
+				// Qualified column references such as t1.t1 must not fall back to
+				// whole-row tuple expansion; retain the resolver error instead.
+				if t.TableName == nil || t.TableName.Object() == "" {
+					return func() (bool, tree.Expr) {
+						defer wrapColTupleStarPanic(resolveErr)
+						return s.VisitPre(columnNameAsTupleStar(string(t.ColumnName)))
+					}()
+				}
 			}
 			if sqlerrors.IsUndefinedRelationError(resolveErr) && t.TableName.Object() != "" {
 				// If we are inside a PL/pgSQL routine and the prefix names a

--- a/pkg/sql/opt/optbuilder/testdata/qualified-whole-row
+++ b/pkg/sql/opt/optbuilder/testdata/qualified-whole-row
@@ -1,0 +1,42 @@
+exec-ddl
+CREATE TABLE t1(f1 INT)
+----
+
+exec-ddl
+CREATE TABLE t2(f1 INT)
+----
+
+build
+SELECT t1.t1 FROM t1
+----
+error (42703): column "t1.t1" does not exist
+
+build
+SELECT a.a FROM t1 AS a
+----
+error (42703): column "a.a" does not exist
+
+build
+SELECT * FROM t1 WHERE t1.t2 = 1
+----
+error (42703): column "t1.t2" does not exist
+
+build
+SELECT t1.t2 FROM t1, t2
+----
+error (42703): column "t1.t2" does not exist
+
+build
+WITH c AS (SELECT 1 AS x) SELECT c.y FROM c
+----
+error (42703): column "c.y" does not exist
+
+build
+SELECT d.y FROM (SELECT 1 AS x) AS d
+----
+error (42703): column "d.y" does not exist
+
+build
+SELECT (SELECT o.t2 FROM t1) FROM t1 AS o
+----
+error (42703): column "o.t2" does not exist


### PR DESCRIPTION
`SELECT t1.t1 FROM t1` returned a whole-row record when `t1` contained only `f1`. A predicate such as `WHERE t1.t1 IS NULL` could therefore silently test the row instead of reporting a missing column.

Restrict optbuilder's whole-row fallback to unqualified references. Qualified missing columns now preserve the original undefined-column error (`42703`); bare whole-row references and real columns retain their behavior. Add seven native optbuilder regression cases covering qualified names, aliases, predicates, multiple sources, CTEs, derived tables, and correlation.

Fixes #120625.

Related PR: #173881 also addresses this issue. This PR contains an independently generated fix with regression coverage in optbuilder's data-driven tests.

Validation:

- Confirmed that the new regression file fails before the fix and passes afterward.
- Built and ran the complete `//pkg/sql/opt/optbuilder:optbuilder_test` executable on this branch: 109 tests and subtests passed, with no skips.
- Executed 20 SQL cases twice against real single-node test servers and an additional exact-row assertion: 41/41 checks passed. All valid-query rows matched the original baseline, including bare rows, aliases, existing same-named columns, stars, tuple fields, and correlated queries.
- `crlfmt -fast -tab 2` and `git diff --check` passed.

The product fix and regression fixture were generated using DeepSeek, then reviewed and validated locally. Local native test binaries were built with Bazel using `--norun_validations`; the `./dev` wrapper refuses to run in this root execution environment. Full-repository generation and lint are not claimed here.

Release note (bug fix): Fixed a bug where a qualified reference to a nonexistent column, such as `SELECT t1.t1 FROM t1`, could silently return an entire table row. Such references now report an undefined-column error (`SQLSTATE 42703`). Unqualified whole-row references such as `SELECT t1 FROM t1` and references to existing columns remain valid.
