### PR TITLE
sql: expand stars directly inside ROW expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1332,3 +1332,58 @@ query B
 SELECT ROW() IS NOT NULL;
 ----
 true
+
+subtest row_star_expansion_26619
+
+# A direct star contributes fields to ROW rather than one tuple-valued field.
+query T
+SELECT ROW((pg_get_keywords()).*) ORDER BY 1 LIMIT 1
+----
+(abort,U,unreserved)
+
+query T
+SELECT ROW((ROW(1, 2)).*)
+----
+(1,2)
+
+query T
+SELECT ROW(0, (ROW(1, 2)).*, 3, (ROW(4, 5)).*)
+----
+(0,1,2,3,4,5)
+
+query T
+SELECT ROW(t.*) FROM (VALUES (1, 'one'), (2, NULL)) AS t(a, b) ORDER BY t.a
+----
+(1,one)
+(2,)
+
+query T
+SELECT ROW(ROW((ROW(1, 2)).*), 3)
+----
+("(1,2)",3)
+
+# Non-star and shorthand tuple children keep their tuple boundary.
+query T
+SELECT ROW(ROW(1, 2), 3)
+----
+("(1,2)",3)
+
+query T
+SELECT ((ROW(1, 2)).*, 3)
+----
+("(1,2)",3)
+
+query T
+SELECT ROW(1, (ROW(2, 3)).*, NULL::INT)
+----
+(1,2,3,)
+
+# Labels belong to the enclosing tuple after expansion.
+query II
+SELECT ((ROW((ROW(1, 2)).*) AS a, b)).a,
+       ((ROW((ROW(1, 2)).*) AS a, b)).b
+----
+1  2
+
+query error mismatch in tuple definition: 2 expressions, 1 labels
+SELECT (ROW((ROW(1, 2)).*) AS a)

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1035,12 +1035,77 @@ func makeUntypedTuple(labels []string, texprs []tree.TypedExpr) *tree.Tuple {
 	return &tree.Tuple{Exprs: exprs, Labels: labels}
 }
 
+// normalizeDirectRowStar normalizes variable names before determining whether
+// they are expanded into the immediately enclosing ROW constructor.
+func normalizeDirectRowStar(expr tree.Expr) (tree.Expr, bool) {
+	if varName, ok := expr.(tree.VarName); ok {
+		normalized, err := varName.NormalizeVarName()
+		if err != nil {
+			panic(err)
+		}
+		expr = normalized
+	}
+	switch expr.(type) {
+	case *tree.AllColumnsSelector, *tree.TupleStar:
+		return expr, true
+	default:
+		return expr, false
+	}
+}
+
+// rebuildTupleAfterStarExpansion replaces a tuple's expressions while
+// preserving its explicit labels. In particular, labels from expandStar must
+// not replace labels explicitly attached to the enclosing tuple. Tuple.TypeCheck
+// validates the preserved labels against the final, expanded expression count.
+func rebuildTupleAfterStarExpansion(t *tree.Tuple, exprs tree.Exprs) *tree.Tuple {
+	tupleCopy := *t
+	tupleCopy.Exprs = exprs
+	if len(t.Labels) > 0 {
+		tupleCopy.Labels = append([]string(nil), t.Labels...)
+	}
+	return &tupleCopy
+}
+
 // VisitPre is part of the Visitor interface.
 //
 // NB: This code is adapted from sql/select_name_resolution.go and
 // sql/subquery.go.
 func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	switch t := expr.(type) {
+	case *tree.Tuple:
+		if !t.Row {
+			return true, expr
+		}
+		// A star that is a direct child of a ROW constructor expands into the
+		// ROW, rather than becoming a single tuple-valued element. Handle that
+		// here, since the expression walker cannot replace one child with
+		// multiple children.
+		hasDirectStar := false
+		for i := range t.Exprs {
+			if _, isStar := normalizeDirectRowStar(t.Exprs[i]); isStar {
+				hasDirectStar = true
+				break
+			}
+		}
+		if !hasDirectStar {
+			return true, expr
+		}
+
+		exprs := make(tree.Exprs, 0, len(t.Exprs))
+		for i := range t.Exprs {
+			normalized, isStar := normalizeDirectRowStar(t.Exprs[i])
+			if isStar {
+				_, expanded := s.builder.expandStar(normalized, s)
+				for _, e := range expanded {
+					exprs = append(exprs, e)
+				}
+				continue
+			}
+			e, _ := tree.WalkExpr(s, normalized)
+			exprs = append(exprs, e)
+		}
+		return false, rebuildTupleAfterStarExpansion(t, exprs)
+
 	case *tree.AllColumnsSelector, *tree.TupleStar:
 		// AllColumnsSelectors and TupleStars at the top level of a SELECT clause
 		// are replaced when the select's renders are prepared. If we


### PR DESCRIPTION
## Summary

Expand stars that are direct children of an explicit `ROW(...)` constructor into the enclosing row expression, matching PostgreSQL tuple semantics.

Fixes #26619

## Root cause

The expression visitor normally replaces one expression with one expression. For `ROW((pg_get_keywords()).*)`, the star expands to several columns, but the visitor cannot splice those columns into the parent tuple. The expanded value was therefore retained as a nested tuple-valued expression and later rendered as a single string-like field. PostgreSQL instead replaces the direct star with the expanded fields, producing one row with the expected columns.

The syntax distinction matters: an explicit `ROW(...)` constructor has different expansion semantics from shorthand tuple expressions. Applying the splice to every tuple would change existing behavior for shorthand tuples and regress the counterexample covered by the surrounding name-resolution logic.

## Change

Handle `tree.Tuple` nodes before the ordinary child walk:

1. Restrict the new behavior to tuples marked as explicit rows.
2. Normalize direct variable names before checking for `AllColumnsSelector` or `TupleStar` children.
3. Expand each direct star with the existing `expandStar` implementation and append all resulting expressions to the enclosing row.
4. Continue walking non-star children normally.
5. Rebuild the tuple while preserving its explicit labels and original tuple metadata.

Nested stars and shorthand tuples continue through the existing path. The change is limited to direct-star expansion inside `ROW(...)`, so it fixes the reported case without changing unrelated tuple construction.

## Validation

- Reproduced `SELECT ROW((pg_get_keywords()).*)` and verified that the expanded fields form the enclosing row instead of a nested string-like value.
- Verified shorthand tuple behavior remains unchanged.
- Ran the affected optimizer/name-resolution module tests, native regression checks, held-out checks, and the full regression suite.
