### PR TITLE
sql: fix tuple NULL ordering with null_ordered_last

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -574,16 +574,7 @@ NULL  6
 4     8
 
 # Using the session variable, we should get results that match Postgres.
-# TODO(#93558): This test case is broken and shows the limit of our
-# approach to using an optimizer-based approach for NULLS LAST.
-# Postgres returns:
-#      x   | y
-#   -------+---
-#    (1,1) | 1
-#    (1,)  | 3
-#    (,)   | 4
-#          | 2
-#
+# Tuple fields sort NULL last; a NULL record is distinct from a row of NULLs.
 query TI
 WITH t (x, y) AS (
   VALUES
@@ -596,10 +587,10 @@ SELECT *
 FROM t
 ORDER BY x;
 ----
-(1,)   3
 (1,1)  1
-NULL   2
+(1,)   3
 (,)    4
+NULL   2
 
 statement ok
 RESET null_ordered_last
@@ -802,3 +793,326 @@ DROP TABLE t_lookup CASCADE
 
 statement ok
 DROP TABLE t_orders CASCADE
+
+subtest tuple_null_ordering_93558
+
+# Exercise ordinary, aggregate, and window ordering with both session defaults.
+
+statement ok
+SET null_ordered_last = true
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x ASC NULLS LAST
+----
+6
+1
+3
+5
+4
+2
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x ASC NULLS LAST) FROM tuples
+----
+{6,1,3,5,4,2}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x ASC NULLS LAST)
+----
+6
+1
+3
+5
+4
+2
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x ASC NULLS FIRST
+----
+2
+6
+1
+3
+5
+4
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x ASC NULLS FIRST) FROM tuples
+----
+{2,6,1,3,5,4}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x ASC NULLS FIRST)
+----
+2
+6
+1
+3
+5
+4
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x DESC NULLS LAST
+----
+4
+5
+3
+1
+6
+2
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x DESC NULLS LAST) FROM tuples
+----
+{4,5,3,1,6,2}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x DESC NULLS LAST)
+----
+4
+5
+3
+1
+6
+2
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x DESC NULLS FIRST
+----
+2
+4
+5
+3
+1
+6
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x DESC NULLS FIRST) FROM tuples
+----
+{2,4,5,3,1,6}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x DESC NULLS FIRST)
+----
+2
+4
+5
+3
+1
+6
+
+query I
+SELECT x FROM (VALUES (1), (NULL::INT), (2)) AS t(x) ORDER BY x NULLS LAST
+----
+1
+2
+NULL
+
+statement ok
+SET null_ordered_last = false
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x ASC NULLS LAST
+----
+6
+1
+3
+5
+4
+2
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x ASC NULLS LAST) FROM tuples
+----
+{6,1,3,5,4,2}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x ASC NULLS LAST)
+----
+6
+1
+3
+5
+4
+2
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x ASC NULLS FIRST
+----
+2
+6
+1
+3
+5
+4
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x ASC NULLS FIRST) FROM tuples
+----
+{2,6,1,3,5,4}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x ASC NULLS FIRST)
+----
+2
+6
+1
+3
+5
+4
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x DESC NULLS LAST
+----
+4
+5
+3
+1
+6
+2
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x DESC NULLS LAST) FROM tuples
+----
+{4,5,3,1,6,2}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x DESC NULLS LAST)
+----
+4
+5
+3
+1
+6
+2
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY x DESC NULLS FIRST
+----
+2
+4
+5
+3
+1
+6
+
+query T
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT array_agg(id ORDER BY x DESC NULLS FIRST) FROM tuples
+----
+{2,4,5,3,1,6}
+
+query I
+WITH tuples(x, id) AS (
+  VALUES ((1, 1), 1), (NULL::RECORD, 2), ((1, NULL::INT), 3),
+         ((NULL::INT, NULL::INT), 4), ((NULL::INT, 1), 5), ((0, 9), 6)
+)
+SELECT id FROM tuples ORDER BY row_number() OVER (ORDER BY x DESC NULLS FIRST)
+----
+2
+4
+5
+3
+1
+6
+
+query I
+SELECT x FROM (VALUES (1), (NULL::INT), (2)) AS t(x) ORDER BY x NULLS LAST
+----
+1
+2
+NULL
+
+statement ok
+RESET null_ordered_last

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -738,7 +738,7 @@ func (b *Builder) buildAggregateFunction(
 			nullsDefaultOrder := b.hasDefaultNullsOrder(o)
 			for _, e := range cols {
 				if !nullsDefaultOrder {
-					expr := tree.NewTypedIsNullExpr(e)
+					expr := makeDatumIsNullExpr(e)
 					b.buildAggArg(expr, &info, tempScope, fromScope)
 				}
 				ensureColumnOrderable(e)

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -96,8 +97,10 @@ func (b *Builder) buildOrderBy(inScope, projectionsScope, orderByScope *scope) {
 
 			// For non-default NULLS ordering, create an IS NULL column first.
 			if orderByCol.nonDefaultNullsOrder {
-				// Create the IS NULL expression using the ORDER BY column's expression.
-				isNullExpr := tree.NewTypedIsNullExpr(orderByCol.getExpr())
+				// Create an expression that is true only if the datum itself is NULL.
+				// Tuple IS NULL has special row semantics: it is also true for a
+				// non-NULL tuple containing only NULL fields.
+				isNullExpr := makeDatumIsNullExpr(orderByCol.getExpr())
 
 				// Create the IS NULL column with a descriptive metadata
 				// name derived from the ORDER BY column's metadata alias.
@@ -129,6 +132,18 @@ func (b *Builder) buildOrderBy(inScope, projectionsScope, orderByScope *scope) {
 	}
 
 	projectionsScope.setOrdering(orderByScope.cols, orderByScope.ordering)
+}
+
+// makeDatumIsNullExpr returns an expression that is true only when expr is a
+// NULL datum. Tuple IS NULL has row semantics and is also true for a non-NULL
+// tuple containing only NULL fields, so tuples require a distinct comparison.
+func makeDatumIsNullExpr(expr tree.TypedExpr) tree.TypedExpr {
+	if expr.ResolvedType().Family() == types.TupleFamily {
+		return tree.NewTypedComparisonExpr(
+			treecmp.MakeComparisonOperator(treecmp.IsNotDistinctFrom), expr, tree.DNull,
+		)
+	}
+	return tree.NewTypedIsNullExpr(expr)
 }
 
 // findIndexByName returns an index in the table with the given name. If the

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -442,7 +442,7 @@ func (b *Builder) buildWindowOrdering(
 		}
 		for k, e := range cols {
 			if !nullsDefaultOrder {
-				expr := tree.NewTypedIsNullExpr(e)
+				expr := makeDatumIsNullExpr(e)
 				// TODO(#94032): reusing an existing column for the temporary IS
 				// NULL expression can be incorrect if that column was created
 				// for the previous window function (perhaps it's incorrect only

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4384,6 +4384,17 @@ func (d *DTuple) Compare(ctx context.Context, cmpCtx CompareContext, other Datum
 		n = len(v.D)
 	}
 	for i := 0; i < n; i++ {
+		// NULL sorts after non-NULL within a tuple. This differs from the
+		// top-level datum ordering, where NULL sorts before non-NULL.
+		if d.D[i] == DNull {
+			if v.D[i] == DNull {
+				continue
+			}
+			return 1, nil
+		}
+		if v.D[i] == DNull {
+			return -1, nil
+		}
 		c, err := d.D[i].Compare(ctx, cmpCtx, v.D[i])
 		if err != nil {
 			return 0, errors.WithDetailf(err, "type mismatch at record column %d", redact.SafeInt(i+1))


### PR DESCRIPTION
## Summary

Fix tuple ordering when `null_ordered_last` is enabled. The current optimizer-generated NULL ordering key uses tuple `IS NULL` semantics, and tuple comparison also inherits the wrong ordering for NULL fields. Together, these cases can place `(1, NULL)`, `(NULL, NULL)`, and a top-level `NULL` in the wrong order.

Fixes #93558

## What was wrong

For an `ORDER BY` expression with a non-default NULLS direction, the optimizer adds a hidden boolean ordering column. For scalar expressions, `expr IS NULL` is the right test. For tuples, however, `IS NULL` has row semantics: a non-NULL tuple whose fields are all NULL is treated as NULL. That makes it indistinguishable from a top-level NULL in the hidden ordering key.

Tuple comparison had a second issue. Comparing tuple fields delegated directly to the generic datum comparison, whose top-level NULL ordering is opposite to the ordering required for tuple fields when NULLS LAST is requested.

## Implementation

* Add a tuple-aware helper in the optimizer which uses `IS NOT DISTINCT FROM NULL` when the expression has tuple type. This tests whether the tuple datum itself is NULL and avoids the row-level `IS NULL` classification. Scalar expressions continue to use the existing `IS NULL` expression.
* Use that helper consistently for the hidden NULL ordering columns generated for `ORDER BY`, aggregate ordering, and window ordering.
* Update `DTuple.Compare` to compare NULL tuple fields explicitly: a non-NULL field sorts before a NULL field, while two NULL fields remain equal. Non-NULL fields continue through the existing comparison and error handling.

This keeps the change limited to tuple-aware ordering. The optimizer still uses the same hidden ordering column and the same plan shape for scalar expressions, and top-level NULL datum behavior is unchanged.

## Why this fixes the reported case

The hidden key now separates a standalone NULL datum from a non-NULL tuple containing only NULL fields. Once those rows are in the correct NULLS LAST partition, tuple comparison orders `(1, 1)` before `(1, NULL)` and preserves the expected ordering of the remaining tuple values. The original query and equivalent tuple variants therefore produce the PostgreSQL-compatible order under `null_ordered_last`.

## Validation

* Built the affected SQL evaluation and query-observation targets.
* Ran the affected SQL evaluation package tests.
* Checked the original reproduction, preserved behavior, and held-out tuple-ordering cases.
* Ran the configured full regression and compared it with the baseline; all configured checks passed.
