### PR TITLE
kvserver: merge undersized ranges into adequately-sized neighbors

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4539,6 +4539,43 @@ func TestMergeQueue(t *testing.T) {
 		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
 	})
 
+	// These two subtests cover the case where the LHS is undersized but the
+	// RHS individually already meets the minimum size threshold. The merge
+	// queue still merges in this case, as long as the combined size would
+	// stay comfortably below the threshold (below twice the minimum). This
+	// lets an undersized range wedged next to an adequately-sized neighbor
+	// merge away instead of persisting forever, while avoiding merging into
+	// a neighbor that's likely to need to split again soon (see #100443).
+	t.Run("rhs-above-threshold-merges-when-combined-is-small", func(t *testing.T) {
+		reset(t)
+		clearRange(t, lhsStartKey, rhsStartKey)
+
+		conf := conf
+		rhsSize := rhs().GetMVCCStats().Total()
+		// The RHS alone already meets the minimum size threshold...
+		conf.RangeMinBytes = rhsSize * 3 / 4
+		// ...but the combined size (~rhsSize, since the LHS is empty) stays
+		// comfortably below twice that threshold, so the merge should occur.
+		conf.RangeMaxBytes = rhsSize * 10
+		setSpanConfigs(t, conf)
+		verifyMergedSoon(t, store, lhsStartKey, rhsStartKey)
+	})
+
+	t.Run("rhs-above-threshold-does-not-merge-when-combined-is-large", func(t *testing.T) {
+		reset(t)
+		clearRange(t, lhsStartKey, rhsStartKey)
+
+		conf := conf
+		rhsSize := rhs().GetMVCCStats().Total()
+		// The RHS alone already meets the minimum size threshold, and the
+		// combined size (~rhsSize) would not stay comfortably below twice
+		// that threshold, so the merge should still be skipped.
+		conf.RangeMinBytes = rhsSize / 3
+		conf.RangeMaxBytes = rhsSize * 10
+		setSpanConfigs(t, conf)
+		verifyUnmergedSoon(t, store, lhsStartKey, rhsStartKey)
+	})
+
 	t.Run("non-collocated", func(t *testing.T) {
 		reset(t)
 		verifyUnmergedSoon(t, store, lhsStartKey, rhsStartKey)

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -257,9 +257,26 @@ func (mq *mergeQueue) process(
 	if err != nil {
 		return false, err
 	}
-	if rhsStats.Total() >= minBytes {
-		log.VEventf(ctx, 2, "skipping merge: RHS meets minimum size threshold %d with %d bytes",
-			minBytes, rhsStats.Total())
+
+	mergedStats := lhsStats
+	mergedStats.Add(rhsStats)
+
+	// A merge only helps if it eliminates a range that is beneath the
+	// minimum size threshold. The LHS is already known to be undersized (it
+	// was checked above). If the RHS is also undersized, the merge is
+	// unconditionally worth pursuing. If the RHS already meets the
+	// threshold, the merge is still worth pursuing as long as the combined
+	// range stays comfortably below the threshold -- below twice minBytes,
+	// the same bound already implied above when both sides are individually
+	// undersized. This preserves the anti-thrashing property (an undersized
+	// range is never merged into a neighbor that's already close to its max
+	// size) while still letting a range wedged between two adequately-sized
+	// neighbors merge away, instead of persisting forever (see #100443).
+	if rhsStats.Total() >= minBytes && mergedStats.Total() >= 2*minBytes {
+		log.VEventf(ctx, 2,
+			"skipping merge: RHS meets minimum size threshold %d with %d bytes, and "+
+				"combined size %d would not stay comfortably below it",
+			minBytes, rhsStats.Total(), mergedStats.Total())
 		return false, nil
 	}
 
@@ -276,8 +293,6 @@ func (mq *mergeQueue) process(
 		StartKey: lhsDesc.StartKey,
 		EndKey:   rhsDesc.EndKey,
 	}
-	mergedStats := lhsStats
-	mergedStats.Add(rhsStats)
 
 	lhsLoadSplitSnap := lhsRepl.loadBasedSplitter.Snapshot(ctx, mq.store.Clock().PhysicalTime())
 	var loadMergeReason redact.RedactableString


### PR DESCRIPTION
## Summary

The merge queue previously required *both* the LHS and RHS of a candidate
merge to be individually below the `RangeMinBytes` threshold before merging
them (see `mergeQueue.process` in `merge_queue.go`). This meant a range
wedged between two neighbors that were each at or above the threshold could
never merge with either of them and would persist indefinitely — even if it
held zero or near-zero bytes, e.g. after all of its rows were deleted.

This was discussed at length in #100443 (kvoli, andrewbaptist, erikgrinaker),
including simulations comparing a few different fix strategies, but no fix
ever landed. This PR implements the minimal, backportable fix that the
discussion converged on: merge whenever *either* side is below the
threshold, as long as the combined range stays below twice the threshold.

This preserves the existing anti-thrashing behavior — an undersized range is
never merged into a neighbor that's already close to its max size, since
`shouldSplitRange` already guards against producing an over-max-size range,
and the doubled-threshold check avoids producing a range that's likely to
need re-splitting soon — while letting genuinely small ranges merge away
instead of persisting forever.

## Test plan

Added two new subtests to `TestMergeQueue` covering both the newly-allowed
case (RHS above threshold, but combined size stays well under 2x the
threshold) and the still-disallowed case (RHS above threshold, combined size
would not stay comfortably below 2x). Ran the full `TestMergeQueue` suite
(including all pre-existing subtests) to confirm no regressions.

Resolves: #100443
Epic: none

Release note (bug fix): Fixed a bug where a range could become permanently
unmergeable if its immediate neighbor's size was at or above the configured
minimum range size, even if the range itself was empty or nearly empty. The
range merge queue now merges such ranges as long as the resulting merged
range would stay comfortably below the minimum size threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)