### PR TITLE
opt: expand immediate stars in row constructors

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1041,6 +1041,53 @@ func makeUntypedTuple(labels []string, texprs []tree.TypedExpr) *tree.Tuple {
 // sql/subquery.go.
 func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	switch t := expr.(type) {
+	case *tree.Tuple:
+		// Expand immediate star children so they flatten into the row
+		// constructor fields, while deliberate nested tuples remain intact.
+		needExpand := false
+		for _, e := range t.Exprs {
+			if un, ok := e.(*tree.UnresolvedName); ok {
+				vn, err := un.NormalizeVarName()
+				if err != nil {
+					panic(err)
+				}
+				e = vn
+			}
+			if _, ok := e.(*tree.AllColumnsSelector); ok {
+				needExpand = true
+				break
+			}
+			if _, ok := e.(*tree.TupleStar); ok {
+				needExpand = true
+				break
+			}
+		}
+		if !needExpand {
+			return true, t
+		}
+		newExprs := make(tree.Exprs, 0, len(t.Exprs))
+		for _, child := range t.Exprs {
+			e := child
+			if un, ok := e.(*tree.UnresolvedName); ok {
+				vn, err := un.NormalizeVarName()
+				if err != nil {
+					panic(err)
+				}
+				e = vn
+			}
+			switch star := e.(type) {
+			case *tree.AllColumnsSelector, *tree.TupleStar:
+				_, starExprs := s.builder.expandStar(star, s)
+				for _, starExpr := range starExprs {
+					newExprs = append(newExprs, starExpr)
+				}
+			default:
+				newExprs = append(newExprs, child)
+			}
+		}
+		tupleCopy := *t
+		tupleCopy.Exprs = newExprs
+		return true, &tupleCopy
 	case *tree.AllColumnsSelector, *tree.TupleStar:
 		// AllColumnsSelectors and TupleStars at the top level of a SELECT clause
 		// are replaced when the select's renders are prepared. If we

--- a/pkg/sql/opt/optbuilder/testdata/row-star-expansion
+++ b/pkg/sql/opt/optbuilder/testdata/row-star-expansion
@@ -1,0 +1,136 @@
+# Regression for issue 115150: row constructors expand immediate star fields.
+
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+
+# simple_row_star
+build
+SELECT ROW(xy.*) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (x:1, y:2) [as=r:5]
+
+# mixed_scalar_prefix_suffix
+build
+SELECT ROW(1, xy.*, NULL) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (1, x:1, y:2, NULL) [as=r:5]
+
+# repeated_star
+build
+SELECT ROW(xy.*, xy.*) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (x:1, y:2, x:1, y:2) [as=r:5]
+
+# nested_row_wrapper
+build
+SELECT ROW(ROW(xy.*), 1) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── ((x:1, y:2), 1) [as=r:5]
+
+# tuple_star_expression
+build
+SELECT ROW((ROW(x, y)).*) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (x:1, y:2) [as=r:5]
+
+# table_alias_star
+build
+SELECT ROW(a.*) AS r FROM xy AS a
+----
+project
+ ├── columns: r:5
+ ├── scan xy [as=a]
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (x:1, y:2) [as=r:5]
+
+# control_bare_whole_row
+build
+SELECT ROW(xy) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (((x:1, y:2) AS x, y),) [as=r:5]
+
+# control_deliberate_nested_tuple
+build
+SELECT ROW(ROW(x, y)) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── ((x:1, y:2),) [as=r:5]
+
+# star_then_explicit_columns
+build
+SELECT ROW(xy.*, xy.x, xy.y) AS r FROM xy
+----
+project
+ ├── columns: r:5
+ ├── scan xy
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (x:1, y:2, x:1, y:2) [as=r:5]
+
+# control_alias_whole_row
+build
+SELECT ROW(a) AS r FROM xy AS a
+----
+project
+ ├── columns: r:5
+ ├── scan xy [as=a]
+ │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ └── projections
+      └── (((x:1, y:2) AS x, y),) [as=r:5]
+
+# ordered_array_agg
+build
+SELECT array_agg(ROW(xy.*) ORDER BY x) AS a FROM xy
+----
+scalar-group-by
+ ├── columns: a:6
+ ├── window partition=() ordering=+1
+ │    ├── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4 column5:5 array_agg:6
+ │    ├── project
+ │    │    ├── columns: column5:5 x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    │    ├── scan xy
+ │    │    │    └── columns: x:1!null y:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    │    └── projections
+ │    │         └── (x:1, y:2) [as=column5:5]
+ │    └── windows
+ │         └── array-agg [as=array_agg:6, frame="range from unbounded to unbounded"]
+ │              └── column5:5
+ └── aggregations
+      └── const-agg [as=array_agg:6]
+           └── array_agg:6


### PR DESCRIPTION
`ROW(table.*)` introduced an extra record layer, so `array_agg(ROW(table.*))` returned arrays whose elements had the wrong tuple shape. This PR expands immediate star arguments into the enclosing row constructor's fields, matching [PostgreSQL's row-constructor semantics](https://www.postgresql.org/docs/current/rowtypes.html#ROWTYPES-USAGE).

Fixes #115150.

**Problem and reproduction**

```sql
CREATE TABLE xy (x INT PRIMARY KEY, y INT);
INSERT INTO xy VALUES (1, 2), (100, 100);

SELECT array_agg(ROW(xy.*) ORDER BY x) FROM xy;
```

Before this change, the array contains one-field records whose sole field is another record:

```text
{"(\"(1,2)\")","(\"(100,100)\")"}
```

After this change, it contains the two-field records requested by the query:

```text
{"(1,2)","(100,100)"}
```

The aggregate's `ORDER BY` makes element order explicit for this reproduction; the defect concerns tuple shape, not ordering. The result should match `array_agg(ROW(x, y) ORDER BY x)` and `array_agg(xy.* ORDER BY x)`. Likewise, `ROW(ROW(xy.*))` should preserve its explicit outer row while expanding the inner row's star exactly once.

**Cause and change**

During optbuilder's expression walk, a star encountered as an ordinary expression is converted into a tuple of its expanded columns. That is appropriate for a whole-row argument such as `array_agg(xy.*)`. Previously, the same handling ran for a star directly inside a row constructor: the child became a tuple, and the enclosing `ROW(...)` then wrapped that tuple as one field. The extra nesting was already present in the optimizer expression before aggregate execution.

`scope.VisitPre` now handles `*tree.Tuple` before the generic child walk:

- Normalize unresolved child names when recognizing immediate table/composite stars.
- Keep the original tuple unchanged when no immediate star needs expansion.
- Expand `AllColumnsSelector` and `TupleStar` children with the existing `expandStar` resolver and append each expanded field to the enclosing expression list.
- Copy the original tuple by value, replace only its expression list, and continue ordinary traversal of the resulting children.

**Why this preserves the intended semantics**

Expansion is restricted to syntax that directly requests the fields of a row. It does not flatten arbitrary tuple-valued expressions: `ROW(xy)` still contains one whole-row field, and explicit nested `ROW(...)` layers remain. Non-star children are retained for normal name resolution. Reusing `expandStar` preserves the existing field ordering, visibility rules (including hidden columns), and composite-expression resolution. Copying the tuple preserves its labels and other metadata. Ordinary function-star arguments continue through their existing path.

This fixes the shape at row construction, so aggregate execution and array formatting require no special cases or changes.

**Validation**

The branch is based directly on upstream `8812064a015d2faf99d3fc7e15880f94042954b0` and contains only the product change and its native regression file.

- Added 11 SQL cases to `TestBuilder/row-star-expansion`, including the ordered `array_agg(ROW(xy.*))` reproduction, immediate stars, mixed/repeated fields, aliases, composite-expression stars, deliberate nesting, and bare whole-row controls.
- Generated the expected plans from executed explicit-field reference queries, then froze the fixture. The identical fixture fails on the exact upstream baseline and passes with this patch.
- Built and ran the complete `//pkg/sql/opt/optbuilder:optbuilder_test` executable on this branch: 109 tests and subtests passed, with no failures or skips.
- Executed 22 SQL scenarios with `vectorize=on` and `vectorize=off`, twice per setting: 20/88 observations passed on the upstream baseline and 88/88 passed with the patch. Comparisons retain complete ordered array values, duplicates, NULLs, and tuple nesting. All reference values and previously correct results were unchanged.
- `crlfmt -fast -tab 2` and `git diff --check` passed.

The complete native package can be run with `./dev test pkg/sql/opt/optbuilder`; the focused case is `TestBuilder/row-star-expansion`. In this environment the `./dev generate`, `./dev lint --short`, and `./dev test` wrappers refuse to run as root, so validation used directly built Bazel test executables with `--norun_validations`. Full-repository generation, lint, and tests are not claimed. SQL validation used real single-node test servers; no historical release or separate PostgreSQL binary was tested.

The product fix and the initial regression inputs were generated with DeepSeek, then reviewed and tested locally; an additional direct aggregate regression was added during PR preparation.

Release note (bug fix): Fixed a bug where `ROW(table.*)` introduced an extra level of record nesting instead of expanding the table's fields. This could produce incorrectly nested array elements in expressions such as `array_agg(ROW(table.*))`. Explicit nested `ROW` expressions and whole-row references without a star retain their intended nesting.
