### PR TITLE
opt: expand labeled tuple fields for table-source unnest

### DIFF
--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -94,6 +94,7 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	// Build each of the provided expressions.
 	zip := make(memo.ZipExpr, 0, len(exprs))
 	var outCols opt.ColSet
+	var expandSingleUnnestTuple bool
 	for _, expr := range exprs {
 		// Output column names should exactly match the original expression, so we
 		// have to determine the output column name before we perform type
@@ -113,6 +114,10 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 			); err != nil {
 				panic(err)
 			}
+			tupleLabels := texpr.ResolvedType().TupleLabels()
+			expandSingleUnnestTuple = len(exprs) == 1 && isSingleColumnBuiltinUnnest(funcExpr) &&
+				len(tupleLabels) > 0 &&
+				len(tupleLabels) == len(texpr.ResolvedType().TupleContents())
 		}
 
 		var outCol *scopeColumn
@@ -196,6 +201,32 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 	// Construct the zip as a ProjectSet with empty input.
 	input := b.factory.ConstructNoColsRow()
 	outScope.expr = b.factory.ConstructProjectSet(input, zip)
+	if expandSingleUnnestTuple {
+		// A one-argument unnest produces one datum per input array element, even
+		// when that datum is a labeled tuple. Keep that single physical output
+		// column in ProjectSet, but expose its fields as the columns of the table
+		// source.
+		if len(zip) != 1 || len(zip[0].Cols) != 1 || len(outScope.cols) != 1 ||
+			zip[0].Cols[0] != outScope.cols[0].id {
+			panic(errors.AssertionFailedf(
+				"single-column unnest has inconsistent zip and scope output columns",
+			))
+		}
+		tupleCol := outScope.cols[0]
+		tupleTyp := tupleCol.typ
+		expandedScope := outScope.push()
+		for i, elemTyp := range tupleTyp.TupleContents() {
+			variable := b.factory.ConstructVariable(tupleCol.id)
+			field := b.factory.ConstructColumnAccess(variable, memo.TupleOrdinal(i))
+			col := b.synthesizeColumn(
+				expandedScope, scopeColName(tree.Name(tupleTyp.TupleLabels()[i])),
+				elemTyp, nil /* expr */, field,
+			)
+			col.table = tupleCol.table
+		}
+		b.constructProjectForScope(outScope, expandedScope)
+		return expandedScope
+	}
 	if len(outScope.cols) == 1 {
 		outScope.singleSRFColumn = true
 	}

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1008,6 +1008,34 @@ project
       ├── (unnest:6).a [as=a:7]
       └── (unnest:6).b [as=b:8]
 
+# Regression test for #98352: when unnest of a table row is used as a table
+# source, expose the tuple fields as individual columns.
+exec-ddl
+CREATE TABLE t98352(a INT, b INT);
+----
+
+build
+SELECT * FROM t98352, LATERAL (SELECT * FROM unnest(ARRAY[t98352.*])) AS foo;
+----
+project
+ ├── columns: a:1 b:2 a:7 b:8
+ └── inner-join-apply
+      ├── columns: t98352.a:1 t98352.b:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5 a:7 b:8
+      ├── scan t98352
+      │    └── columns: t98352.a:1 t98352.b:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── project
+      │    ├── columns: a:7 b:8
+      │    ├── project-set
+      │    │    ├── columns: unnest:6
+      │    │    ├── values
+      │    │    │    └── ()
+      │    │    └── zip
+      │    │         └── unnest(ARRAY[((t98352.a:1, t98352.b:2) AS a, b)])
+      │    └── projections
+      │         ├── (unnest:6).a [as=a:7]
+      │         └── (unnest:6).b [as=b:8]
+      └── filters (true)
+
 # Test record-returning SRFs, which need to keep track of the most recently set
 # AS clause above them.
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -253,7 +253,9 @@ func (b *Builder) shouldCreateDefaultColumn(texpr tree.TypedExpr) bool {
 			// will be one output column. This is necessary because the type of the
 			// single column output by unnest in this case may be a tuple with labels,
 			// which breaks the assumption made below.
-			return len(funcExpr.Exprs) == 1
+			if isSingleColumnBuiltinUnnest(funcExpr) {
+				return true
+			}
 		case "crdb_internal.unary_table":
 			// Special case for crdb_internal.unary_table, which produces no columns.
 			return false
@@ -268,6 +270,23 @@ func (b *Builder) shouldCreateDefaultColumn(texpr tree.TypedExpr) bool {
 	// return type doesn't declare any return labels. This logic assumes that any
 	// SRF that has a labeled tuple as a return type returns multiple columns.
 	return len(texpr.ResolvedType().TupleLabels()) == 0
+}
+
+// isSingleColumnBuiltinUnnest returns true for the built-in unnest overload
+// whose single array argument produces one physical output column. In
+// particular, a UDF named unnest is not this overload.
+func isSingleColumnBuiltinUnnest(funcExpr *tree.FuncExpr) bool {
+	overload := funcExpr.ResolvedOverload()
+	if overload == nil || overload.Type != tree.BuiltinRoutine ||
+		overload.Class != tree.GeneratorClass || len(funcExpr.Exprs) != 1 {
+		return false
+	}
+	def, ok := funcExpr.Func.FunctionReference.(*tree.ResolvedFunctionDefinition)
+	if !ok || def.Name != "unnest" {
+		return false
+	}
+	arg, ok := funcExpr.Exprs[0].(tree.TypedExpr)
+	return ok && arg.ResolvedType().Family() == types.ArrayFamily
 }
 
 func (b *Builder) synthesizeResultColumns(scope *scope, cols colinfo.ResultColumns) {


### PR DESCRIPTION
When `unnest(ARRAY[t.*])` is used as a table source, a labeled row value should expose its fields as separate columns. The query in #98352 currently returns the two columns from `t` plus one tuple-valued `unnest` column. This change returns four scalar columns while preserving the three result rows.

The single-array `unnest` generator still emits one physical datum per array element. Changing only the declared output columns would leave the optimizer's column IDs out of sync with the executor. Instead, this patch keeps the single tuple column in `ProjectSet` and adds a projection above it to extract each labeled field. The scope exposes those projected fields as the table-source columns.

The special case is selected using the resolved built-in generator overload and its single array argument. A user-defined function named `unnest` therefore does not acquire the built-in's output layout. An assertion checks that the Zip output and scope refer to the same single physical column before the projection is constructed.

The data-driven regression records the expanded columns and the projection above `ProjectSet` for the reported lateral query.

### Validation

- `bazel test //pkg/sql/opt/optbuilder:optbuilder_test --test_arg=-test.run=^TestBuilder$/^srfs$` passed.
- Adding the same regression to unmodified `8812064a` failed: the plan retained one tuple column instead of the two field projections.
- `bazel test //pkg/sql/opt/optbuilder:optbuilder_test` passed.
- Runs used two build jobs, disabled sharding, one Go-test parallel worker, and a fixed seed, with CockroachDB's randomized test knobs, test tenants and DRPC disabled.

The repair harness also executed the reported query and equivalents, checking all four INT8 columns and the three ordered result rows. The checks do not establish exhaustive compatibility for NULL composite values, alias lists or arbitrary same-named UDFs.

Fixes #98352

Release note (backward-incompatible change): A single-array unnest call used as a table source now expands labeled composite values into individual columns, rather than returning one tuple-valued column. Queries using SELECT * from that table source may therefore return more columns. The number of array elements returned is unchanged.
