### PR TITLE
opt: reject aggregate ORDER BY in window functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4397,3 +4397,37 @@ NULL  4  4
 
 statement ok
 RESET null_ordered_last
+
+subtest aggregate_order_by_43133
+
+# ORDER BY inside an aggregate must not be silently ignored for window calls.
+query error pgcode 0A000 aggregate ORDER BY is not implemented for window functions
+SELECT array_agg(x ORDER BY y DESC) OVER () FROM (VALUES (1, 2), (2, 1)) AS t(x, y)
+
+query error pgcode 0A000 aggregate ORDER BY is not implemented for window functions
+SELECT string_agg(x::STRING, ',' ORDER BY y) OVER () FROM (VALUES (1, 2), (2, 1)) AS t(x, y)
+
+query error pgcode 0A000 aggregate ORDER BY is not implemented for window functions
+SELECT sum(x ORDER BY y) OVER (PARTITION BY y) FROM (VALUES (1, 2), (2, 1)) AS t(x, y)
+
+query error pgcode 0A000 aggregate ORDER BY is not implemented for window functions
+SELECT array_agg(x ORDER BY y) FILTER (WHERE x > 0) OVER () FROM (VALUES (1, 2), (2, 1)) AS t(x, y)
+
+# Ordinary aggregate ordering and ordering in OVER remain supported.
+query T
+SELECT array_agg(x ORDER BY y) FROM (VALUES (1, 2), (2, 1)) AS t(x, y)
+----
+{2,1}
+
+query IT
+SELECT x, array_agg(x) OVER (ORDER BY y ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM (VALUES (1, 2), (2, 1)) AS t(x, y) ORDER BY y
+----
+2  {2}
+1  {2,1}
+
+query IR
+SELECT x, sum(x) OVER () FROM (VALUES (1), (2)) AS t(x) ORDER BY x
+----
+1  3
+2  3

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1466,6 +1466,9 @@ func (expr *FuncExpr) TypeCheck(
 		if expr.Type == DistinctFuncType {
 			return nil, pgerror.New(pgcode.FeatureNotSupported, "DISTINCT is not implemented for window functions")
 		}
+		if len(expr.OrderBy) > 0 {
+			return nil, pgerror.New(pgcode.FeatureNotSupported, "aggregate ORDER BY is not implemented for window functions")
+		}
 	} else {
 		// Make sure the window function builtins are used as window function applications.
 		if !expr.InCall && funcCls == WindowClass {


### PR DESCRIPTION
## Summary

Reject aggregate `ORDER BY` when an aggregate is used as a window function instead of silently ignoring the ordering clause.

Fixes #43133

## Problem

For an aggregate call used with `OVER (...)`, CockroachDB accepted an `ORDER BY` clause inside the aggregate expression but did not carry that ordering into the window aggregate execution. The query therefore returned a valid-looking result with a different order from the SQL text, which is worse than an explicit unsupported-feature error.

`DISTINCT` on window functions already follows this behavior: the type checker returns `FeatureNotSupported` rather than accepting syntax that the execution path cannot honor. Aggregate `ORDER BY` needs the same guard.

## Change

In `FuncExpr.TypeCheck`, while checking a function expression as a window function, return `pgcode.FeatureNotSupported` when `expr.OrderBy` is non-empty. The error text is `aggregate ORDER BY is not implemented for window functions`.

This check is placed alongside the existing `DISTINCT` restriction and runs before the expression is accepted as a window function. It does not change ordinary aggregate ordering, ordinary window functions, or supported window syntax. It only prevents a clause that would otherwise be ignored.

## Result

The reported query now fails explicitly with SQLSTATE `0A000` instead of returning rows whose aggregate ordering does not match the requested `ORDER BY`. Existing valid window aggregates continue through the same type-check and execution paths.

## Validation

- Built `//pkg/sql/opt/optbuilder:optbuilder_test` and the query-observation target.
- Ran the affected optbuilder package tests.
- Re-ran the original reproduction and confirmed the explicit `0A000` rejection.
- Ran the configured full regression and compared it with the baseline; all required validation stages passed.
