### PR TITLE
backup: reject incompatible online cluster restores

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -530,9 +530,9 @@ func checkManifestsForOnlineCompat(
 }
 
 // checkBackupElidedPrefixForOnlineCompat ensures the backup is online
-// restorable depending on the kind of elided prefix in the backup. If no
-// prefixes were stripped in the backup, the restore cannot rewrite table
-// descriptors.
+// restorable depending on the kind of elided prefix in the backup. If table
+// prefixes were not stripped from the keys in the backup, the restore cannot
+// rewrite table descriptors.
 func checkBackupElidedPrefixForOnlineCompat(
 	ctx context.Context, manifests []backuppb.BackupManifest, rewrites jobspb.DescRewriteMap,
 ) error {
@@ -546,9 +546,7 @@ func checkBackupElidedPrefixForOnlineCompat(
 	switch elidePrefix {
 	case execinfrapb.ElidePrefix_TenantAndTable:
 		return nil
-	case execinfrapb.ElidePrefix_Tenant:
-		return nil
-	case execinfrapb.ElidePrefix_None:
+	case execinfrapb.ElidePrefix_Tenant, execinfrapb.ElidePrefix_None:
 		for oldID, rw := range rewrites {
 			if rw.ID != oldID {
 				return pgerror.Newf(pgcode.FeatureNotSupported, "experimental online restore: descriptor rewrites not supported but required (%d -> %d) on backup without stripped table prefixes", oldID, rw.ID)

--- a/pkg/backup/testdata/backup-restore/online-restore-cluster
+++ b/pkg/backup/testdata/backup-restore/online-restore-cluster
@@ -38,3 +38,29 @@ SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' and status='succeeded'
 ----
 2
 
+# Online restore cannot rewrite table IDs when the backup strips only tenant prefixes.
+
+reset test-nodelocal
+----
+
+new-cluster name=s3 disable-tenant
+----
+
+exec-sql
+CREATE TABLE tenant_backup_data (id INT PRIMARY KEY, value STRING);
+INSERT INTO tenant_backup_data VALUES (1, 'one'), (2, 'two');
+SELECT crdb_internal.create_tenant(5);
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster-with-tenants/' WITH include_all_virtual_clusters;
+----
+
+new-cluster name=s4 share-io-dir=s3 allow-implicit-access disable-tenant
+----
+
+exec-sql expect-error-regex=(experimental online restore: descriptor rewrites not supported but required)
+RESTORE FROM LATEST IN 'nodelocal://1/cluster-with-tenants/' WITH EXPERIMENTAL DEFERRED COPY;
+----
+regex matches error
+


### PR DESCRIPTION
## Summary

Online cluster restore cannot rewrite descriptor IDs when backup SSTs retain their table prefixes.

Backups created with `include_all_virtual_clusters` use `ElidePrefix_Tenant`. This strips the tenant prefix but leaves the original table ID in each stored key. Online restore can rewrite the destination span and apply a synthetic tenant prefix, but linking the external SST does not rewrite the table ID embedded in every key.

The compatibility check previously accepted `ElidePrefix_Tenant` unconditionally. This could link data under incorrect keys, leave restored system-tenant tables empty, and later cause a panic while restoring system tables.

This change treats `ElidePrefix_Tenant` like `ElidePrefix_None` when descriptor IDs must change. The restore is rejected during planning with a `FeatureNotSupported` error, before incompatible SSTs are linked.

The existing successful online cluster restore coverage is preserved. A separate regression scenario creates a secondary tenant, backs up with `include_all_virtual_clusters`, and verifies that online cluster restore fails cleanly instead of panicking.

Fixes #174659

## Tests

* `./dev test pkg/backup -f=TestDataDriven_online_restore_cluster -v`
* `./dev test pkg/backup -f=TestDataDriven_online_restore_prefix_backups -v`

Release note (bug fix): Online cluster restores now reject backups created with `include_all_virtual_clusters` when descriptor ID rewrites are required. This prevents system-tenant tables from appearing empty and avoids a panic during system table restoration.
