### PR TITLE
sql: discard final rows from SETOF VOID functions

### DIFF
--- a/pkg/sql/function_resolver_test.go
+++ b/pkg/sql/function_resolver_test.go
@@ -444,3 +444,36 @@ CREATE FUNCTION sc1.lower(a STRING) RETURNS STRING VOLATILE LANGUAGE SQL AS $$ S
 	})
 	require.NoError(t, err)
 }
+
+// TestSetReturningVoidCardinality checks that discarding a SETOF VOID result
+// does not suppress execution of the body or change scalar VOID functions.
+func TestSetReturningVoidCardinality(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	runner := sqlutils.MakeSQLRunner(db)
+	runner.Exec(t, `
+CREATE FUNCTION setof_void() RETURNS SETOF VOID IMMUTABLE LANGUAGE SQL AS $$ SELECT NULL $$;
+CREATE FUNCTION scalar_void() RETURNS VOID IMMUTABLE LANGUAGE SQL AS $$ SELECT NULL $$;
+CREATE FUNCTION setof_int() RETURNS SETOF INT IMMUTABLE LANGUAGE SQL AS $$ VALUES (1), (2) $$;
+CREATE TABLE calls (v INT);
+CREATE FUNCTION setof_void_write() RETURNS SETOF VOID VOLATILE LANGUAGE SQL AS $$
+  INSERT INTO calls VALUES (1);
+  SELECT NULL;
+$$;
+`)
+	for _, query := range []string{
+		"SELECT setof_void()",
+		"SELECT * FROM setof_void()",
+		"SELECT setof_void_write()",
+	} {
+		t.Run(query, func(t *testing.T) {
+			require.Empty(t, runner.QueryStr(t, query))
+		})
+	}
+	runner.CheckQueryResults(t, "SELECT count(*) FROM calls", [][]string{{"1"}})
+	runner.CheckQueryResults(t, "SELECT scalar_void()", [][]string{{"NULL"}})
+	runner.CheckQueryResults(t, "SELECT * FROM setof_int() ORDER BY 1", [][]string{{"1"}, {"2"}})
+}

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -1057,9 +1057,11 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	enableStepping := udf.Def.Volatility == volatility.Volatile
 
 	// A non-zero ResultBufferID indicates that the UDF is a set-returning
-	// function, with sub-routines adding to the result set. In this case, the
+	// function, with sub-routines adding to the result set. SETOF VOID functions
+	// also produce no result from their final body statement. In these cases, the
 	// last body statement does not directly contribute to the result set.
-	discardLastStmtResult := udf.Def.ResultBufferID != 0
+	discardLastStmtResult := udf.Def.ResultBufferID != 0 ||
+		(udf.Def.SetReturning && udf.Typ.Family() == types.VoidFamily)
 
 	// The calling routine, if any, will have already determined whether this
 	// routine is in tail-call position.


### PR DESCRIPTION
Selecting from a SQL UDF declared `RETURNS SETOF VOID` currently exposes a NULL row from its final `SELECT NULL`. This change makes that function produce no result rows, while still executing its body.

The existing `DiscardLastStmtResult` path already runs the final statement without adding its output to the routine's result buffer. `buildUDF` now selects that path for a set-returning routine whose result family is VOID, as well as for routines that use an explicit result buffer. Checking both properties keeps scalar VOID functions and non-VOID set-returning functions on their existing paths.

The issue explicitly leaves open whether CockroachDB should adopt PostgreSQL's behavior here. This PR implements that compatibility choice; it does not assume that the API decision has already been made.

```sql
CREATE FUNCTION f() RETURNS SETOF VOID LANGUAGE SQL AS 'SELECT NULL';
SELECT f();
-- Before: one NULL row. After: no rows.
```

The regression exercises calls in both the SELECT list and FROM clause, checks that a volatile function still performs an INSERT, and checks scalar VOID and SETOF INT results.

### Validation

- `bazel test //pkg/sql:sql_test --test_arg=-test.run=^TestSetReturningVoidCardinality$` passed.
- The same test added to unmodified `8812064a` failed because each SETOF VOID call returned `[[NULL]]` instead of an empty result.
- Candidate and baseline runs used two build jobs, disabled sharding, one Go-test parallel worker, and a fixed seed. CockroachDB's randomized test knobs, test tenants and DRPC were disabled.

The earlier broad `//pkg/sql:sql_test` run did not complete cleanly on this machine. `TestTenantStatementTimeoutAdmissionQueueCancellation` also timed out when run alone on the unmodified baseline. Other resource-related failures passed when rerun with one job. I am reporting the focused regression results here, not a clean full SQL-suite pass.


Fixes #103119

Release note (backward-incompatible change): SQL functions declared RETURNS SETOF VOID no longer produce a row from their final body statement. Applications relying on that row should use a scalar VOID function when one return row is required. Function bodies still execute, including their side effects.
