### PR TITLE
sysutil: fill ballast files with random data instead of zeroes

### DIFF
--- a/pkg/util/sysutil/large_file.go
+++ b/pkg/util/sysutil/large_file.go
@@ -6,7 +6,9 @@
 package sysutil
 
 import (
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/cockroachdb/errors"
 )
@@ -17,7 +19,17 @@ func resizeLargeFileNaive(path string, bytes int64) error {
 		return err
 	}
 	defer f.Close()
+	// Fill the file with pseudo-random data rather than zeroes. Some
+	// filesystems (eg, ZFS with compression enabled) compress long runs of
+	// zeroes down to almost nothing, defeating the purpose of a ballast file:
+	// reserving real, reclaimable disk space (see #78606). Random data is
+	// effectively incompressible, forcing the filesystem to actually
+	// allocate the requested space. The data need not be cryptographically
+	// random, only resistant to compression, so a single buffer generated
+	// once and reused for the whole file keeps large ballasts fast to
+	// create.
 	sixtyFourMB := make([]byte, 64<<20)
+	_, _ = rand.New(rand.NewSource(time.Now().UnixNano())).Read(sixtyFourMB) // (*rand.Rand).Read never errors
 	for bytes > 0 {
 		z := sixtyFourMB
 		if bytes < int64(len(z)) {

--- a/pkg/util/sysutil/large_file_test.go
+++ b/pkg/util/sysutil/large_file_test.go
@@ -6,6 +6,8 @@
 package sysutil
 
 import (
+	"bytes"
+	"compress/flate"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,5 +28,46 @@ func TestResizeLargeFile(t *testing.T) {
 		if n != fi.Size() {
 			t.Fatalf("expected size of file %d, got %d", n, fi.Size())
 		}
+	}
+}
+
+// TestResizeLargeFileNaiveIncompressible verifies that the naive fallback
+// (used on non-Linux platforms, and on Linux when fallocate is unsupported)
+// fills files with data that resists compression. Filesystems like ZFS
+// compress long runs of zeroes down to almost nothing, which would defeat
+// the purpose of a ballast file: reserving real, reclaimable disk space
+// (see #78606).
+func TestResizeLargeFileNaiveIncompressible(t *testing.T) {
+	fname := filepath.Join(t.TempDir(), "ballast")
+	const size = 4 << 20 // 4MiB, enough for a meaningful compression ratio
+	if err := resizeLargeFileNaive(fname, size); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(fname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(data)) != size {
+		t.Fatalf("expected file of size %d, got %d", size, len(data))
+	}
+
+	var compressed bytes.Buffer
+	w, err := flate.NewWriter(&compressed, flate.BestCompression)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A standard compressor should not be able to shrink pseudo-random data
+	// by more than a small margin; all-zero data compresses by orders of
+	// magnitude more than this.
+	if ratio := float64(compressed.Len()) / float64(len(data)); ratio < 0.9 {
+		t.Fatalf("ballast data compressed too well: %d bytes -> %d bytes (ratio %.2f)",
+			len(data), compressed.Len(), ratio)
 	}
 }


### PR DESCRIPTION
## Summary

`resizeLargeFileNaive` is used to create emergency ballast files on
platforms without `fallocate` support: all non-Linux platforms, and Linux
filesystems that report `fallocate` as unsupported (eg some ZFS
configurations, per the reproduction in #78606). It previously wrote
zero-filled buffers to reserve the requested disk space.

Some filesystems compress long runs of zeroes down to almost nothing (eg ZFS
with `compression=on`), so the ballast file's logical size matched the
requested size but its actual on-disk footprint did not — as demonstrated in
the original report, a 559GB ballast occupied only ~2.7MB of pool space.
This defeats the purpose of a ballast file: reserving real, reclaimable disk
space that can be freed by deleting the file when a node runs low on disk.

This exact fix (write random data instead of zeroes for the buffer-writing
fallback path) was proposed and agreed on by @knz, @nicktrav, and @jbowens
in the issue thread back in 2022, but was never implemented.

This only addresses the buffer-writing fallback path. It does not address
the separate, harder case raised later in the thread where `fallocate`
itself reports success without actually reserving space on some
filesystems — that needs separate investigation (eg checking on-disk usage
after allocation) and is out of scope here.

## Test plan

Added `TestResizeLargeFileNaiveIncompressible`, which writes a ballast file
via the naive path and verifies a standard compressor (`compress/flate`)
cannot shrink its content by more than a small margin, directly regression
testing the compressibility issue from #78606. Existing `TestResizeLargeFile`
continues to pass unmodified.

Resolves: #78606
Epic: none

Release note (bug fix): Fixed a bug where the automatically-created
emergency ballast file could fail to reserve real disk space on filesystems
that compress zero-filled data (such as ZFS with compression enabled),
preventing it from being useful as a safety margin when a node ran low on
disk space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)