### PR TITLE
sql: improve sqrdiff accuracy for large offsets

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -4109,10 +4109,12 @@ type decimalSqrDiffAggregate struct {
 	count   apd.Decimal
 	mean    apd.Decimal
 	sqrDiff apd.Decimal
+	offset  apd.Decimal
 
 	// Variables used as scratch space within iterations.
 	delta apd.Decimal
 	tmp   apd.Decimal
+	value apd.Decimal
 }
 
 func newDecimalSqrDiff(evalCtx *eval.Context) decimalSqrDiff {
@@ -4147,22 +4149,32 @@ func (a *decimalSqrDiffAggregate) Add(
 	}
 	d := &datum.(*tree.DDecimal).Decimal
 
+	// Center the inputs around the first value. Variance is invariant under
+	// translation, and centering prevents a large common offset from consuming
+	// the precision needed for differences between the values.
+	if a.count.IsZero() {
+		a.offset.Set(d)
+	}
+	a.ed.Sub(&a.value, d, &a.offset)
+
 	// Uses the Knuth/Welford method for accurately computing squared difference online in a
 	// single pass. Refer to squared difference calculations
 	// in http://www.johndcook.com/blog/standard_deviation/ and
 	// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online_algorithm.
 	a.ed.Add(&a.count, &a.count, decimalOne)
-	a.ed.Sub(&a.delta, d, &a.mean)
+	a.ed.Sub(&a.delta, &a.value, &a.mean)
 	a.ed.Quo(&a.tmp, &a.delta, &a.count)
 	a.ed.Add(&a.mean, &a.mean, &a.tmp)
-	a.ed.Sub(&a.tmp, d, &a.mean)
+	a.ed.Sub(&a.tmp, &a.value, &a.mean)
 	a.ed.Add(&a.sqrDiff, &a.sqrDiff, a.ed.Mul(&a.delta, &a.delta, &a.tmp))
 
 	size := int64(a.count.Size() +
 		a.mean.Size() +
 		a.sqrDiff.Size() +
+		a.offset.Size() +
 		a.delta.Size() +
-		a.tmp.Size())
+		a.tmp.Size() +
+		a.value.Size())
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
 		return err
 	}
@@ -4192,6 +4204,8 @@ func (a *decimalSqrDiffAggregate) Reset(ctx context.Context) {
 	a.count.SetInt64(0)
 	a.mean.SetInt64(0)
 	a.sqrDiff.SetInt64(0)
+	a.offset.SetInt64(0)
+	a.value.SetInt64(0)
 	a.reset(ctx)
 }
 
@@ -4303,12 +4317,14 @@ type decimalSumSqrDiffsAggregate struct {
 	count   apd.Decimal
 	mean    apd.Decimal
 	sqrDiff apd.Decimal
+	offset  apd.Decimal
 
 	// Variables used as scratch space within iterations.
-	tmpCount apd.Decimal
-	tmpMean  apd.Decimal
-	delta    apd.Decimal
-	tmp      apd.Decimal
+	tmpCount    apd.Decimal
+	tmpMean     apd.Decimal
+	centeredSum apd.Decimal
+	delta       apd.Decimal
+	tmp         apd.Decimal
 }
 
 func newDecimalSumSqrDiffs(evalCtx *eval.Context) decimalSqrDiff {
@@ -4341,7 +4357,21 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	sum := &sumD.(*tree.DDecimal).Decimal
 	a.tmpCount.SetInt64(int64(*countD.(*tree.DInt)))
 
-	a.ed.Quo(&a.tmpMean, sum, &a.tmpCount)
+	// Use the first partial mean as a common offset, then center every partial
+	// sum before dividing. The exact multiply and subtract preserve differences
+	// that would be lost by subtracting two independently rounded large means.
+	if a.count.IsZero() {
+		if _, err := tree.IntermediateCtx.Quo(&a.offset, sum, &a.tmpCount); err != nil {
+			return err
+		}
+	}
+	if _, err := tree.ExactCtx.Mul(&a.centeredSum, &a.offset, &a.tmpCount); err != nil {
+		return err
+	}
+	if _, err := tree.ExactCtx.Sub(&a.centeredSum, sum, &a.centeredSum); err != nil {
+		return err
+	}
+	a.ed.Quo(&a.tmpMean, &a.centeredSum, &a.tmpCount)
 	a.ed.Sub(&a.delta, &a.tmpMean, &a.mean)
 
 	// Compute the sum of Knuth/Welford sum of squared differences from the
@@ -4377,8 +4407,10 @@ func (a *decimalSumSqrDiffsAggregate) Add(
 	size := int64(a.count.Size() +
 		a.mean.Size() +
 		a.sqrDiff.Size() +
+		a.offset.Size() +
 		a.tmpCount.Size() +
 		a.tmpMean.Size() +
+		a.centeredSum.Size() +
 		a.delta.Size() +
 		a.tmp.Size())
 	if err := a.updateMemoryUsage(ctx, size); err != nil {
@@ -4405,6 +4437,8 @@ func (a *decimalSumSqrDiffsAggregate) Reset(ctx context.Context) {
 	a.count.SetInt64(0)
 	a.mean.SetInt64(0)
 	a.sqrDiff.SetInt64(0)
+	a.offset.SetInt64(0)
+	a.centeredSum.SetInt64(0)
 	a.reset(ctx)
 }
 

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -885,3 +885,67 @@ func runRegressionAggregateBenchmarks(
 		)
 	})
 }
+
+// TestSqrDiffLargeOffset checks permutations of the same multiset through both
+// decimal accumulation paths. The squared deviations are independent of the
+// shared offset, and Reset must not retain the previous group's origin.
+func TestSqrDiffLargeOffset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(ctx)
+	acc := evalCtx.TestingMon.MakeBoundAccount()
+	defer acc.Close(ctx)
+	evalCtx.SingleDatumAggMemAccount = &acc
+	decimal := func(s string) *tree.DDecimal {
+		d, err := tree.ParseDDecimal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return d
+	}
+	orders := [][]int{{0, 0, 1, 1}, {0, 1, 0, 1}, {0, 1, 1, 0},
+		{1, 0, 0, 1}, {1, 0, 1, 0}, {1, 1, 0, 0}}
+	for _, partials := range []bool{false, true} {
+		for _, order := range orders {
+			t.Run(fmt.Sprintf("partials=%t/order=%v", partials, order), func(t *testing.T) {
+				agg := newDecimalSqrDiff(evalCtx)
+				if partials {
+					agg = newDecimalSumSqrDiffs(evalCtx)
+				}
+				defer agg.Close(ctx)
+				for _, values := range [][2]string{
+					{"856809699799498753", "856809699799531521"},
+					{"0", "32768"},
+					{"-856809699799531521", "-856809699799498753"},
+				} {
+					agg.Reset(ctx)
+					if err := agg.Add(ctx, tree.DNull, tree.DNull, tree.DNull); err != nil {
+						t.Fatal(err)
+					}
+					for _, index := range order {
+						var err error
+						if partials {
+							// A singleton partial has zero squared deviation.
+							err = agg.Add(ctx, decimal("0"), decimal(values[index]), tree.NewDInt(1))
+						} else {
+							err = agg.Add(ctx, decimal(values[index]))
+						}
+						if err != nil {
+							t.Fatal(err)
+						}
+					}
+					result, err := agg.Result()
+					if err != nil {
+						t.Fatal(err)
+					}
+					// Four values, two at each endpoint, give (32768)^2.
+					got, ok := result.(*tree.DDecimal)
+					if !ok || got.Decimal.Cmp(&decimal("1073741824").Decimal) != 0 {
+						t.Fatalf("values %v: expected 1073741824, got %s", values, result)
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
`SQRDIFF` can lose accuracy when its inputs have a large common offset and a much smaller spread. In #101588, the same four integer values produce different answers depending on the order selected by the join. For two copies each of `856809699799498753` and `856809699799531521`, the squared deviations sum to `1073741824`.

The decimal accumulator already uses Welford's update, but it maintains a mean near the original large values. Updating that mean in a finite-precision context loses digits that are needed for the small differences.

This change centers the inputs around the first value before accumulating. Translation preserves squared deviations, and the running mean now describes the small spread instead of the large offset. The integer implementation also benefits because it delegates to the decimal accumulator.

The partial-state combiner needs the same treatment. It uses the first partial mean as a common origin and computes `sum - origin * count` with exact multiplication and subtraction before dividing. That avoids first rounding two large means and then subtracting them. Both accumulators account for the additional decimal storage and clear it in `Reset`.

The regression runs all six orders of the two-value multiset through the direct and partial-state accumulators, with positive, zero and negative offsets. It also exercises NULL input and reuse after `Reset`. This improves the reported large-offset case; finite-precision arithmetic still applies to general decimal inputs.

### Validation

- `bazel test //pkg/sql/sem/builtins:builtins_test --test_arg=-test.run=^TestSqrDiffLargeOffset$` passed.
- The same test on unmodified `8812064a` failed in both the direct and partial-state paths; one observed result was `1073741823.9989077333` instead of `1073741824`.
- `bazel test //pkg/sql/sem/builtins:builtins_test` passed, including the added regression.
- Runs used two build jobs, disabled sharding, one Go-test parallel worker, and a fixed seed, with CockroachDB's randomized test knobs, test tenants and DRPC disabled.

The package tests exercise the partial-state implementation directly. They are not a separate multi-node SQL or exhaustive extreme-DECIMAL/window-function validation.


Fixes #101588

Release note (bug fix): Improved SQRDIFF accuracy for integer and decimal inputs with large common offsets. Changes in input order or the combination of partial aggregates could previously produce inaccurate results for these values.
