### PR TITLE
geo: avoid false negatives for geography ST_DWithin

### DIFF
--- a/pkg/geo/geoindex/s2_geography_index.go
+++ b/pkg/geo/geoindex/s2_geography_index.go
@@ -172,7 +172,10 @@ func (i *s2GeographyIndex) DWithin(
 	// desire.
 	//
 	// Construct the cell covering for the shape.
-	gCovering := geogCovererWithBBoxFallback{rc: i.rc, g: g}.covering(r)
+	// Do not use the bounding-box fallback here. A geography polygon can represent
+	// the large side of its boundary, which is not contained by the coordinate
+	// bounding box. Expanding such a fallback would omit qualifying index cells.
+	gCovering := simpleCovererImpl{rc: i.rc}.covering(r)
 	// Convert the distanceMeters to an angle, in order to expand the cell covering
 	// on the sphere by the angle.
 	multiplier := 1.0

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_index
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_index
@@ -135,3 +135,98 @@ CREATE TABLE public.geo_table (
   FAMILY fam_1_geom (geom),
   FAMILY fam_2_id (id)
 ) WITH (schema_locked = true);
+
+subtest geography_dwithin_80374
+
+# This oriented polygon covers the large side of its boundary. Its coordinate
+# bounding box cannot be used to exclude matching geography index entries.
+let $geography_80374_polygon
+SELECT '01060000E0E61000000100000001030000C001000000040000002410B7E16B9D4440F80C9162CE5C2140459E64E4C1D0F2C1A82FC5D8CCBDF241280A013B1F235340F8BF387C28115640D42C81DD911DF7C15068D6DBDEE7CCC10CA4E8AB08844D40125A0D02ADB35440F86FC12B1966DD4104A5183738C5FF412410B7E16B9D4440F80C9162CE5C2140459E64E4C1D0F2C1A82FC5D8CCBDF241'
+
+statement ok
+CREATE TABLE geography_80374 (geo_col GEOGRAPHY, INVERTED INDEX geog_idx (geo_col))
+
+statement ok
+INSERT
+  INTO geography_80374 (geo_col)
+VALUES ('0104000020E610000008000000010100000054A4D87CD5AD4B40E8B73A825C8637C0010100000081A76E24086666C0AC4CF2E3AF584C4001010000001A7FC234D9FA4FC032A6F3C0BE1051C001010000004FCAE361214452C0B8C3171AA0E552400101000000035E7A43C0E352C030FDD4FB3E2B4840010100000021432579E97C65C0CC0DDAAFD6B23940010100000018DD72AEB8FE5E4037CB45DA4A7C47C001010000000CBA9522724E65406CF65B95512053C0');
+
+query I
+SELECT count(*) FROM geography_80374@geography_80374_pkey
+WHERE ST_DWithin('$geography_80374_polygon'::GEOGRAPHY, geo_col, 0.24216150138503956, true)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geography_80374_pkey
+WHERE ST_DWithin(geo_col, '$geography_80374_polygon'::GEOGRAPHY, 0.24216150138503956, true)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geog_idx
+WHERE ST_DWithin('$geography_80374_polygon'::GEOGRAPHY, geo_col, 0.24216150138503956, true)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geog_idx
+WHERE ST_DWithin(geo_col, '$geography_80374_polygon'::GEOGRAPHY, 0.24216150138503956, true)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geography_80374_pkey
+WHERE ST_DWithin('$geography_80374_polygon'::GEOGRAPHY, geo_col, 0.24216150138503956, false)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geography_80374_pkey
+WHERE ST_DWithin(geo_col, '$geography_80374_polygon'::GEOGRAPHY, 0.24216150138503956, false)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geog_idx
+WHERE ST_DWithin('$geography_80374_polygon'::GEOGRAPHY, geo_col, 0.24216150138503956, false)
+----
+1
+
+query I
+SELECT count(*) FROM geography_80374@geog_idx
+WHERE ST_DWithin(geo_col, '$geography_80374_polygon'::GEOGRAPHY, 0.24216150138503956, false)
+----
+1
+
+# Empty and NULL entries must not introduce false positives.
+statement ok
+INSERT INTO geography_80374 VALUES ('POINT EMPTY'::GEOGRAPHY), (NULL)
+
+# Inverted joins construct the spatial filter from each input row at runtime.
+statement ok
+CREATE TABLE geography_80374_probes (id INT PRIMARY KEY, geog GEOGRAPHY)
+
+statement ok
+INSERT INTO geography_80374_probes VALUES
+  (1, '$geography_80374_polygon'::GEOGRAPHY), (2, 'POINT(0 0)'::GEOGRAPHY), (3, NULL)
+
+query I
+SELECT p.id FROM geography_80374_probes AS p
+INNER INVERTED JOIN geography_80374@geog_idx AS g
+ON ST_DWithin(p.geog, g.geo_col, 0.24216150138503956, true)
+----
+1
+
+query I
+SELECT p.id FROM geography_80374_probes AS p
+INNER INVERTED JOIN geography_80374@geog_idx AS g
+ON ST_DWithin(g.geo_col, p.geog, 0.24216150138503956, false)
+----
+1
+
+statement ok
+DROP TABLE geography_80374_probes
+
+statement ok
+DROP TABLE geography_80374

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -669,6 +669,9 @@ func extractGeoFilterCondition(
 	if err != nil {
 		return inverted.NonInvertedColExpression{}, nil
 	}
+	if !canUseGeoPreFilter(d.ResolvedType(), relationship) {
+		return invExpr, nil
+	}
 	return invExpr,
 		&invertedexpr.PreFiltererStateForInvertedFilterer{
 			Expr: preFilterExpr,
@@ -820,6 +823,13 @@ type PreFilterer struct {
 	additionalPreFilterParams []tree.Datum
 	// Batch allocated for reducing heap allocations.
 	preFilterState []filterState
+}
+
+// canUseGeoPreFilter returns whether bounding boxes are conservative for the
+// given type and relationship. A geography can represent the large side of a
+// polygon boundary, which is not contained by its coordinate bounding box.
+func canUseGeoPreFilter(typ *types.T, relationship geoindex.RelationshipType) bool {
+	return typ.Family() != types.GeographyFamily || relationship != geoindex.DWithin
 }
 
 // NewPreFilterer constructs a PreFilterer
@@ -1090,7 +1100,7 @@ func NewGeoDatumsToInvertedExpr(
 	if err != nil {
 		return nil, err
 	}
-	if funcExprCount == 1 {
+	if funcExprCount == 1 && canUseGeoPreFilter(g.typ, preFilterRelationship) {
 		g.filterer = NewPreFilterer(g.typ, preFilterRelationship, additionalPreFilterParams)
 	}
 	return g, nil


### PR DESCRIPTION
## Summary

Prevent false negatives when a geography `ST_DWithin` query uses the geography inverted index. The fix keeps the inverted scan and exact residual predicate, but removes two lossy bounding-box assumptions that can discard a true match before exact evaluation.

Fixes #80374

## What was wrong

Geography is represented on the sphere, and a polygon can describe the large side of its boundary. Its coordinate bounding box does not necessarily contain the represented spherical region. The `DWithin` covering path used a bounding-box fallback in this situation, so the generated S2 spans could omit cells that contain a qualifying indexed value.

The optional geography pre-filter made the same assumption: it derived a bounding rectangle and rejected candidates from that rectangle before the exact `ST_DWithin` residual predicate ran. For a large-side geography polygon, that rejection is not conservative and can turn a true result into a false negative.

## Implementation

* Replace the bounding-box fallback in `s2GeographyIndex.DWithin` with the covering produced from the actual S2 region representation.
* Add a single relationship/type guard for pre-filter construction. The guard disables the optional pre-filter only for `Geography` plus `DWithin`.
* Apply the guard at both production construction sites: inverted filter extraction and the geography inverted-expression builder.

Other geometry relationships and other geography relationships retain their existing pre-filter behavior. The inverted index scan remains in the plan for geography `DWithin`; only the unsafe bounding-cap pruning is removed. Any extra candidates admitted by the conservative spans are still checked by the exact residual predicate.

## Why this fixes the reported case

The query-side S2 covering now follows the represented spherical region rather than a coordinate rectangle that may describe only the short side of a polygon boundary. The optional pre-filter can no longer reject a geography `DWithin` candidate using that non-conservative rectangle. This removes the false-negative path while preserving exact result filtering and index-based execution.

## Validation

* Built the affected geography index and query-observation targets.
* Ran the geography index package tests.
* Checked the reported intersection/`DWithin` cases, preserved relationships, and held-out large-side geography cases.
* Verified that the optimizer continues to produce inverted-index scans with the exact residual predicate where applicable.
* Ran the configured full regression and compared it with the baseline; all configured checks passed.
